### PR TITLE
chore: added comment to cidr_blocks to only support 1 at the moment

### DIFF
--- a/kfd.yaml
+++ b/kfd.yaml
@@ -7,7 +7,7 @@ modules:
   auth: v0.0.2
   aws: v2.1.0
   dr: v1.10.1
-  ingress: 75e921ea35029350020714c1169c1dd554802608 # feat/change-behaviour-on-externaldns-module
+  ingress: feat/change-behaviour-on-externaldns-module
   logging: v3.0.1
   monitoring: v2.0.0
   opa: v1.7.3

--- a/pkg/schema/ekscluster_kfd_v1alpha2.go
+++ b/pkg/schema/ekscluster_kfd_v1alpha2.go
@@ -959,6 +959,9 @@ func (j *SpecKubernetesNodePoolAdditionalFirewallRule) UnmarshalJSON(b []byte) e
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
+	if len(plain.CidrBlocks) < 1 {
+		return fmt.Errorf("field %s length: must be >= %d", "cidrBlocks", 1)
+	}
 	*j = SpecKubernetesNodePoolAdditionalFirewallRule(plain)
 	return nil
 }

--- a/schemas/ekscluster-kfd-v1alpha2.json
+++ b/schemas/ekscluster-kfd-v1alpha2.json
@@ -515,7 +515,8 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/$defs/Types.Cidr"
-                    }
+                    },
+                    "minItems": 1
                 },
                 "protocol": {
                     "$ref": "#/$defs/Types.AwsIpProtocol"

--- a/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
@@ -118,7 +118,7 @@ spec:
         #  - name: traffic_80_from_172_31_0_0_16
         #    # The type of the rule, can be ingress or egress
         #    type: ingress
-        #    # The CIDR blocks 
+        #    # The CIDR blocks, at the moment only one is supported, others will be ignored
         #    cidrBlocks:
         #      - 172.31.0.0/16
         #    # The protocol

--- a/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
@@ -118,7 +118,7 @@ spec:
         #  - name: traffic_80_from_172_31_0_0_16
         #    # The type of the rule, can be ingress or egress
         #    type: ingress
-        #    # The CIDR blocks, at the moment only one is supported, others will be ignored
+        #    # The CIDR blocks for the FW rule. At the moment the first item of the list will be used, others will be ignored. See https://github.com/sighupio/fury-eks-installer/issues/46
         #    cidrBlocks:
         #      - 172.31.0.0/16
         #    # The protocol


### PR DESCRIPTION
Changelist:

- improved comment on additionalFirewallrules.cidrBlocks about current support to only one rule
- improved schema, now cidrBlocks needs to have at least one element