### PR TITLE
chore(kfd.yaml): bump aws module version

### DIFF
--- a/kfd.yaml
+++ b/kfd.yaml
@@ -5,7 +5,7 @@
 version: v1.24.1
 modules:
   auth: v0.0.2
-  aws: v2.0.0
+  aws: v2.1.0
   dr: v1.10.1
   ingress: v1.13.1
   logging: v3.0.1


### PR DESCRIPTION
bump AWS module version to add support for Kubernetes 1.24