### PR TITLE
Feat: improve and fix sso on distro template

### DIFF
--- a/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
@@ -159,36 +159,65 @@ spec:
           value: infra
     # This section contains all the configurations for all the KFD core modules
     modules:
+      # This section contains all the configurations for the ingress module
       ingress:
+        # This optional key is used to override automatic parameters
         overrides:
+          # This key is used to override the spec.distribution.common.nodeSelector settings
           nodeSelector: null
+          # This key is used to override the spec.distribution.common.tolerations settings
           tolerations: null
+          # This key is used to override some parameters on the ingresses managed by this module
           ingresses:
             forecastle:
+              # if the authentication is enabled, it can be disabled
               disableAuth: false
+              # the host can be ovverridden, by default is forecastle.{.spec.distribution.modules.ingress.baseDomain}
               host: ""
+              # the ingressClass can be overriden if needed
               ingressClass: ""
-        baseDomain: example.dev
+        # the base domain used for all the KFD ingresses
+        baseDomain: internal.example.dev
+        # configurations for the nginx package
         nginx:
+          # type defines if the nginx should be configured as single or dual
           type: single
+          # the tls section defines how the tls for the ingresses should be managed
           tls:
+            # provider can be certManager, secret
             provider: certManager
+            # if provider is set as secret, this key will be used to create the certificate in the cluster
             secret:
+              # the certificate file, a file notation can be used to get the content from a file
               cert: "{file://relative/path/to/ssl.crt}"
+              # the key file, a file notation can be used to get the content from a file
               key: "{file://relative/path/to/ssl.key}"
+              # the ca file, a file notation can be used to get the content from a file
               ca: "{file://relative/path/to/ssl.ca}"
+        # configurations for the cert-manager package
         certManager:
+          # the configuration for the clusterIssuer that will be created
           clusterIssuer:
+            # the name of the clusterIssuer
             name: letsencrypt-fury
+            # the email used during issuing procedures
             email: example@sighup.io
+            # the type of the clusterIssuer, can be http01 or dns01, if dns01, the route53 integration will be used
             type: http01
+        # DNS definition, used in conjunction with externalDNS package to automate DNS management and certificates emission
         dns:
+          # the public DNS zone definition
           public:
+            # the name of the zone
             name: "example.dev"
+            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
             create: false
+          # the private DNS zone definition, that will be attached to the VPC
           private:
+            # the name of the zone
             name: "internal.example.dev"
             vpcId: "vpc-0123456789abcdef0"
+            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
             create: false
       logging:
         overrides:

--- a/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
@@ -222,21 +222,35 @@ spec:
             create: false
             # This field is ignored, but needed. TBD better validation
             vpcId: "dummyvalue"
+      # This section contains all the configurations for the logging module      
       logging:
+        # This optional key is used to override automatic parameters
         overrides:
+          # This key is used to override the spec.distribution.common.nodeSelector setting
           nodeSelector: null
+          # This key is used to override the spec.distribution.common.tolerations setting
           tolerations: null
+          # This key is used to override some parameters on the ingresses managed by this module
           ingresses:
             opensearch-dashboards:
+              # if the authentication is enabled, it can be disabled
               disableAuth: false
+              # the host can be ovverridden, by default is opensearch-dashboards.{.spec.distribution.modules.ingress.baseDomain}
               host: ""
+              # the ingressClass can be overriden if needed
               ingressClass: ""
             cerebro:
+              # if the authentication is enabled, it can be disabled
               disableAuth: false
+              # the host can be ovverridden, by default is cerebro.{.spec.distribution.modules.ingress.baseDomain}
               host: ""
+              # the ingressClass can be overriden if needed
               ingressClass: ""
+        # configurations for the opensearch package
         opensearch:
+          # the type of opensearch to install, can be single or triple
           type: single
+          # optional settings to override requests and limits
           resources:
             requests:
               cpu: ""
@@ -244,27 +258,37 @@ spec:
             limits:
               cpu: ""
               memory: ""
+          # the PVC size used by opensearch, for each pod
           storageSize: "150Gi"
       monitoring:
+        # This optional key is used to override automatic parameters
         overrides:
+          # This key is used to override the spec.distribution.common.nodeSelector setting
           nodeSelector: null
+          # This key is used to override the spec.distribution.common.tolerations setting
           tolerations: null
+          # This key is used to override some parameters on the ingresses managed by this module
           ingresses:
             prometheus:
+              # if the authentication is enabled, it can be disabled
               disableAuth: false
+              # the host can be ovverridden, by default is prometheus.{.spec.distribution.modules.ingress.baseDomain}
               host: ""
+              # the ingressClass can be overriden if needed
               ingressClass: ""
             alertmanager:
+              # if the authentication is enabled, it can be disabled
               disableAuth: false
+              # the host can be ovverridden, by default is alertmanager.{.spec.distribution.modules.ingress.baseDomain}
               host: ""
+              # the ingressClass can be overriden if needed
               ingressClass: ""
             grafana:
+              # if the authentication is enabled, it can be disabled
               disableAuth: false
+              # the host can be ovverridden, by default is grafana.{.spec.distribution.modules.ingress.baseDomain}
               host: ""
-              ingressClass: ""
-            goldpinger:
-              disableAuth: false
-              host: ""
+              # the ingressClass can be overriden if needed
               ingressClass: ""
         prometheus:
           resources:

--- a/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
@@ -145,6 +145,8 @@ spec:
           groups:
             - example:masters
           rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
+    # Optional value if spec.infrastructure is left empty and not managed by furyctl
+    vpcId: "vpc-123456780"
   # This section describes how the KFD distribution will be installed
   distribution:
     # This common configuration will be applied to all the packages that will be installed in the cluster
@@ -216,9 +218,10 @@ spec:
           private:
             # the name of the zone
             name: "internal.example.dev"
-            vpcId: "vpc-0123456789abcdef0"
             # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
             create: false
+            # This field is ignored, but needed. TBD better validation
+            vpcId: "dummyvalue"
       logging:
         overrides:
           nodeSelector: null
@@ -286,7 +289,8 @@ spec:
         velero:
           eks:
             bucketName: example-velero
-            iamRoleArn: arn:aws:iam::123456789012:role/example-velero
+            # This field is ignored, but needed. TBD better validation
+            iamRoleArn: dummyvalue
             region: eu-west-1
         overrides:
           nodeSelector: null

--- a/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
@@ -6,47 +6,72 @@
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
+  # The name of the cluster, and the prefix for all the other resources created on AWS
   name: {{.Name}}
 spec:
+  # This value defines which KFD version to use to install the cluster
   distributionVersion: {{.DistributionVersion}}
+  # This sections defines where to store the terraform state files used by furyctl
   toolsConfiguration:
     terraform:
       state:
         s3:
+          # This value defines which bucket will be used to store all the states
           bucketName: example-bucket
+          # This value defines which folder will be used to store all the states inside the bucket
           keyPrefix: example-cluster/
+          # This value defines in which region the bucket is
           region: eu-west-1
+  # This value defines which region will be used to install the cluster and all the related resources
   region: eu-west-1
+  # This map defines which will be the common tags that will be added to all the resources created on AWS
   tags:
     env: "example"
     k8s: "example2"
+  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
+  # If you already have a VPC, you can remove this key from the configuration file
   infrastructure:
+    # This key defines the VPC that will be created in AWS
     vpc:
       network:
+        # This is the CIDR of the VPC
         cidr: 10.1.0.0/16
         subnetsCidrs:
+          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
           private:
             - 10.1.0.0/20
             - 10.1.16.0/20
             - 10.1.32.0/20
+          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
           public:
             - 10.1.48.0/24
             - 10.1.49.0/24
             - 10.1.50.0/24
+      # This section defines the creation of VPN bastions
       vpn:
+        # The number of instance to create, 0 to skip the creation
         instances: 2
+        # The port used by the OpenVPN server
         port: 1194
+        # The size of the AWS ec2 instance
         instanceType: t3.micro
+        # The size of the disk in GB
         diskSize: 50
+        # The name of the user create inside the bastion server
         operatorName: sighup
+        # The dhParamsBits size used for the creation of the .pem file that will  be used in the dh openvpn server.conf file
         dhParamsBits: 2048
+        # The CIDR that will be used to assign IP addresses to the VPN clients when connected
         vpnClientsSubnetCidr: 172.16.0.0/16
+        # ssh access settings
         ssh:
           publicKeys:
             - "ssh-ed25519 XYZ"
             - "{file://relative/path/to/ssh.pub}"
+          # The github user name list that will be used to get the ssh public key that will be added as authorized key to the operatorName user
           githubUsersName:
             - johndoe
+          # The CIDR enabled in the security group that can access the bastions in SSH
           allowedFromCidrs:
             - 0.0.0.0/0
   kubernetes:

--- a/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
@@ -365,7 +365,6 @@ spec:
               host: ""
               # the ingressClass can be overriden if needed
               ingressClass: ""
-          tolerations: null
         provider:
           # The authentication type used for the infrastructure ingresses (all the ingress for the distribution) can be none, basicAuth, sso
           type: none

--- a/templates/distribution/manifests/auth/patches/pomerium-ingress.yml.tpl
+++ b/templates/distribution/manifests/auth/patches/pomerium-ingress.yml.tpl
@@ -10,9 +10,10 @@ metadata:
   name: pomerium
   namespace: pomerium
 spec:
-  ingressClassName: {{ template "ingressClass" (dict "module" "auth" "package" "pomerium" "type" "internal" "spec" .spec) }}
+  # Needs to be externally available if the user wants to protect other applications in the cluster
+  ingressClassName: {{ template "ingressClass" (dict "module" "auth" "package" "pomerium" "type" "external" "spec" .spec) }}
   rules:
-    - host: {{ template "pomeriumHost" . }}
+    - host: {{ template "pomeriumUrl" .spec }}
       http:
         paths:
           - path: /
@@ -22,5 +23,5 @@ spec:
                 name: pomerium
                 port:
                   number: 80
-{{- template "ingressTls" (dict "module" "auth" "package" "pomerium" "prefix" "pomerium.internal." "spec" .spec) }}
+{{- template "ingressTlsAuth" (dict "module" "auth" "package" "pomerium" "prefix" "pomerium." "spec" .spec) }}
 {{- end }}

--- a/templates/distribution/manifests/auth/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/auth/resources/ingress-infra.yml.tpl
@@ -13,7 +13,7 @@ spec:
   # Needs to be externally available in order to act as callback from GitHub.
   ingressClassName: {{ template "ingressClass" (dict "module" "auth" "package" "dex" "type" "external" "spec" .spec) }}
   rules:
-    - host: {{ template "ingressHost" (dict "module" "auth" "package" "dex" "prefix" "login." "spec" .spec) }}
+    - host: {{ template "dexUrl" .spec }}
       http:
         paths:
           - path: /
@@ -23,5 +23,5 @@ spec:
                 name: dex
                 port:
                   name: http
-{{- template "ingressTls" (dict "module" "auth" "package" "dex" "prefix" "login." "spec" .spec) }}
+{{- template "ingressTlsAuth" (dict "module" "auth" "package" "dex" "prefix" "login." "spec" .spec) }}
 {{- end }}

--- a/templates/distribution/manifests/auth/resources/pomerium-config.env.tpl
+++ b/templates/distribution/manifests/auth/resources/pomerium-config.env.tpl
@@ -2,7 +2,7 @@
   {{ if .spec.distribution.modules.auth.overrides.ingresses.pomerium.host -}}
     {{ .spec.distribution.modules.auth.overrides.ingresses.pomerium.host }}
   {{- else -}}
-    {{ print "pomerium.internal." .spec.distribution.modules.ingress.baseDomain }}
+    {{ print "pomerium." .spec.distribution.modules.ingress.baseDomain }}
   {{- end }}
 {{- end -}}
 {{- define "dexHost" -}}

--- a/templates/distribution/manifests/auth/resources/pomerium-policy.yml.tpl
+++ b/templates/distribution/manifests/auth/resources/pomerium-policy.yml.tpl
@@ -1,3 +1,35 @@
 {{- if eq .spec.distribution.modules.auth.provider.type "sso" -}}
-{{ .spec.distribution.modules.auth.pomerium.policy }}
+address: ":8080"
+metrics_address: ":9090"
+grcp_address: ":8080"
+
+insecure_server: true
+autocert: false
+
+policy:
+  - from: https://{{ template "prometheusUrl" .spec }}
+    to: http://prometheus-k8s.monitoring.svc.cluster.local:9090
+    allow_any_authenticated_user: true
+  - from: https://{{ template "alertmanagerUrl" .spec }}
+    to: http://alertmanager-main.monitoring.svc.cluster.local:9093
+    allow_any_authenticated_user: true
+  - from: https://{{ template "grafanaUrl" .spec }}
+    to: http://grafana.monitoring.svc.cluster.local:3000
+    allow_any_authenticated_user: true
+  - from: https://{{ template "forecastleUrl" .spec }}
+    to: http://forecastle.ingress-nginx.svc.cluster.local
+    allow_any_authenticated_user: true
+  - from: https://{{ template "cerebroUrl" .spec }}
+    to: http://cerebro.logging.svc.cluster.local:9000
+    allow_any_authenticated_user: true
+  - from: https://{{ template "opensearchDashboardsUrl" .spec }}
+    to: http://opensearch-dashboards.logging.svc.cluster.local:5601
+    allow_any_authenticated_user: true
+  - from: https://{{ template "minioUrl" .spec }}
+    to: http://minio.logging.svc.cluster.local:9000
+    allow_any_authenticated_user: true
+  - from: https://{{ template "gpmUrl" .spec }}
+    to: http://gatekeeper-policy-manager.gatekeeper-system.svc.cluster.local
+    allow_any_authenticated_user: true
+{{ .spec.distribution.modules.auth.provider.pomerium.policy | indent 2 }}
 {{- end }}

--- a/templates/distribution/manifests/auth/secrets/dex.yml.tpl
+++ b/templates/distribution/manifests/auth/secrets/dex.yml.tpl
@@ -2,14 +2,14 @@
   {{ if .spec.distribution.modules.auth.overrides.ingresses.dex.host -}}
     {{ print "https://" .spec.distribution.modules.auth.overrides.ingresses.dex.host }}
   {{- else -}}
-    {{ print "https://login." .spec.distribution.modules.ingress.baseDomain }}
+    {{ print "https://login." .spec.distribution.modules.auth.baseDomain }}
   {{- end }}
 {{- end -}}
 {{- define "pomeriumHost" }}
   {{- if .spec.distribution.modules.auth.overrides.ingresses.pomerium.host -}}
     {{ print "https://" .spec.distribution.modules.auth.overrides.ingresses.pomerium.host "/oauth2/callback" }}
   {{- else -}}
-    {{ print "https://pomerium.internal." .spec.distribution.modules.ingress.baseDomain "/oauth2/callback" }}
+    {{ print "https://pomerium." .spec.distribution.modules.auth.baseDomain "/oauth2/callback" }}
   {{- end }}
 {{- end -}}
 {{- if eq .spec.distribution.modules.auth.provider.type "sso" -}}

--- a/templates/distribution/manifests/ingress/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/ingress/kustomization.yaml.tpl
@@ -67,7 +67,7 @@ patchesJson6902:
       name: nginx-ingress-controller-internal
       namespace: ingress-nginx
     path: patchesJson/ingress-nginx.yml
-  {{- else if .spec.distribution.modules.ingress.nginx.type "single" -}}
+  {{- else if eq .spec.distribution.modules.ingress.nginx.type "single" -}}
   - target:
       group: apps
       version: v1

--- a/templates/distribution/manifests/ingress/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/ingress/resources/ingress-infra.yml.tpl
@@ -9,7 +9,7 @@ metadata:
     {{ if not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
   name: forecastle
-  {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+  {{ if and (not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
   namespace: pomerium
   {{ else }}
   namespace: ingress-nginx
@@ -23,7 +23,7 @@ spec:
         - path: /
           pathType: Prefix
           backend:
-          {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+          {{ if and (not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
             service:
               name: pomerium
               port:

--- a/templates/distribution/manifests/logging/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/logging/resources/ingress-infra.yml.tpl
@@ -9,7 +9,7 @@ metadata:
     {{ if not .spec.distribution.modules.logging.overrides.ingresses.cerebro.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
   name: cerebro
-  {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+  {{ if and (not .spec.distribution.modules.logging.overrides.ingresses.cerebro.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
   namespace: pomerium
   {{ else }}
   namespace: logging
@@ -23,7 +23,7 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-            {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+            {{ if and (not .spec.distribution.modules.logging.overrides.ingresses.cerebro.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
               service:
                 name: pomerium
                 port:
@@ -46,7 +46,7 @@ metadata:
     {{ if not .spec.distribution.modules.logging.overrides.ingresses.opensearchDashboards.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
   name: opensearch-dashboards
-  {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+  {{ if and (not .spec.distribution.modules.logging.overrides.ingresses.opensearch-dashboards.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
   namespace: pomerium
   {{ else }}
   namespace: logging
@@ -60,7 +60,7 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-            {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+            {{ if and (not .spec.distribution.modules.logging.overrides.ingresses.opensearch-dashboards.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
               service:
                 name: pomerium
                 port:
@@ -83,7 +83,7 @@ metadata:
     {{ if not .spec.distribution.modules.logging.overrides.ingresses.minio.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
   name: minio
-  {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+  {{ if and (not .spec.distribution.modules.logging.overrides.ingresses.minio.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
   namespace: pomerium
   {{ else }}
   namespace: logging
@@ -97,7 +97,7 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-            {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+            {{ if and (not .spec.distribution.modules.logging.overrides.ingresses.minio.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
               service:
                 name: pomerium
                 port:

--- a/templates/distribution/manifests/logging/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/logging/resources/ingress-infra.yml.tpl
@@ -9,21 +9,32 @@ metadata:
     {{ if not .spec.distribution.modules.logging.overrides.ingresses.cerebro.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
   name: cerebro
+  {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+  namespace: pomerium
+  {{ else }}
   namespace: logging
+  {{ end }}
 spec:
   ingressClassName: {{ template "ingressClass" (dict "module" "logging" "package" "cerebro" "type" "internal" "spec" .spec) }}
   rules:
-    - host: {{ template "ingressHost" (dict "module" "logging" "package" "cerebro" "prefix" "cerebro.internal." "spec" .spec) }}
+    - host: {{ template "cerebroUrl" .spec }}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
+            {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+              service:
+                name: pomerium
+                port:
+                  number: 80
+            {{ else }}
               service:
                 name: cerebro
                 port:
                   name: http
-{{- template "ingressTls" (dict "module" "logging" "package" "cerebro" "prefix" "cerebro.internal." "spec" .spec) }}
+            {{ end }}
+{{- template "ingressTls" (dict "module" "logging" "package" "cerebro" "prefix" "cerebro." "spec" .spec) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -35,21 +46,32 @@ metadata:
     {{ if not .spec.distribution.modules.logging.overrides.ingresses.opensearchDashboards.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
   name: opensearch-dashboards
+  {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+  namespace: pomerium
+  {{ else }}
   namespace: logging
+  {{ end }}
 spec:
   ingressClassName: {{ template "ingressClass" (dict "module" "logging" "package" "opensearchDashboards" "type" "internal" "spec" .spec) }}
   rules:
-    - host: {{ template "ingressHost" (dict "module" "logging" "package" "opensearchDashboards" "prefix" "opensearch-dashboards.internal." "spec" .spec) }}
+    - host: {{ template "opensearchDashboardsUrl" .spec }}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
+            {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+              service:
+                name: pomerium
+                port:
+                  number: 80
+            {{ else }}
               service:
                 name: opensearch-dashboards
                 port:
                   name: http
-{{- template "ingressTls" (dict "module" "logging" "package" "opensearchDashboards" "prefix" "opensearch-dashboards.internal." "spec" .spec) }}
+            {{ end }}
+{{- template "ingressTls" (dict "module" "logging" "package" "opensearchDashboards" "prefix" "opensearch-dashboards." "spec" .spec) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -61,18 +83,29 @@ metadata:
     {{ if not .spec.distribution.modules.logging.overrides.ingresses.minio.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
   name: minio
+  {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+  namespace: pomerium
+  {{ else }}
   namespace: logging
+  {{ end }}
 spec:
   ingressClassName: {{ template "ingressClass" (dict "module" "logging" "package" "minio" "type" "internal" "spec" .spec) }}
   rules:
-    - host: {{ template "ingressHost" (dict "module" "logging" "package" "minio" "prefix" "minio.internal." "spec" .spec) }}
+    - host: {{ template "minioUrl" .spec }}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
+            {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+              service:
+                name: pomerium
+                port:
+                  number: 80
+            {{ else }}
               service:
                 name: minio
                 port:
                   name: minio
-{{- template "ingressTls" (dict "module" "logging" "package" "minio" "prefix" "minio.internal." "spec" .spec) }}
+            {{ end }}
+{{- template "ingressTls" (dict "module" "logging" "package" "minio" "prefix" "minio." "spec" .spec) }}

--- a/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
@@ -9,7 +9,11 @@ metadata:
     {{ if not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
   name: alertmanager
+  {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+  namespace: pomerium
+  {{ else }}
   namespace: monitoring
+  {{ end }}
 spec:
   ingressClassName: {{ template "ingressClass" (dict "module" "monitoring" "package" "alertmanager" "type" "internal" "spec" .spec) }}
   rules:
@@ -19,11 +23,18 @@ spec:
           - path: /
             pathType: Prefix
             backend:
+            {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+              service:
+                name: pomerium
+                port:
+                  number: 80
+            {{ else }}
               service:
                 name: alertmanager-main
                 port:
                   name: web
-{{- template "ingressTls" (dict "module" "monitoring" "package" "alertmanager" "prefix" "alertmanager.internal." "spec" .spec) }}
+            {{ end }}
+{{- template "ingressTls" (dict "module" "monitoring" "package" "alertmanager" "prefix" "alertmanager." "spec" .spec) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -35,21 +46,32 @@ metadata:
     {{ if not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
   name: grafana
+  {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+  namespace: pomerium
+  {{ else }}
   namespace: monitoring
+  {{ end }}
 spec:
   ingressClassName: {{ template "ingressClass" (dict "module" "monitoring" "package" "grafana" "type" "internal" "spec" .spec) }}
   rules:
-    - host: {{ template "ingressHost" (dict "module" "monitoring" "package" "grafana" "prefix" "grafana.internal." "spec" .spec) }}
+    - host: {{ template "grafanaUrl" .spec }}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
+            {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+              service:
+                name: pomerium
+                port:
+                  number: 80
+            {{ else }}
               service:
                 name: grafana
                 port:
                   name: http
-{{- template "ingressTls" (dict "module" "monitoring" "package" "grafana" "prefix" "grafana.internal." "spec" .spec) }}
+            {{ end }}
+{{- template "ingressTls" (dict "module" "monitoring" "package" "grafana" "prefix" "grafana." "spec" .spec) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -61,7 +83,11 @@ metadata:
     {{ if not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
   name: prometheus
+  {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+  namespace: pomerium
+  {{ else }}
   namespace: monitoring
+  {{ end }}
 spec:
   ingressClassName: {{ template "ingressClass" (dict "module" "monitoring" "package" "prometheus" "type" "internal" "spec" .spec) }}
   rules:
@@ -71,8 +97,15 @@ spec:
           - path: /
             pathType: Prefix
             backend:
+            {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+              service:
+                name: pomerium
+                port:
+                  number: 80
+            {{ else }}
               service:
                 name: prometheus-k8s
                 port:
                   name: web
-{{- template "ingressTls" (dict "module" "monitoring" "package" "prometheus" "prefix" "prometheus.internal." "spec" .spec) }}
+            {{ end }}
+{{- template "ingressTls" (dict "module" "monitoring" "package" "prometheus" "prefix" "prometheus." "spec" .spec) }}

--- a/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
@@ -9,7 +9,7 @@ metadata:
     {{ if not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
   name: alertmanager
-  {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+  {{ if and (not .spec.distribution.modules.monitoring.overrides.ingresses.alertmanager.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
   namespace: pomerium
   {{ else }}
   namespace: monitoring
@@ -23,7 +23,7 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-            {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+            {{ if and (not .spec.distribution.modules.monitoring.overrides.ingresses.alertmanager.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
               service:
                 name: pomerium
                 port:
@@ -46,7 +46,7 @@ metadata:
     {{ if not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
   name: grafana
-  {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+  {{ if and (not .spec.distribution.modules.monitoring.overrides.ingresses.grafana.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
   namespace: pomerium
   {{ else }}
   namespace: monitoring
@@ -60,7 +60,7 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-            {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+            {{ if and (not .spec.distribution.modules.monitoring.overrides.ingresses.grafana.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
               service:
                 name: pomerium
                 port:
@@ -83,7 +83,7 @@ metadata:
     {{ if not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
   name: prometheus
-  {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+  {{ if and (not .spec.distribution.modules.monitoring.overrides.ingresses.prometheus.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
   namespace: pomerium
   {{ else }}
   namespace: monitoring
@@ -97,7 +97,7 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-            {{ if and (not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+            {{ if and (not .spec.distribution.modules.monitoring.overrides.ingresses.prometheus.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
               service:
                 name: pomerium
                 port:


### PR DESCRIPTION
This pr addresses #42 and #41 

The notable changes are : 
- now pomerium is ingressClass external in the case of dual ingresses
- all the other ingresses are create in the pomerium namespace if auth is sso, and the target service is always pomerium
- the policy field under pomerium configuration, is only "additional" from the infra ingresses
- a new `baseDomain` field is added to the auth module, to manage the SSO auth urls in a different way from the other ingresses

This PR needs to be reviewed after #38 