### PR TITLE
docs(release-1.25): remove "new auth module" announcement

### DIFF
--- a/docs/releases/v1.25.0.md
+++ b/docs/releases/v1.25.0.md
@@ -2,9 +2,9 @@
 
 Welcome to KFD release `v1.25.0`.
 
-The distribution is maintained with ❤️ by the team [SIGHUP](https://sighup.io/), and is battle tested in production environments.
+The distribution is maintained with ❤️ by the team [SIGHUP](https://sighup.io/) it is battle tested in production environments.
 
-This release adds a bunch of new features and improvements to the core modules, adds a new core module `auth` and some package replacement/removals.
+This release adds a bunch of new features and improvements to the core modules and some package replacement/removals.
 
 ## New Features since `v1.24.0`
 


### PR DESCRIPTION
Auth module was introduced in KFD 1.24.0

notice that I've already edited the release in GitHub with this change