### PR TITLE
feat: bump logging to v3.1.2

### DIFF
--- a/Furyfile.yml
+++ b/Furyfile.yml
@@ -5,7 +5,7 @@
 versions:
   networking: v1.12.1
   monitoring: v2.1.0-rc10
-  logging: v3.1.1
+  logging: v3.1.2
   ingress: v1.14.1
   dr: v1.11.0
   opa: v1.8.0

--- a/docs/releases/v1.25.0.md
+++ b/docs/releases/v1.25.0.md
@@ -24,7 +24,7 @@ This release adds a bunch of new features and improvements to the core modules, 
   - Updated prometheus-operated from `2.36.1` to `2.41.1`.
   - Updated thanos from `0.24.0` to `0.30.2`.
   - Updated x509-exporter from `3.2.0` to `3.6.0`.
-- [logging](https://github.com/sighupio/fury-kubernetes-logging) 📦 core module: v3.0.1 -> [**v3.1.1**](https://github.com/sighupio/fury-kubernetes-logging/releases/tag/v3.1.1)
+- [logging](https://github.com/sighupio/fury-kubernetes-logging) 📦 core module: v3.0.1 -> [**v3.1.2**](https://github.com/sighupio/fury-kubernetes-logging/releases/tag/v3.1.2)
   - Replaced technical preview loki-single package with production grade loki-dstributed package. loki version `2.7.3`.
   - Updated opensearch from `2.0.0` to `2.5.0`.
   - Updated opensearch-dashboards from `2.0.0` to `2.5.0`.

--- a/docs/upgrades/v1.24.0-to-v1.25.0.md
+++ b/docs/upgrades/v1.24.0-to-v1.25.0.md
@@ -87,7 +87,7 @@ To upgrade the Logging module to the new version, update the version on the `Fur
 ```yaml
 versions:
 ...
-  logging: v3.1.1
+  logging: v3.1.2
 ...
 ```
 
@@ -110,7 +110,6 @@ Apply your Kustomize project that uses Logging module packages as bases with:
 ```bash
 kustomize build <your-project-path> | kubectl apply -f - --server-side --force-conflicts
 ```
-
 
 #### Ingress module upgrade
 
@@ -213,7 +212,6 @@ You can try to deploy a pod that is not compliant with the rules deployed in the
 #### Auth module upgrade
 
 To upgrade the Auth module to the new version, update the version on the `Furyfile.yml` file to the new version:
-
 
 If you were using these components, adjust your Kustomize project to use the new `auth` module as a base:
 

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -14,6 +14,7 @@ resources:
   # OPA
   - ./vendor/katalog/opa/gatekeeper/core
   - ./vendor/katalog/opa/gatekeeper/rules/templates
+  - ./vendor/katalog/opa/gatekeeper/rules/config
   - ./vendor/katalog/opa/gatekeeper/gpm
   # Monitoring
   - ./vendor/katalog/monitoring/prometheus-operator


### PR DESCRIPTION
This PR:

- Bumps Logging to 3.1.2 that includes a patch to the included Grafana dashboard for the logging stack.

- Adds the `config` base to the sample kustomization.yaml in the OPA section (needed for basic configuration)

 - Minor linting to some files.

Creating as draft while we wait for logging e2e tests