### PR TITLE
Prepare fury-distribution pre-release 1.7.0-rc

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,11 +27,17 @@ steps:
   - name: lint
     image: quay.io/sighup/policeman
     pull: always
+    environment:
+      # Identifies false positives like missing 'selector'.
+      # Doing this is valid for Kustomize patches
+      VALIDATE_KUBERNETES_KUBEVAL: "false"
+      # Some duplicated code is intended.
+      VALIDATE_JSCPD: "false"
     depends_on:
       - clone
 
   - name: render
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.19_3.8.7_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.19.11_3.8.7_2.4.1
     pull: always
     depends_on:
       - clone
@@ -49,112 +55,10 @@ steps:
 
 ---
 kind: pipeline
-name: e2e-kubernetes-1.18
-
-depends_on:
-  - policeman
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
-    settings:
-      action: custom-cluster-118
-      pipeline_id: cluster-118
-      local_kind_config_path: katalog/tests/config/kind-config-custom
-      cluster_version: '1.18.19'
-      instance_path: /shared
-      instance_size: 2-extra-large
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: test
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.18.19_3.8.7_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-118
-      - bats -t katalog/tests/install.sh
-      - bats -t katalog/tests/networking.sh
-      - bats -t katalog/tests/monitoring.sh
-      - bats -t katalog/tests/logging.sh
-      - bats -t katalog/tests/ingress.sh
-      - bats -t katalog/tests/dr.sh
-      - bats -t katalog/tests/opa.sh
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
-    depends_on: [ test ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-118
-      instance_size: 2-extra-large
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-    when:
-      status:
-      - success
-      - failure
-
-volumes:
-- name: shared
-  temp: {}
-
----
-kind: pipeline
 name: e2e-kubernetes-1.19
 
 depends_on:
   - policeman
-  - e2e-kubernetes-1.18
 
 platform:
   os: linux
@@ -164,10 +68,11 @@ trigger:
   ref:
     include:
       - refs/tags/**
+      - refs/heads/master
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.12.0
     pull: always
     volumes:
     - name: shared
@@ -217,7 +122,7 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.12.0
     depends_on: [ test ]
     settings:
       action: destroy
@@ -256,7 +161,6 @@ name: e2e-kubernetes-1.20
 
 depends_on:
   - policeman
-  - e2e-kubernetes-1.18
   - e2e-kubernetes-1.19
 
 platform:
@@ -267,10 +171,11 @@ trigger:
   ref:
     include:
       - refs/tags/**
+      - refs/heads/master
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.12.0
     pull: always
     volumes:
     - name: shared
@@ -320,7 +225,7 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.12.0
     depends_on: [ test ]
     settings:
       action: destroy
@@ -359,7 +264,6 @@ name: e2e-kubernetes-1.21
 
 depends_on:
   - policeman
-  - e2e-kubernetes-1.18
   - e2e-kubernetes-1.19
   - e2e-kubernetes-1.20
 
@@ -371,10 +275,11 @@ trigger:
   ref:
     include:
       - refs/tags/**
+      - refs/heads/master
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.12.0
     pull: always
     volumes:
     - name: shared
@@ -424,7 +329,7 @@ steps:
       - bats -t katalog/tests/opa.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.11.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.12.0
     depends_on: [ test ]
     settings:
       action: destroy
@@ -459,12 +364,118 @@ volumes:
 
 ---
 kind: pipeline
+name: e2e-kubernetes-1.22
+
+depends_on:
+  - policeman
+  - e2e-kubernetes-1.19
+  - e2e-kubernetes-1.20
+  - e2e-kubernetes-1.21
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+      - refs/heads/master
+
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.12.0
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ clone ]
+    settings:
+      action: custom-cluster-122
+      pipeline_id: cluster-122
+      local_kind_config_path: katalog/tests/config/kind-config-custom
+      cluster_version: '1.22.0'
+      instance_path: /shared
+      instance_size: 2-extra-large
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+
+  - name: test
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.22.0_3.8.7_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ init ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-122
+      - bats -t katalog/tests/install.sh
+      - bats -t katalog/tests/networking.sh
+      - bats -t katalog/tests/monitoring.sh
+      - bats -t katalog/tests/logging.sh
+      - bats -t katalog/tests/ingress.sh
+      - bats -t katalog/tests/dr.sh
+      - bats -t katalog/tests/opa.sh
+
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.12.0
+    depends_on: [ test ]
+    settings:
+      action: destroy
+      pipeline_id: cluster-122
+      instance_size: 2-extra-large
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+    when:
+      status:
+      - success
+      - failure
+
+volumes:
+- name: shared
+  temp: {}
+
+---
+kind: pipeline
 name: release
 
 depends_on:
-  - e2e-kubernetes-1.18
   - e2e-kubernetes-1.19
   - e2e-kubernetes-1.20
+  - e2e-kubernetes-1.21
+  - e2e-kubernetes-1.22
 
 platform:
   os: linux
@@ -508,7 +519,7 @@ steps:
   - name: publish-prerelease
     image: plugins/github-release
     pull: always
-    depends_on: 
+    depends_on:
       - prepare-release-manifests
       - prepare-release-notes
     settings:
@@ -535,7 +546,7 @@ steps:
   - name: publish-stable
     image: plugins/github-release
     pull: always
-    depends_on: 
+    depends_on:
       - prepare-release-manifests
       - prepare-release-notes
     settings:

--- a/Furyfile.yml
+++ b/Furyfile.yml
@@ -3,12 +3,12 @@
 # license that can be found in the LICENSE file.
 
 versions:
-  networking: v1.6.0
-  monitoring: v1.12.0
-  logging: v1.8.0
-  ingress: v1.10.0
-  dr: v1.7.0
-  opa: v1.4.0
+  networking: v1.7.0
+  monitoring: v1.13.0
+  logging: v1.9.0
+  ingress: v1.11.1
+  dr: v1.8.0
+  opa: v1.5.0
 
 bases:
   - name: networking/calico
@@ -22,6 +22,7 @@ bases:
   - name: monitoring/kube-state-metrics
   - name: monitoring/node-exporter
   - name: monitoring/metrics-server
+  - name: monitoring/alertmanager-operated
   - name: logging/elasticsearch-single
   - name: logging/cerebro
   - name: logging/curator

--- a/docs/releases/v1.7.0.md
+++ b/docs/releases/v1.7.0.md
@@ -1,0 +1,143 @@
+# Fury Distribution v1.7.0
+
+Welcome to the **Fury Distribution v1.7.0**. In this new version, we had addressed the update of multiples
+packages that belong to the distribution. All of them have been pushed to the latest stable release of each.
+It includes testing (as tech preview) against Kubernetes `v1.22.0`.
+
+The team has been working to make the release upgrade as simple as possible, so read carefully the upgrade path of each
+core module listed below along with the upgrade path of the distribution.
+
+## Changelog
+
+The most important changes are listed below:
+
+- [networking](https://github.com/sighupio/fury-kubernetes-networking) 📦 core module: v1.5.0 -> [**v1.7.0**](https://github.com/sighupio/fury-kubernetes-networking/releases/tag/v1.7.0)
+  - Kubernetes `1.22` Tech preview.
+  - Update [Calico] from version `3.19.1` to `3.19.2`.
+- [monitoring](https://github.com/sighupio/fury-kubernetes-monitoring) 📦 core module: v1.12.3 -> [**v1.13.0**](https://github.com/sighupio/fury-kubernetes-monitoring/releases/tag/v1.13.0)
+  - Kubernetes `1.22` Tech preview.
+  - Update [Prometheus Operator] from version `0.48.1` to `0.50.0`.
+  - Update [Prometheus] from version `2.27.1` to `2.29.1`.
+  - Update [Grafana] from version `7.5.7` to `8.1.2`.
+  - Update [x509-exporter] from version `2.9.2` to `2.11.0`.
+  - Update [thanos] from version `0.20.2` to `0.22.0`.
+  - Update [kube-proxy-metrics] from version `0.10.0` to `0.11.0`.
+  - Update [node-exporter] from version `1.1.2` to `1.2.2`.
+  - Add `oauth2` field to prometheus CRDs to allow authentication with oauth2
+  - Add `podDisruptionBudget` to alertmanager and prometheus.
+  - Add alertmanager dashboard.
+  - Fix dashboards to work with the latest grafana synching with kube-prometheus.
+  - Updates to verious prometheus monitoring rules synching with kube-prometheus.
+  - Remove `CPUThrottlingHigh`.
+- [logging](https://github.com/sighupio/fury-kubernetes-logging) 📦 core module: v1.8.0 -> [**v1.9.0**](https://github.com/sighupio/fury-kubernetes-logging/releases/tag/v1.9.0)
+  - Kubernetes `1.22` Tech preview.
+  - Update [fluentd] from version `1.12.3` to `1.14.0`.
+  - Update [fluent-bit] from version `1.7.7` to `1.8.2`.
+  - Update [elasticsearch] from version `7.13.0` to `7.13.3`.
+  - Update [kibana] from version `7.30.0` to `7.13.3`.
+  - Change Kibana rolling strategy to recreate and remove kibana cpu limits
+  - Add startupProbe that creates index-patterns, reverting readinessProbe to the previous version
+- [ingress](https://github.com/sighupio/fury-kubernetes-ingress) 📦 core module: v1.10.0 -> [**v1.11.0**](https://github.com/sighupio/fury-kubernetes-ingress/releases/tag/v1.11.0)
+  - Kubernetes `1.22` Tech preview.
+  - Fix the apiVersion of `Ingress` and `IngressClass` to v1 to support 1.22
+  - Adapt new `spec.backend` syntax for `Ingress`
+  - Update cert-manager CRDs as per upstream
+  - Update [forecastle] from version `1.0.61` to `1.0.66`.
+  - Update [nginx] ingress controller from version `0.46.0` to `1.0.0`.
+  - Update [cert-manager] from version `1.3.1` to `1.5.3`.
+  - Update [pomerium] from version `0.14.4` to `0.15.0`.
+- [dr](https://github.com/sighupio/fury-kubernetes-dr) 📦 core module: v1.7.0 -> [**v1.8.0**](https://github.com/sighupio/fury-kubernetes-dr/releases/tag/v1.8.0)
+  - Kubernetes `1.22` Tech preview.
+  - Update [Velero] from version `1.6.0` to `1.6.3`.
+    - Upgrade velero-plugin-for-aws from `1.2.0` to `1.2.1`
+    - Upgrade velero-plugin-for-microsoft-azure from `1.2.0` to `1.2.1`
+    - Upgrade velero-plugin-for-gcp from `1.2.0` to `1.2.1`
+  - Adapt the CRDs to use `apiextensions.k8s.io/v1` to support Kubernetes 1.22
+- [OPA](https://github.com/sighupio/fury-kubernetes-opa) 📦 core module: v1.4.0 -> [**v1.5.0**](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.5.0)
+  - Kubernetes `1.22` Tech preview.
+  - Update [Gatekeeper] from version `v3.4.0` to `v3.6.0`.
+    - Add `v1` constraint template CRD to the module.
+  - Adapt the CRDs to use `apiextensions.k8s.io/v1` to support Kubernetes 1.22
+  - Update [Gatekeeper Policy Manager]. Version `v0.5.0`.
+
+## Upgrade path
+
+### Katalog Procedure
+
+To upgrade this distribution from `v1.6.0` to `v1.7.0`, you need to download this new version, vendor the dependencies,
+finally applying the `kustomize` project.
+
+```bash
+furyctl vendor -H
+kustomize build . | kubectl apply -f -
+```
+
+> **NOTE**: *The upgrade takes some minutes (depends on the cluster size), and you should expect some downtime during
+the upgrade process.*
+
+### Terraform Procedure
+
+## Test it
+
+If you want to test the distribution in a test environment, spin up a
+[`kind`](https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.0) cluster, then deploy all rendered manifests.
+
+```bash
+$ kind version
+kind v0.11.0 go1.16.4 darwin/amd64
+$ curl -Ls https://github.com/sighupio/fury-distribution/releases/download/v1.7.0/katalog/tests/kind-config-v1.7.0 | kind create cluster --config -
+Creating cluster "kind" ...
+ ✓ Ensuring node image (kindest/node:v1.20.1) 🖼
+ ✓ Preparing nodes 📦 📦
+ ✓ Writing configuration 📜
+ ✓ Starting control-plane 🕹️
+ ✓ Installing StorageClass 💾
+ ✓ Joining worker nodes 🚜
+Set kubectl context to "kind-kind"
+You can now use your cluster with:
+
+kubectl cluster-info --context kind-kind
+
+Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
+$ kubectl apply -f https://github.com/sighupio/fury-distribution/releases/download/v1.7.0/fury-distribution-v1.7.0.yml
+namespace/cert-manager created
+namespace/gatekeeper-system created
+namespace/ingress-nginx created
+namespace/logging created
+namespace/monitoring created
+customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com created
+customresourcedefinition.apiextensions.k8s.io/bgpconfigurations.crd.projectcalico.org created
+customresourcedefinition.apiextensions.k8s.io/bgppeers.crd.projectcalico.org created
+customresourcedefinition.apiextensions.k8s.io/blockaffinities.crd.projectcalico.org created
+customresourcedefinition.apiextensions.k8s.io/certificaterequests.cert-manager.io created
+customresourcedefinition.apiextensions.k8s.io/certificates.cert-manager.io created
+customresourcedefinition.apiextensions.k8s.io/challenges.acme.cert-manager.io created
+customresourcedefinition.apiextensions.k8s.io/clusterinformations.crd.projectcalico.org created
+<TRUNCATED OUTPUT>
+```
+
+> **NOTE**: *Run `kubectl apply` multiple times until you see no errors in the console*
+
+[fluentd]: https://github.com/fluent/fluentd/releases/tag/v1.14.0
+[curator]: https://github.com/elastic/curator/releases/tag/v5.8.4
+[kibana]: https://github.com/elastic/kibana/releases/tag/v7.13.3
+[elasticsearch]: https://github.com/elastic/elasticsearch/releases/tag/v7.13.3
+[Cerebro]: https://github.com/lmenezes/cerebro/releases/tag/v0.9.4
+[Velero]: https://velero.io/
+[cert-manager]: https://github.com/jetstack/cert-manager
+[forecastle]: https://github.com/stakater/Forecastle
+[nginx]: https://github.com/kubernetes/ingress-nginx
+[metrics-server]: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/metrics-server
+[node-exporter]: https://github.com/prometheus/node_exporter
+[kube-state-metrics]: https://github.com/kubernetes/kube-state-metrics
+[Grafana]: https://grafana.com/
+[Alertmanager]: https://github.com/prometheus/alertmanager
+[Prometheus]: https://prometheus.io/
+[Prometheus Operator]: https://github.com/prometheus-operator/prometheus-operator
+[Calico]: https://www.projectcalico.org/
+[Gatekeeper]: https://github.com/open-policy-agent/gatekeeper
+[Gatekeeper Policy Manager]: https://github.com/sighupio/gatekeeper-policy-manager
+[thanos]: https://github.com/thanos-io/thanos
+[goldpinger]: https://github.com/bloomberg/goldpinger
+[fluent-bit]: https://fluentbit.io/
+[kube-proxy-metrics]: https://github.com/sighupio/fury-kubernetes-monitoring/tree/v1.12.0/katalog/kube-proxy-metrics

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -19,6 +19,7 @@ bases:
   - ./vendor/katalog/monitoring/kube-state-metrics
   - ./vendor/katalog/monitoring/node-exporter
   - ./vendor/katalog/monitoring/metrics-server
+  - ./vendor/katalog/monitoring/alertmanager-operated
   # Logging
   - ./vendor/katalog/logging/elasticsearch-single
   - ./vendor/katalog/logging/cerebro

--- a/release-notes.py
+++ b/release-notes.py
@@ -3,6 +3,7 @@
 # license that can be found in the LICENSE file.
 
 import os
+import sys
 from shutil import copyfile
 
 import semantic_version  # pylint: disable=import-error
@@ -11,12 +12,15 @@ RELEASE_NOTES_FILE_PATH = os.getenv("RELEASE_NOTES_FILE_PATH")
 DRONE_TAG = os.getenv("DRONE_TAG")
 
 if __name__ == "__main__":
+    if not DRONE_TAG or not RELEASE_NOTES_FILE_PATH:
+        sys.exit("DRONE_TAG or RELEASE_NOTES_FILE_PATH variables not found, returning")
+
     version = DRONE_TAG[1:]
 
     major = semantic_version.Version(version).major
     minor = semantic_version.Version(version).minor
     patch = semantic_version.Version(version).patch
 
-    release_notes_file = f"./docs/releases/v{major}.{minor}.{patch}.md"
-    print(f"Copying from {release_notes_file} to {RELEASE_NOTES_FILE_PATH}")
+    release_notes_file = "./docs/releases/v{}.{}.{}.md".format(major, minor, patch)
+    print("Copying from {} to {}".format(release_notes_file, RELEASE_NOTES_FILE_PATH))
     copyfile(release_notes_file, RELEASE_NOTES_FILE_PATH)


### PR DESCRIPTION
This PR release a RC for fury-distribution 1.7.0. This release adds the tech preview for Kuberenetes 1.22. Refer [release notes](https://github.com/sighupio/fury-distribution/blob/43c840404d619203bc540520459618b9d95babad/docs/releases/v1.7.0.md) to see other changes.