### PR TITLE
Add commonLabels to all KFD resources

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -2,6 +2,12 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+commonLabels:
+  app.kubernetes.io/part-of: "kfd"
+  kfd.sighup.io/version: "1.7.0"
+  kfd.sighup.io/source: "kustomize"
+  kfd.sighup.io/installer: "furyctl"
+
 bases:
   # Networking
   - ./vendor/katalog/networking/calico


### PR DESCRIPTION
The labels will be useful to identify each resource as a part of KFD and which release of KFD is deployed. The assumption is that, the `vendor/` directory will be populated by `furyctl` so this installation is managed by `furyctl`. The version of `furyctl` is hard to assess at this point and hence not including that.