### PR TITLE
Release 1.3.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,14 +1,35 @@
 ---
 kind: pipeline
-name: e2e-kubernetes-1.16
+name: policeman
 
 platform:
   os: linux
   arch: amd64
 
 steps:
+  - name: lint
+    image: quay.io/sighup/policeman
+    pull: always
+
+---
+kind: pipeline
+name: e2e-kubernetes-1.16
+
+depends_on:
+  - policeman
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.2
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.3
     pull: always
     volumes:
     - name: shared
@@ -28,10 +49,12 @@ steps:
         from_secret: aws_secret_access_key
       terraform_tf_states_bucket_name:
         from_secret: terraform_tf_states_bucket_name
-    when:
-      ref:
-        include:
-          - refs/tags/**
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
 
   - name: test
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.16.4_3.2.2_2.4.1
@@ -49,76 +72,9 @@ steps:
       - bats -t katalog/tests/ingress.sh
       - bats -t katalog/tests/dr.sh
       - bats -t katalog/tests/opa.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: prepare-release-notes
-    image: python:3.7
-    pull: always
-    depends_on: [ test ]
-    environment:
-      RELEASE_NOTES_FILE_PATH: release-notes.md
-    commands:
-      - pip install semantic_version==2.8.4
-      - python -u release-notes.py
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: publish-prerelease
-    image: plugins/github-release
-    pull: always
-    depends_on: [ prepare-release-notes ]
-    settings:
-      api_key:
-        from_secret: github_token
-      file_exists: skip
-      files:
-        - Furyfile.yml
-        - kustomization.yaml
-      prerelease: true
-      overwrite: true
-      title: "Prerelease ${DRONE_TAG}"
-      note: release-notes.md
-      checksum:
-        - md5
-        - sha256
-    when:
-      ref:
-        include:
-          - refs/tags/v**-rc**
-
-  - name: publish-stable
-    image: plugins/github-release
-    pull: always
-    depends_on: [ prepare-release-notes ]
-    settings:
-      api_key:
-        from_secret: github_token
-      file_exists: skip
-      files:
-        - Furyfile.yml
-        - kustomization.yaml
-      prerelease: false
-      overwrite: true
-      title: "Release ${DRONE_TAG}"
-      note: release-notes.md
-      checksum:
-        - md5
-        - sha256
-    when:
-      ref:
-        exclude:
-          - refs/tags/v**-rc**
-        include:
-          - refs/tags/v**
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.2
-    pull: always
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.3
     depends_on: [ test ]
     settings:
       action: destroy
@@ -131,6 +87,12 @@ steps:
         from_secret: aws_secret_access_key
       terraform_tf_states_bucket_name:
         from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
     when:
       status:
       - success
@@ -142,25 +104,33 @@ volumes:
 
 ---
 kind: pipeline
-name: e2e-kubernetes-1.15
+name: e2e-kubernetes-1.17
+
+depends_on:
+  - policeman
 
 platform:
   os: linux
   arch: amd64
 
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.2
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.3
     pull: always
     volumes:
     - name: shared
       path: /shared
     depends_on: [ clone ]
     settings:
-      action: custom-cluster-115
-      pipeline_id: cluster-115
+      action: custom-cluster-117
+      pipeline_id: cluster-117
       local_kind_config_path: katalog/tests/config/kind-config-custom
-      cluster_version: '1.15.11'
+      cluster_version: '1.17.5'
       instance_path: /shared
       aws_default_region:
         from_secret: aws_region
@@ -170,20 +140,22 @@ steps:
         from_secret: aws_secret_access_key
       terraform_tf_states_bucket_name:
         from_secret: terraform_tf_states_bucket_name
-    when:
-      ref:
-        include:
-          - refs/tags/**
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
 
   - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.15.7_3.2.2_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.17.2_3.2.2_2.4.1
     pull: always
     volumes:
     - name: shared
       path: /shared
     depends_on: [ init ]
     commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-115
+      - export KUBECONFIG=/shared/kube/kubeconfig-117
       - bats -t katalog/tests/install.sh
       - bats -t katalog/tests/networking.sh
       - bats -t katalog/tests/monitoring.sh
@@ -191,15 +163,145 @@ steps:
       - bats -t katalog/tests/ingress.sh
       - bats -t katalog/tests/dr.sh
       - bats -t katalog/tests/opa.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
 
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.3
+    depends_on: [ test ]
+    settings:
+      action: destroy
+      pipeline_id: cluster-117
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+    when:
+      status:
+      - success
+      - failure
+
+volumes:
+- name: shared
+  temp: {}
+
+---
+kind: pipeline
+name: e2e-kubernetes-1.18
+
+depends_on:
+  - policeman
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.3
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ clone ]
+    settings:
+      action: custom-cluster-118
+      pipeline_id: cluster-118
+      local_kind_config_path: katalog/tests/config/kind-config-custom
+      cluster_version: '1.18.2'
+      instance_path: /shared
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+
+  - name: test
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.0_3.2.2_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ init ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-118
+      - bats -t katalog/tests/install.sh
+      - bats -t katalog/tests/networking.sh
+      - bats -t katalog/tests/monitoring.sh
+      - bats -t katalog/tests/logging.sh
+      - bats -t katalog/tests/ingress.sh
+      - bats -t katalog/tests/dr.sh
+      - bats -t katalog/tests/opa.sh
+
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.3
+    depends_on: [ test ]
+    settings:
+      action: destroy
+      pipeline_id: cluster-118
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+    when:
+      status:
+      - success
+      - failure
+
+volumes:
+- name: shared
+  temp: {}
+
+---
+kind: pipeline
+name: release
+
+depends_on:
+  - e2e-kubernetes-1.16
+  - e2e-kubernetes-1.17
+  - e2e-kubernetes-1.18
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
   - name: prepare-release-notes
     image: python:3.7
     pull: always
-    depends_on: [ test ]
+    depends_on: [ clone ]
     environment:
       RELEASE_NOTES_FILE_PATH: release-notes.md
     commands:
@@ -257,168 +359,3 @@ steps:
           - refs/tags/v**-rc**
         include:
           - refs/tags/v**
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.2
-    pull: always
-    depends_on: [ test ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-115
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-    when:
-      status:
-      - success
-      - failure
-
-volumes:
-- name: shared
-  temp: {}
----
-kind: pipeline
-name: e2e-kubernetes-1.14
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.2
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
-    settings:
-      action: custom-cluster-114
-      pipeline_id: cluster-114
-      local_kind_config_path: katalog/tests/config/kind-config-custom
-      cluster_version: '1.14.10'
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.14.10_3.2.2_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-114
-      - bats -t katalog/tests/install.sh
-      - bats -t katalog/tests/networking.sh
-      - bats -t katalog/tests/monitoring.sh
-      - bats -t katalog/tests/logging.sh
-      - bats -t katalog/tests/ingress.sh
-      - bats -t katalog/tests/dr.sh
-      - bats -t katalog/tests/opa.sh
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: prepare-release-notes
-    image: python:3.7
-    pull: always
-    depends_on: [ test ]
-    environment:
-      RELEASE_NOTES_FILE_PATH: release-notes.md
-    commands:
-      - pip install semantic_version==2.8.4
-      - python -u release-notes.py
-    when:
-      ref:
-        include:
-          - refs/tags/**
-
-  - name: publish-prerelease
-    image: plugins/github-release
-    pull: always
-    depends_on: [ prepare-release-notes ]
-    settings:
-      api_key:
-        from_secret: github_token
-      file_exists: skip
-      files:
-        - Furyfile.yml
-        - kustomization.yaml
-      prerelease: true
-      overwrite: true
-      title: "Prerelease ${DRONE_TAG}"
-      note: release-notes.md
-      checksum:
-        - md5
-        - sha256
-    when:
-      ref:
-        include:
-          - refs/tags/v**-rc**
-
-  - name: publish-stable
-    image: plugins/github-release
-    pull: always
-    depends_on: [ prepare-release-notes ]
-    settings:
-      api_key:
-        from_secret: github_token
-      file_exists: skip
-      files:
-        - Furyfile.yml
-        - kustomization.yaml
-      prerelease: false
-      overwrite: true
-      title: "Release ${DRONE_TAG}"
-      note: release-notes.md
-      checksum:
-        - md5
-        - sha256
-    when:
-      ref:
-        exclude:
-          - refs/tags/v**-rc**
-        include:
-          - refs/tags/v**
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.3.2
-    pull: always
-    depends_on: [ test ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-114
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-    when:
-      status:
-      - success
-      - failure
-
-volumes:
-- name: shared
-  temp: {}

--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc2
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc3
     pull: always
     volumes:
     - name: shared
@@ -75,7 +75,7 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image:
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc3
     depends_on: [ test ]
     settings:
       action: destroy
@@ -122,7 +122,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc2
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc3
     pull: always
     volumes:
     - name: shared
@@ -168,7 +168,7 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc2
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc3
     depends_on: [ test ]
     settings:
       action: destroy
@@ -215,7 +215,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc2
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc3
     pull: always
     volumes:
     - name: shared
@@ -261,7 +261,7 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc2
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc3
     depends_on: [ test ]
     settings:
       action: destroy

--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.3
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc2
     pull: always
     volumes:
     - name: shared
@@ -41,6 +41,7 @@ steps:
       local_kind_config_path: katalog/tests/config/kind-config-custom
       cluster_version: '1.16.9'
       instance_path: /shared
+      instance_size: extra-large
       aws_default_region:
         from_secret: aws_region
       aws_access_key_id:
@@ -74,11 +75,12 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.3
+    image:
     depends_on: [ test ]
     settings:
       action: destroy
       pipeline_id: cluster-116
+      instance_size: extra-large
       aws_default_region:
         from_secret: aws_region
       aws_access_key_id:
@@ -120,7 +122,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.3
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc2
     pull: always
     volumes:
     - name: shared
@@ -132,6 +134,7 @@ steps:
       local_kind_config_path: katalog/tests/config/kind-config-custom
       cluster_version: '1.17.5'
       instance_path: /shared
+      instance_size: extra-large
       aws_default_region:
         from_secret: aws_region
       aws_access_key_id:
@@ -165,11 +168,12 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.3
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc2
     depends_on: [ test ]
     settings:
       action: destroy
       pipeline_id: cluster-117
+      instance_size: extra-large
       aws_default_region:
         from_secret: aws_region
       aws_access_key_id:
@@ -211,7 +215,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.3
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc2
     pull: always
     volumes:
     - name: shared
@@ -223,6 +227,7 @@ steps:
       local_kind_config_path: katalog/tests/config/kind-config-custom
       cluster_version: '1.18.2'
       instance_path: /shared
+      instance_size: extra-large
       aws_default_region:
         from_secret: aws_region
       aws_access_key_id:
@@ -256,11 +261,12 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.4.3
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc2
     depends_on: [ test ]
     settings:
       action: destroy
       pipeline_id: cluster-118
+      instance_size: extra-large
       aws_default_region:
         from_secret: aws_region
       aws_access_key_id:

--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc3
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0
     pull: always
     volumes:
     - name: shared
@@ -75,7 +75,7 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc3
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0
     depends_on: [ test ]
     settings:
       action: destroy
@@ -122,7 +122,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc3
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0
     pull: always
     volumes:
     - name: shared
@@ -168,7 +168,7 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc3
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0
     depends_on: [ test ]
     settings:
       action: destroy
@@ -215,7 +215,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc3
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0
     pull: always
     volumes:
     - name: shared
@@ -261,7 +261,7 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0-rc3
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.5.0
     depends_on: [ test ]
     settings:
       action: destroy

--- a/.drone.yml
+++ b/.drone.yml
@@ -58,7 +58,7 @@ steps:
         from_secret: vsphere_user
 
   - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.16.4_3.2.2_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.16.9_3.3.0_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -151,7 +151,7 @@ steps:
         from_secret: vsphere_user
 
   - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.17.2_3.2.2_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.17.5_3.3.0_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -244,7 +244,7 @@ steps:
         from_secret: vsphere_user
 
   - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.0_3.2.2_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.2_3.3.0_2.4.1
     pull: always
     volumes:
     - name: shared

--- a/.rules/.markdown-lint.yml
+++ b/.rules/.markdown-lint.yml
@@ -1,0 +1,36 @@
+---
+###########################
+###########################
+## Markdown Linter rules ##
+###########################
+###########################
+
+# Linter rules doc:
+# - https://github.com/DavidAnson/markdownlint
+#
+# Note:
+# To comment out a single error:
+#   <!-- markdownlint-disable -->
+#   any violations you want
+#   <!-- markdownlint-restore -->
+#
+
+###############
+# Rules by id #
+###############
+MD004: false                  # Unordered list style
+MD007:
+  indent: 2                   # Unordered list indentation
+MD013:
+  line_length: 808            # Line length
+MD026:
+  punctuation: ".,;:!。，；:"  # List of not allowed
+MD029: false                  # Ordered list item prefix
+MD033: false                  # Allow inline HTML
+MD036: false                  # Emphasis used instead of a heading
+MD041: false
+
+#################
+# Rules by tags #
+#################
+blank_lines: false  # Error on blank lines

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,5 +10,5 @@
   - Optional Dual Ingress
     - Be careful with the cert-manager cluster-issuer
   - Optional Velero Cloud (aws, gke, aks)
-    - If choosen a cloud DR deployment, a terraform module has to be instantiate to create "cloud-credentials" and 
+    - If choosen a cloud DR deployment, a terraform module has to be instantiate to create "cloud-credentials" and
     VolumeSnapshotsLocation/BackupLocation CRDs from the output of the module.

--- a/Furyfile.yml
+++ b/Furyfile.yml
@@ -2,7 +2,7 @@ versions:
   networking: v1.3.0
   monitoring: v1.8.0
   logging: v1.5.0
-  ingress: v1.7.0-rc4
+  ingress: v1.7.0
   dr: v1.4.0-rc6
   opa: v1.1.0
 

--- a/Furyfile.yml
+++ b/Furyfile.yml
@@ -3,7 +3,7 @@ versions:
   monitoring: v1.8.0
   logging: v1.5.0
   ingress: v1.7.0
-  dr: v1.4.0-rc6
+  dr: v1.4.0
   opa: v1.1.0
 
 bases:

--- a/Furyfile.yml
+++ b/Furyfile.yml
@@ -1,10 +1,10 @@
 versions:
-  networking: v1.3.0-rc1
-  monitoring: v1.8.0-rc1
-  logging: v1.5.0-rc1
+  networking: v1.3.0
+  monitoring: v1.8.0
+  logging: v1.5.0
   ingress: v1.7.0-rc4
   dr: v1.4.0-rc6
-  opa: v1.1.0-rc6
+  opa: v1.1.0
 
 bases:
   - name: networking/calico

--- a/Furyfile.yml
+++ b/Furyfile.yml
@@ -1,10 +1,10 @@
 versions:
-  networking: v1.2.1
-  monitoring: v1.6.1
-  logging: v1.3.0
-  ingress: v1.6.1
-  dr: v1.3.1
-  opa: v1.0.0
+  networking: v1.3.0-rc1
+  monitoring: v1.8.0-rc1
+  logging: v1.5.0-rc1
+  ingress: v1.7.0-rc4
+  dr: v1.4.0-rc6
+  opa: v1.1.0-rc6
 
 bases:
   - name: networking/calico

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fury Distribution
 
-[![Build Status](http://ci.sighup.io/api/badges/sighupio/fury-distribution/status.svg?ref=refs/tags/v1.2.0)](http://ci.sighup.io/sighupio/fury-distribution)
+[![Build Status](http://ci.sighup.io/api/badges/sighupio/fury-distribution/status.svg?ref=refs/tags/v1.3.0)](http://ci.sighup.io/sighupio/fury-distribution)
 
 ## Information
 

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,10 +1,27 @@
 ### Release Notes
 
-Welcome to the Fury Distribution v1.2.0. In this new version we had addressed some logging updates along with new stability and observability improvements while supporting three different Kubernetes Upstream Version: 1.14, 1.15 and 1.16.
+Welcome to the Fury Distribution v1.3.0. In this new version we had addressed the support of three different Kubernetes
+versions: 1.16, 1.17 and 1.18 along with new stability and observability improvements.
 
 #### Changelog
 
 Most important changes are listed below:
+
+- [networking](https://github.com/sighupio/fury-kubernetes-networking) 📦 core module: v1.2.1 -> [**v1.3.0**](https://github.com/sighupio/fury-kubernetes-networking/tree/v1.3.0)
+  - Support Kubernetes 1.16, 1.17 and 1.18.
+  - Reduce verbosity. From `info` to `error`.
+- [monitoring](https://github.com/sighupio/fury-kubernetes-monitoring) 📦 core module: v1.6.1 -> [**v1.8.0**](https://github.com/sighupio/fury-kubernetes-monitoring/tree/v1.8.0)
+  - Support Kubernetes 1.16, 1.17 and 1.18.
+  - Adds [Gatekeeper] dashboard to [Grafana].
+  - Adds Kong Ingress dashboard to [Grafana].
+- [logging](https://github.com/sighupio/fury-kubernetes-logging) 📦 core module: v1.3.0 -> [**v1.5.0**](https://github.com/sighupio/fury-kubernetes-logging/tree/v1.5.0)
+  - Changed logging architecture adding fluentbit as log recolector and fluentd as log buffer.
+    - More information [here](https://github.com/sighupio/fury-kubernetes-logging/blob/master/docs/releases/v1.4.0.md).
+  - Support Kubernetes 1.16, 1.17 and 1.18.
+- [ingress](https://github.com/sighupio/fury-kubernetes-ingress) 📦 core module: v1.6.1 -> [**v1.7.0**](https://github.com/sighupio/fury-kubernetes-ingress/tree/v1.7.0)
+  - Support Kubernetes 1.16, 1.17 and 1.18.
+- [dr](https://github.com/sighupio/fury-kubernetes-dr) 📦 core module: v1.3.1 -> [**v1.4.0**](https://github.com/sighupio/fury-kubernetes-dr/tree/v1.4.0)
+  - Support Kubernetes 1.16, 1.17 and 1.18.
 
 [fluentd]: https://github.com/fluent/fluentd/releases/tag/v1.10.2
 [curator]: https://github.com/elastic/curator/releases/tag/v5.8.1

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,0 +1,26 @@
+### Release Notes
+
+Welcome to the Fury Distribution v1.2.0. In this new version we had addressed some logging updates along with new stability and observability improvements while supporting three different Kubernetes Upstream Version: 1.14, 1.15 and 1.16.
+
+#### Changelog
+
+Most important changes are listed below:
+
+[fluentd]: https://github.com/fluent/fluentd/releases/tag/v1.10.2
+[curator]: https://github.com/elastic/curator/releases/tag/v5.8.1
+[kibana]: https://github.com/elastic/kibana/releases/tag/v6.8.6
+[elasticsearch]: https://github.com/elastic/elasticsearch/releases/tag/v6.8.6
+[Cerebro]: https://github.com/lmenezes/cerebro/releases/tag/v0.8.5
+[Velero]: https://velero.io/
+[cert-manager]: https://github.com/jetstack/cert-manager
+[forecastle]: https://github.com/stakater/Forecastle
+[nginx]: https://github.com/kubernetes/ingress-nginx
+[metrics-server]: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/metrics-server
+[node-exporter]: https://github.com/prometheus/node_exporter
+[kube-state-metrics]: https://github.com/kubernetes/kube-state-metrics
+[Grafana]: https://grafana.com/
+[Alertmanager]: https://github.com/prometheus/alertmanager
+[Prometheus]: https://prometheus.io/
+[Prometheus Operator]: https://github.com/coreos/prometheus-operator
+[calico]: https://www.projectcalico.org/
+[Gatekeeper]: https://github.com/open-policy-agent/gatekeeper

--- a/katalog/tests/dr.sh
+++ b/katalog/tests/dr.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2154
 
 load ./helper
 

--- a/katalog/tests/dr.sh
+++ b/katalog/tests/dr.sh
@@ -18,7 +18,7 @@ load ./helper
     test() {
         kubectl get pods -l k8s-app=velero-restic -o json -n kube-system |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 60 5
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }

--- a/katalog/tests/ingress.sh
+++ b/katalog/tests/ingress.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2154
 
 load ./helper
 

--- a/katalog/tests/ingress.sh
+++ b/katalog/tests/ingress.sh
@@ -8,7 +8,7 @@ load ./helper
     test() {
         kubectl get pods -l app=cert-manager -o json -n cert-manager |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }
@@ -18,7 +18,7 @@ load ./helper
     test() {
         kubectl get pods -l app=webhook -o json -n cert-manager |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }
@@ -28,7 +28,7 @@ load ./helper
     test() {
         kubectl get pods -l app=ingress-nginx -o json -n ingress-nginx |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }
@@ -38,7 +38,7 @@ load ./helper
     test() {
         kubectl get pods -l app=forecastle -o json -n ingress-nginx |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }

--- a/katalog/tests/install.sh
+++ b/katalog/tests/install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2154
 
 load ./helper
 

--- a/katalog/tests/install.sh
+++ b/katalog/tests/install.sh
@@ -21,6 +21,18 @@ load ./helper
     [ "$status" -eq 0 ]
 }
 
+@test "Install CRDs" {
+    info
+    kubectl apply -f vendor/katalog/networking/calico/crd.yml
+    kubectl apply -f vendor/katalog/monitoring/prometheus-operator/crd-alertmanager.yml
+    kubectl apply -f vendor/katalog/monitoring/prometheus-operator/crd-prometheus.yml
+    kubectl apply -f vendor/katalog/monitoring/prometheus-operator/crd-rule.yml
+    kubectl apply -f vendor/katalog/monitoring/prometheus-operator/crd-servicemonitor.yml
+    kubectl apply -f vendor/katalog/ingress/cert-manager/cert-manager-controller/crd.yml
+    kubectl apply -f vendor/katalog/opa/gatekeeper/core/crd.yml
+    kubectl apply -f vendor/katalog/dr/velero/velero-base/crds.yaml
+}
+
 @test "Install" {
     info
     install() {

--- a/katalog/tests/install.sh
+++ b/katalog/tests/install.sh
@@ -21,19 +21,6 @@ load ./helper
     [ "$status" -eq 0 ]
 }
 
-@test "Install CRDs" {
-    info
-    skip # Trying again without pre-installing CRDs
-    kubectl apply -f vendor/katalog/networking/calico/crd.yml
-    kubectl apply -f vendor/katalog/monitoring/prometheus-operator/crd-alertmanager.yml
-    kubectl apply -f vendor/katalog/monitoring/prometheus-operator/crd-prometheus.yml
-    kubectl apply -f vendor/katalog/monitoring/prometheus-operator/crd-rule.yml
-    kubectl apply -f vendor/katalog/monitoring/prometheus-operator/crd-servicemonitor.yml
-    kubectl apply -f vendor/katalog/ingress/cert-manager/cert-manager-controller/crd.yml
-    kubectl apply -f vendor/katalog/opa/gatekeeper/core/crd.yml
-    kubectl apply -f vendor/katalog/dr/velero/velero-base/crds.yaml
-}
-
 @test "Install" {
     info
     install() {

--- a/katalog/tests/install.sh
+++ b/katalog/tests/install.sh
@@ -22,6 +22,7 @@ load ./helper
 }
 
 @test "Install CRDs" {
+    skip # Testing without Pre-installing CRDs
     info
     kubectl apply -f vendor/katalog/networking/calico/crd.yml
     kubectl apply -f vendor/katalog/monitoring/prometheus-operator/crd-alertmanager.yml
@@ -38,7 +39,7 @@ load ./helper
     install() {
         apply .
     }
-    loop_it install 30 5
+    loop_it install 120 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }

--- a/katalog/tests/install.sh
+++ b/katalog/tests/install.sh
@@ -22,7 +22,6 @@ load ./helper
 }
 
 @test "Install CRDs" {
-    skip # Testing without Pre-installing CRDs
     info
     kubectl apply -f vendor/katalog/networking/calico/crd.yml
     kubectl apply -f vendor/katalog/monitoring/prometheus-operator/crd-alertmanager.yml

--- a/katalog/tests/install.sh
+++ b/katalog/tests/install.sh
@@ -23,6 +23,7 @@ load ./helper
 
 @test "Install CRDs" {
     info
+    skip # Trying again without pre-installing CRDs
     kubectl apply -f vendor/katalog/networking/calico/crd.yml
     kubectl apply -f vendor/katalog/monitoring/prometheus-operator/crd-alertmanager.yml
     kubectl apply -f vendor/katalog/monitoring/prometheus-operator/crd-prometheus.yml

--- a/katalog/tests/logging.sh
+++ b/katalog/tests/logging.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2154
 
 load ./helper
 

--- a/katalog/tests/logging.sh
+++ b/katalog/tests/logging.sh
@@ -8,7 +8,7 @@ load ./helper
     test() {
         kubectl get pods -l app=elasticsearch -o json -n logging |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }
@@ -18,7 +18,7 @@ load ./helper
     test() {
         kubectl get pods -l app=cerebro -o json -n logging |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }
@@ -28,7 +28,7 @@ load ./helper
     test() {
         kubectl get pods -l app=fluentd -o json -n logging |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }
@@ -38,7 +38,7 @@ load ./helper
     test() {
         kubectl get pods -l app=kibana -o json -n logging |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }

--- a/katalog/tests/monitoring.sh
+++ b/katalog/tests/monitoring.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2154
 
 load ./helper
 

--- a/katalog/tests/monitoring.sh
+++ b/katalog/tests/monitoring.sh
@@ -8,7 +8,7 @@ load ./helper
     test() {
         kubectl get pods -l k8s-app=goldpinger -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }
@@ -18,7 +18,7 @@ load ./helper
     test() {
         kubectl get pods -l app=grafana -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }
@@ -28,7 +28,7 @@ load ./helper
     test() {
         kubectl get pods -l k8s-app=prometheus-operator -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }
@@ -38,7 +38,7 @@ load ./helper
     test() {
         kubectl get pods -l app=kube-state-metrics -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }
@@ -48,7 +48,7 @@ load ./helper
     test() {
         kubectl get pods -l app=node-exporter -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }
@@ -58,7 +58,7 @@ load ./helper
     test() {
         kubectl get pods -l app=prometheus -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }
@@ -68,7 +68,7 @@ load ./helper
     test() {
         kubectl get pods -l app=metrics-server -o json -n kube-system |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 60 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }

--- a/katalog/tests/monitoring.sh
+++ b/katalog/tests/monitoring.sh
@@ -54,6 +54,7 @@ load ./helper
 }
 
 @test "Prometheus is Running" {
+    skip # TODO solve resource problem in e2e testing environment
     info
     test() {
         kubectl get pods -l app=prometheus -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true

--- a/katalog/tests/monitoring.sh
+++ b/katalog/tests/monitoring.sh
@@ -54,7 +54,6 @@ load ./helper
 }
 
 @test "Prometheus is Running" {
-    skip # TODO solve resource problem in e2e testing environment
     info
     test() {
         kubectl get pods -l app=prometheus -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true

--- a/katalog/tests/networking.sh
+++ b/katalog/tests/networking.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2154
 
 load ./helper
 

--- a/katalog/tests/networking.sh
+++ b/katalog/tests/networking.sh
@@ -8,7 +8,7 @@ load ./helper
     test() {
         kubectl get pods -l k8s-app=calico-kube-controllers -o json -n kube-system |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }
@@ -18,7 +18,7 @@ load ./helper
     test() {
         kubectl get pods -l k8s-app=calico-node -o json -n kube-system |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }

--- a/katalog/tests/opa.sh
+++ b/katalog/tests/opa.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2154
 
 load ./helper
 

--- a/katalog/tests/opa.sh
+++ b/katalog/tests/opa.sh
@@ -8,7 +8,7 @@ load ./helper
     test() {
         kubectl get pods -l control-plane=controller-manager -o json -n gatekeeper-system | jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
     }
-    loop_it test 30 2
+    loop_it test 60 10
     status=${loop_it_result}
     [ "$status" -eq 0 ]
 }

--- a/release-notes.py
+++ b/release-notes.py
@@ -1,7 +1,7 @@
 import os
 from shutil import copyfile
 
-import semantic_version
+import semantic_version # pylint: disable=import-error
 
 RELEASE_NOTES_FILE_PATH = os.getenv("RELEASE_NOTES_FILE_PATH")
 DRONE_TAG = os.getenv("DRONE_TAG")


### PR DESCRIPTION
This PR aims to release Fury v1.3.0 adding support to Kubernetes 1.16, 1.17 and 1.18.
Is not a big release in terms of features, but is a step forward to have an updated supported distribution (and certified).

I will work on pending stuff after merging the pr (technical release).

We can promote the new version once:

- docs site is updated
- CNCF verifies our distribution
- having a blog post

Thanks!