### PR TITLE
Fury Distribution v1.6.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ name: license
 
 steps:
   - name: check
-    image: docker.io/library/golang:1.14.3
+    image: docker.io/library/golang:1.16
     pull: always
     commands:
       - go get -u github.com/google/addlicense
@@ -31,7 +31,7 @@ steps:
       - clone
 
   - name: render
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.8_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.19_3.8.7_2.4.1
     pull: always
     depends_on:
       - clone
@@ -40,7 +40,7 @@ steps:
       - kustomize build . > distribution.yml
 
   - name: deprek8ion
-    image: eu.gcr.io/swade1987/deprek8ion:1.1.31
+    image: eu.gcr.io/swade1987/deprek8ion:1.1.34
     pull: always
     depends_on:
       - render
@@ -49,112 +49,10 @@ steps:
 
 ---
 kind: pipeline
-name: e2e-kubernetes-1.17
-
-depends_on:
-  - policeman
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
-    settings:
-      action: custom-cluster-117
-      pipeline_id: cluster-117
-      local_kind_config_path: katalog/tests/config/kind-config-custom
-      cluster_version: '1.17.5'
-      instance_path: /shared
-      instance_size: 2-extra-large
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.17.11_3.3.0_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-117
-      - bats -t katalog/tests/install.sh
-      - bats -t katalog/tests/networking.sh
-      - bats -t katalog/tests/monitoring.sh
-      - bats -t katalog/tests/logging.sh
-      - bats -t katalog/tests/ingress.sh
-      - bats -t katalog/tests/dr.sh
-      - bats -t katalog/tests/opa.sh
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
-    depends_on: [ test ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-117
-      instance_size: 2-extra-large
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-    when:
-      status:
-      - success
-      - failure
-
-volumes:
-- name: shared
-  temp: {}
-
----
-kind: pipeline
 name: e2e-kubernetes-1.18
 
 depends_on:
   - policeman
-  - e2e-kubernetes-1.17
 
 platform:
   os: linux
@@ -167,7 +65,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
     pull: always
     volumes:
     - name: shared
@@ -177,7 +75,7 @@ steps:
       action: custom-cluster-118
       pipeline_id: cluster-118
       local_kind_config_path: katalog/tests/config/kind-config-custom
-      cluster_version: '1.18.8'
+      cluster_version: '1.18.19'
       instance_path: /shared
       instance_size: 2-extra-large
       aws_default_region:
@@ -200,7 +98,7 @@ steps:
         from_secret: dockerhub_password
 
   - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.8_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.19_3.8.7_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -217,7 +115,7 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
     depends_on: [ test ]
     settings:
       action: destroy
@@ -256,7 +154,6 @@ name: e2e-kubernetes-1.19
 
 depends_on:
   - policeman
-  - e2e-kubernetes-1.17
   - e2e-kubernetes-1.18
 
 platform:
@@ -270,7 +167,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
     pull: always
     volumes:
     - name: shared
@@ -280,7 +177,7 @@ steps:
       action: custom-cluster-119
       pipeline_id: cluster-119
       local_kind_config_path: katalog/tests/config/kind-config-custom
-      cluster_version: '1.19.0'
+      cluster_version: '1.19.11'
       instance_path: /shared
       instance_size: 2-extra-large
       aws_default_region:
@@ -303,7 +200,7 @@ steps:
         from_secret: dockerhub_password
 
   - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.19.0_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.19.11_3.8.7_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -320,7 +217,7 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
     depends_on: [ test ]
     settings:
       action: destroy
@@ -359,7 +256,6 @@ name: e2e-kubernetes-1.20
 
 depends_on:
   - policeman
-  - e2e-kubernetes-1.17
   - e2e-kubernetes-1.18
   - e2e-kubernetes-1.19
 
@@ -374,7 +270,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
     pull: always
     volumes:
     - name: shared
@@ -384,7 +280,7 @@ steps:
       action: custom-cluster-120
       pipeline_id: cluster-120
       local_kind_config_path: katalog/tests/config/kind-config-custom
-      cluster_version: '1.20.0'
+      cluster_version: '1.20.7'
       instance_path: /shared
       instance_size: 2-extra-large
       aws_default_region:
@@ -407,7 +303,7 @@ steps:
         from_secret: dockerhub_password
 
   - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.20.7_3.8.7_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -424,7 +320,7 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
     depends_on: [ test ]
     settings:
       action: destroy
@@ -459,12 +355,116 @@ volumes:
 
 ---
 kind: pipeline
+name: e2e-kubernetes-1.21
+
+depends_on:
+  - policeman
+  - e2e-kubernetes-1.18
+  - e2e-kubernetes-1.19
+  - e2e-kubernetes-1.20
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ clone ]
+    settings:
+      action: custom-cluster-121
+      pipeline_id: cluster-121
+      local_kind_config_path: katalog/tests/config/kind-config-custom
+      cluster_version: '1.21.1'
+      instance_path: /shared
+      instance_size: 2-extra-large
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+
+  - name: test
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.21.1_3.8.7_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ init ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-121
+      - bats -t katalog/tests/install.sh
+      - bats -t katalog/tests/networking.sh
+      - bats -t katalog/tests/monitoring.sh
+      - bats -t katalog/tests/logging.sh
+      - bats -t katalog/tests/ingress.sh
+      - bats -t katalog/tests/dr.sh
+      - bats -t katalog/tests/opa.sh
+
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
+    depends_on: [ test ]
+    settings:
+      action: destroy
+      pipeline_id: cluster-121
+      instance_size: 2-extra-large
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+    when:
+      status:
+      - success
+      - failure
+
+volumes:
+- name: shared
+  temp: {}
+
+---
+kind: pipeline
 name: release
 
 depends_on:
-  - e2e-kubernetes-1.17
   - e2e-kubernetes-1.18
   - e2e-kubernetes-1.19
+  - e2e-kubernetes-1.20
 
 platform:
   os: linux
@@ -477,7 +477,7 @@ trigger:
 
 steps:
   - name: prepare-release-manifests
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.8_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.19_3.8.7_2.4.1
     pull: always
     depends_on: [ clone ]
     environment:

--- a/Furyfile.yml
+++ b/Furyfile.yml
@@ -3,12 +3,12 @@
 # license that can be found in the LICENSE file.
 
 versions:
-  networking: v1.5.0
-  monitoring: v1.11.0
-  logging: v1.7.0
-  ingress: v1.9.1
-  dr: v1.6.0
-  opa: v1.3.0
+  networking: v1.6.0-rc4
+  monitoring: v1.12.0-rc3
+  logging: v1.8.0-rc4
+  ingress: v1.10.0-rc2
+  dr: v1.7.0-rc3
+  opa: v1.4.0-rc5
 
 bases:
   - name: networking/calico

--- a/Furyfile.yml
+++ b/Furyfile.yml
@@ -3,12 +3,12 @@
 # license that can be found in the LICENSE file.
 
 versions:
-  networking: v1.6.0-rc4
-  monitoring: v1.12.0-rc4
-  logging: v1.8.0-rc4
-  ingress: v1.10.0-rc2
-  dr: v1.7.0-rc3
-  opa: v1.4.0-rc5
+  networking: v1.6.0
+  monitoring: v1.12.0
+  logging: v1.8.0
+  ingress: v1.10.0
+  dr: v1.7.0
+  opa: v1.4.0
 
 bases:
   - name: networking/calico

--- a/Furyfile.yml
+++ b/Furyfile.yml
@@ -4,7 +4,7 @@
 
 versions:
   networking: v1.6.0-rc4
-  monitoring: v1.12.0-rc3
+  monitoring: v1.12.0-rc4
   logging: v1.8.0-rc4
   ingress: v1.10.0-rc2
   dr: v1.7.0-rc3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fury Distribution
 
-[![Build Status](http://ci.sighup.io/api/badges/sighupio/fury-distribution/status.svg?ref=refs/tags/v1.5.0)](http://ci.sighup.io/sighupio/fury-distribution)
+[![Build Status](http://ci.sighup.io/api/badges/sighupio/fury-distribution/status.svg?ref=refs/tags/v1.6.0)](http://ci.sighup.io/sighupio/fury-distribution)
 
 ## Information
 

--- a/docs/releases/v1.6.0.md
+++ b/docs/releases/v1.6.0.md
@@ -1,0 +1,148 @@
+# Fury Distribution v1.6.0
+
+Welcome to the **Fury Distribution v1.6.0**. In this new version, we had addressed the update of multiples
+packages that belong to the distribution. All of them have been pushed to the latest stable release of each.
+It includes testing (as tech preview) against Kubernetes `v1.21.0`.
+
+The team has been working to make the release upgrade as simple as possible, so read carefully the upgrade path of each
+core module listed below along with the upgrade path of the distribution.
+
+## Changelog
+
+The most important changes are listed below:
+
+- [networking](https://github.com/sighupio/fury-kubernetes-networking) 📦 core module: v1.5.0 -> [**v1.6.0**](https://github.com/sighupio/fury-kubernetes-networking/releases/tag/v1.6.0)
+  - Kubernetes `1.21` Tech preview.
+  - Update [Calico] from version `3.17.1` to `3.19.1`.
+- [monitoring](https://github.com/sighupio/fury-kubernetes-monitoring) 📦 core module: v1.11.0 -> [**v1.12.0**](https://github.com/sighupio/fury-kubernetes-monitoring/releases/tag/v1.12.0)
+  - Kubernetes `1.21` Tech preview.
+  - Update [Prometheus Operator] from version `0.44.1` to `0.48.1`.
+  - Update [Prometheus] from version `2.22.2` to `2.27.1`.
+  - Update [Grafana] from version `7.3.6` to `7.5.7`.
+  - Update [metrics-server] from version `0.4.1` to `0.5.0`.
+  - Update [Alertmanager] from version `0.21.0` to `0.22.1`.
+  - Update [thanos] from version `0.12.2` to `0.20.2`.
+    - Fixing thanos modules, missing namespace on components
+  - Update [kube-state-metrics] from version `1.9.7` to `2.0.0`.
+    - Update all Alerts and Grafana Dashboards
+    - Modify the alerts that track expiration of cluster certificates to fire within 30/7 days of expiration instead
+    of 7/1 days. (kubeadm-k8s-rules, prometheus-k8s-rules)
+  - Update [kube-proxy-metrics]
+  - Update [node-exporter] from version `1.0.1` to `1.1.2`.
+  - Update [goldpinger] from version `3.0.0` to `3.2.0`.
+- [logging](https://github.com/sighupio/fury-kubernetes-logging) 📦 core module: v1.7.0 -> [**v1.8.0**](https://github.com/sighupio/fury-kubernetes-logging/releases/tag/v1.8.0)
+  - Kubernetes `1.21` Tech preview.
+  - Update [Cerebro] from version `0.9.3` to `0.9.4`.
+  - Update [fluentd] from version `1.11.5` to `1.12.3`.
+  - Update [fluent-bit] from version `1.6.9` to `1.7.7`.
+  - Update [elasticsearch] from version `7.10.1` to `7.13.0`.
+  - Update [kibana] from version `7.10.1` to `7.13.0`.
+- [ingress](https://github.com/sighupio/fury-kubernetes-ingress) 📦 core module: v1.9.1 -> [**v1.10.0**](https://github.com/sighupio/fury-kubernetes-ingress/releases/tag/v1.10.0)
+  - Kubernetes `1.21` Tech preview.
+  - Update [forecastle] from version `1.0.61` to `1.0.61`.
+  - Update [nginx] ingress controller from version `0.43.0` to `0.46.0`.
+  - Update [cert-manager] from version `1.1.0` to `1.3.1`.
+- [dr](https://github.com/sighupio/fury-kubernetes-dr) 📦 core module: v1.6.0 -> [**v1.7.0**](https://github.com/sighupio/fury-kubernetes-dr/releases/tag/v1.7.0)
+  - Kubernetes `1.21` Tech preview.
+  - Update [Velero] from version `1.5.2` to `1.6.0`.
+  - Update [Velero] terraform module to use terraform 0.15.4
+    - Simplying the terraform interface.
+- [OPA](https://github.com/sighupio/fury-kubernetes-opa) 📦 core module: v1.3.0 -> [**v1.4.0**](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.4.0)
+  - Kubernetes `1.21` Tech preview.
+  - Update [Gatekeeper] from version `v3.2.2` to `v3.4.0`.
+    - Add a missing template (unique_service_selector_template) to the template package.
+  - Update [Gatekeeper Policy Manager]. Version `v0.4.2`.
+
+## Upgrade path
+
+### Katalog Procedure
+
+To upgrade this distribution from `v1.5.X` to `v1.6.0`, you need to download this new version, vendor the dependencies,
+finally applying the `kustomize` project.
+
+```bash
+furyctl vendor -H
+kustomize build . | kubectl apply -f -
+```
+
+> **NOTE**: *The upgrade takes some minutes (depends on the cluster size), and you should expect some downtime during
+the upgrade process.*
+
+Then, in order to clean up old resources:
+
+```bash
+kubectl delete clusterrolebinding cert-manager-cainjector-leaderelection cert-manager-leaderelection
+kubectl delete clusterrole cert-manager-leaderelection
+```
+
+### Terraform Procedure
+
+It is important to read the
+[Disaster Recovery changelong](https://github.com/sighupio/fury-kubernetes-dr/releases/tag/v1.7.0) to understand how
+to move forward the terraform configuration of the Velero components.
+Ensure you are running terraform [0.15.4](https://releases.hashicorp.com/terraform/).
+
+## Test it
+
+If you want to test the distribution in a test environment, spin up a
+[`kind`](https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.0) cluster, then deploy all rendered manifests.
+
+```bash
+$ kind version
+kind v0.11.0 go1.16.4 darwin/amd64
+$ curl -Ls https://github.com/sighupio/fury-distribution/releases/download/v1.6.0/kind-config-v1.6.0.yml | kind create cluster --config -
+Creating cluster "kind" ...
+ ✓ Ensuring node image (kindest/node:v1.19.1) 🖼
+ ✓ Preparing nodes 📦 📦
+ ✓ Writing configuration 📜
+ ✓ Starting control-plane 🕹️
+ ✓ Installing StorageClass 💾
+ ✓ Joining worker nodes 🚜
+Set kubectl context to "kind-kind"
+You can now use your cluster with:
+
+kubectl cluster-info --context kind-kind
+
+Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
+$ kubectl apply -f https://github.com/sighupio/fury-distribution/releases/download/v1.6.0/fury-distribution-v1.6.0.yml
+namespace/cert-manager created
+namespace/gatekeeper-system created
+namespace/ingress-nginx created
+namespace/logging created
+namespace/monitoring created
+customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com created
+customresourcedefinition.apiextensions.k8s.io/bgpconfigurations.crd.projectcalico.org created
+customresourcedefinition.apiextensions.k8s.io/bgppeers.crd.projectcalico.org created
+customresourcedefinition.apiextensions.k8s.io/blockaffinities.crd.projectcalico.org created
+customresourcedefinition.apiextensions.k8s.io/certificaterequests.cert-manager.io created
+customresourcedefinition.apiextensions.k8s.io/certificates.cert-manager.io created
+customresourcedefinition.apiextensions.k8s.io/challenges.acme.cert-manager.io created
+customresourcedefinition.apiextensions.k8s.io/clusterinformations.crd.projectcalico.org created
+<TRUNCATED OUTPUT>
+```
+
+> **NOTE**: *Run `kubectl apply` multiple times until you see no errors in the console*
+
+[fluentd]: https://github.com/fluent/fluentd/releases/tag/v1.12.3
+[curator]: https://github.com/elastic/curator/releases/tag/v5.8.4
+[kibana]: https://github.com/elastic/kibana/releases/tag/v7.13.0
+[elasticsearch]: https://github.com/elastic/elasticsearch/releases/tag/v7.13.0
+[Cerebro]: https://github.com/lmenezes/cerebro/releases/tag/v0.9.4
+[Velero]: https://velero.io/
+[cert-manager]: https://github.com/jetstack/cert-manager
+[forecastle]: https://github.com/stakater/Forecastle
+[nginx]: https://github.com/kubernetes/ingress-nginx
+[metrics-server]: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/metrics-server
+[node-exporter]: https://github.com/prometheus/node_exporter
+[kube-state-metrics]: https://github.com/kubernetes/kube-state-metrics
+[Grafana]: https://grafana.com/
+[Alertmanager]: https://github.com/prometheus/alertmanager
+[Prometheus]: https://prometheus.io/
+[Prometheus Operator]: https://github.com/prometheus-operator/prometheus-operator
+[Calico]: https://www.projectcalico.org/
+[Gatekeeper]: https://github.com/open-policy-agent/gatekeeper
+[Gatekeeper Policy Manager]: https://github.com/sighupio/gatekeeper-policy-manager
+[thanos]: https://github.com/thanos-io/thanos
+[goldpinger]: https://github.com/bloomberg/goldpinger
+[fluent-bit]: https://fluentbit.io/
+[kube-proxy-metrics]: https://github.com/sighupio/fury-kubernetes-monitoring/tree/v1.12.0/katalog/kube-proxy-metrics

--- a/docs/releases/v1.6.0.md
+++ b/docs/releases/v1.6.0.md
@@ -20,7 +20,7 @@ The most important changes are listed below:
   - Update [Prometheus] from version `2.22.2` to `2.27.1`.
   - Update [Grafana] from version `7.3.6` to `7.5.7`.
   - Update [metrics-server] from version `0.4.1` to `0.5.0`.
-  - Update [Alertmanager] from version `0.21.0` to `0.22.1`.
+  - Update [Alertmanager] from version `0.21.0` to `0.22.2`.
   - Update [thanos] from version `0.12.2` to `0.20.2`.
     - Fixing thanos modules, missing namespace on components
   - Update [kube-state-metrics] from version `1.9.7` to `2.0.0`.


### PR DESCRIPTION
# Fury Distribution v1.6.0

Welcome to the **Fury Distribution v1.6.0**. In this new version, we had addressed the update of multiples
packages that belong to the distribution. All of them have been pushed to the latest stable release of each.
It includes testing (as tech preview) against Kubernetes `v1.21.0`.

The team has been working to make the release upgrade as simple as possible, so read carefully the upgrade path of each
core module listed below along with the upgrade path of the distribution.

## Changelog

The most important changes are listed below:

- [networking](https://github.com/sighupio/fury-kubernetes-networking) 📦 core module: v1.5.0 -> [**v1.6.0**](https://github.com/sighupio/fury-kubernetes-networking/releases/tag/v1.6.0)
  - Kubernetes `1.21` Tech preview.
  - Update [Calico] from version `3.17.1` to `3.19.1`.
- [monitoring](https://github.com/sighupio/fury-kubernetes-monitoring) 📦 core module: v1.11.0 -> [**v1.12.0**](https://github.com/sighupio/fury-kubernetes-monitoring/releases/tag/v1.12.0)
  - Kubernetes `1.21` Tech preview.
  - Update [Prometheus Operator] from version `0.44.1` to `0.48.1`.
  - Update [Prometheus] from version `2.22.2` to `2.27.1`.
  - Update [Grafana] from version `7.3.6` to `7.5.7`.
  - Update [metrics-server] from version `0.4.1` to `0.5.0`.
  - Update [Alertmanager] from version `0.21.0` to `0.22.2`.
  - Update [thanos] from version `0.12.2` to `0.20.2`.
    - Fixing thanos modules, missing namespace on components
  - Update [kube-state-metrics] from version `1.9.7` to `2.0.0`.
    - Update all Alerts and Grafana Dashboards
    - Modify the alerts that track expiration of cluster certificates to fire within 30/7 days of expiration instead
    of 7/1 days. (kubeadm-k8s-rules, prometheus-k8s-rules)
  - Update [kube-proxy-metrics]
  - Update [node-exporter] from version `1.0.1` to `1.1.2`.
  - Update [goldpinger] from version `3.0.0` to `3.2.0`.
- [logging](https://github.com/sighupio/fury-kubernetes-logging) 📦 core module: v1.7.0 -> [**v1.8.0**](https://github.com/sighupio/fury-kubernetes-logging/releases/tag/v1.8.0)
  - Kubernetes `1.21` Tech preview.
  - Update [Cerebro] from version `0.9.3` to `0.9.4`.
  - Update [fluentd] from version `1.11.5` to `1.12.3`.
  - Update [fluent-bit] from version `1.6.9` to `1.7.7`.
  - Update [elasticsearch] from version `7.10.1` to `7.13.0`.
  - Update [kibana] from version `7.10.1` to `7.13.0`.
- [ingress](https://github.com/sighupio/fury-kubernetes-ingress) 📦 core module: v1.9.1 -> [**v1.10.0**](https://github.com/sighupio/fury-kubernetes-ingress/releases/tag/v1.10.0)
  - Kubernetes `1.21` Tech preview.
  - Update [forecastle] from version `1.0.61` to `1.0.61`.
  - Update [nginx] ingress controller from version `0.43.0` to `0.46.0`.
  - Update [cert-manager] from version `1.1.0` to `1.3.1`.
- [dr](https://github.com/sighupio/fury-kubernetes-dr) 📦 core module: v1.6.0 -> [**v1.7.0**](https://github.com/sighupio/fury-kubernetes-dr/releases/tag/v1.7.0)
  - Kubernetes `1.21` Tech preview.
  - Update [Velero] from version `1.5.2` to `1.6.0`.
  - Update [Velero] terraform module to use terraform 0.15.4
    - Simplying the terraform interface.
- [OPA](https://github.com/sighupio/fury-kubernetes-opa) 📦 core module: v1.3.0 -> [**v1.4.0**](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.4.0)
  - Kubernetes `1.21` Tech preview.
  - Update [Gatekeeper] from version `v3.2.2` to `v3.4.0`.
    - Add a missing template (unique_service_selector_template) to the template package.
  - Update [Gatekeeper Policy Manager]. Version `v0.4.2`.

## Upgrade path

### Katalog Procedure

To upgrade this distribution from `v1.5.X` to `v1.6.0`, you need to download this new version, vendor the dependencies,
finally applying the `kustomize` project.

```bash
furyctl vendor -H
kustomize build . | kubectl apply -f -
```

> **NOTE**: *The upgrade takes some minutes (depends on the cluster size), and you should expect some downtime during
the upgrade process.*

Then, in order to clean up old resources:

```bash
kubectl delete clusterrolebinding cert-manager-cainjector-leaderelection cert-manager-leaderelection
kubectl delete clusterrole cert-manager-leaderelection
```

### Terraform Procedure

It is important to read the
[Disaster Recovery changelong](https://github.com/sighupio/fury-kubernetes-dr/releases/tag/v1.7.0) to understand how
to move forward the terraform configuration of the Velero components.
Ensure you are running terraform [0.15.4](https://releases.hashicorp.com/terraform/).

## Test it

If you want to test the distribution in a test environment, spin up a
[`kind`](https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.0) cluster, then deploy all rendered manifests.

```bash
$ kind version
kind v0.11.0 go1.16.4 darwin/amd64
$ curl -Ls https://github.com/sighupio/fury-distribution/releases/download/v1.6.0/kind-config-v1.6.0.yml | kind create cluster --config -
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.19.1) 🖼
 ✓ Preparing nodes 📦 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing StorageClass 💾
 ✓ Joining worker nodes 🚜
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
$ kubectl apply -f https://github.com/sighupio/fury-distribution/releases/download/v1.6.0/fury-distribution-v1.6.0.yml
namespace/cert-manager created
namespace/gatekeeper-system created
namespace/ingress-nginx created
namespace/logging created
namespace/monitoring created
customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/bgpconfigurations.crd.projectcalico.org created
customresourcedefinition.apiextensions.k8s.io/bgppeers.crd.projectcalico.org created
customresourcedefinition.apiextensions.k8s.io/blockaffinities.crd.projectcalico.org created
customresourcedefinition.apiextensions.k8s.io/certificaterequests.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/certificates.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/challenges.acme.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/clusterinformations.crd.projectcalico.org created
<TRUNCATED OUTPUT>
```

> **NOTE**: *Run `kubectl apply` multiple times until you see no errors in the console*

[fluentd]: https://github.com/fluent/fluentd/releases/tag/v1.12.3
[curator]: https://github.com/elastic/curator/releases/tag/v5.8.4
[kibana]: https://github.com/elastic/kibana/releases/tag/v7.13.0
[elasticsearch]: https://github.com/elastic/elasticsearch/releases/tag/v7.13.0
[Cerebro]: https://github.com/lmenezes/cerebro/releases/tag/v0.9.4
[Velero]: https://velero.io/
[cert-manager]: https://github.com/jetstack/cert-manager
[forecastle]: https://github.com/stakater/Forecastle
[nginx]: https://github.com/kubernetes/ingress-nginx
[metrics-server]: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/metrics-server
[node-exporter]: https://github.com/prometheus/node_exporter
[kube-state-metrics]: https://github.com/kubernetes/kube-state-metrics
[Grafana]: https://grafana.com/
[Alertmanager]: https://github.com/prometheus/alertmanager
[Prometheus]: https://prometheus.io/
[Prometheus Operator]: https://github.com/prometheus-operator/prometheus-operator
[Calico]: https://www.projectcalico.org/
[Gatekeeper]: https://github.com/open-policy-agent/gatekeeper
[Gatekeeper Policy Manager]: https://github.com/sighupio/gatekeeper-policy-manager
[thanos]: https://github.com/thanos-io/thanos
[goldpinger]: https://github.com/bloomberg/goldpinger
[fluent-bit]: https://fluentbit.io/
[kube-proxy-metrics]: https://github.com/sighupio/fury-kubernetes-monitoring/tree/v1.12.0/katalog/kube-proxy-metrics
