### PR TITLE
fix: removing '-velero' suffix on terraform templates

### DIFF
--- a/source/terraform/velero.tf.tpl
+++ b/source/terraform/velero.tf.tpl
@@ -1,6 +1,6 @@
 module "velero" {
   source             = "{{ print .spec.distribution.common.relativeVendorPath "/modules/dr/modules/aws-velero" }}"
-  backup_bucket_name = "{{ .metadata.name }}-velero"
+  backup_bucket_name = "{{ .metadata.name }}"
   oidc_provider_url  = replace(data.aws_eks_cluster.this.identity.0.oidc.0.issuer, "https://", "")
 }
 


### PR DESCRIPTION
as per title