### PR TITLE
docs: remove force conflicts from v1.24.0-to-v1.25.0.md

### DIFF
--- a/docs/upgrades/v1.24.0-to-v1.25.0.md
+++ b/docs/upgrades/v1.24.0-to-v1.25.0.md
@@ -46,7 +46,7 @@ Apply your Kustomize project that uses Networking module packages as bases with:
 > The same applies to the rest of the modules, we will not include this warning in every step for simplicity.
 
 ```bash
-kustomize build <your-project-path/monitoring-base> | kubectl apply -f - --server-side --force-conflicts
+kustomize build <your-project-path/monitoring-base> | kubectl apply -f - --server-side
 ```
 
 Wait until all Calico pods are restarted and running. You can check Calico's Grafana dashboard "General / Felix Dashboard (Calico)" and the "Networking / *" dashboards to make sure everything is working as expected.
@@ -307,7 +307,7 @@ You will have to:
 Apply your Kustomize project that uses Auth module packages as bases with:
 
 ```bash
-kustomize build <your-project-path> | kubectl apply -f - --server-side --force-conflicts
+kustomize build <your-project-path> | kubectl apply -f - --server-side
 ```
 
 🎉 **CONGRATULATIONS** you have now successfully updated all the core modules to KFD 1.25.0


### PR DESCRIPTION
remove `--force-conflicts` flag from the upgrade guide instructions. This is not needed anymore.

The `--force-conflicts` flag was needed while migrating from client-side apply to server-side.