### PR TITLE
feat: update single nginx svc to use ALB controller and proxy protocol

### DIFF
--- a/templates/distribution/manifests/ingress/patches/ingress-nginx.yml.tpl
+++ b/templates/distribution/manifests/ingress/patches/ingress-nginx.yml.tpl
@@ -8,9 +8,21 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    service.beta.kubernetes.io/aws-load-balancer-type: "external"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
   name: ingress-nginx
   namespace: ingress-nginx
 spec:
   type: LoadBalancer
+  externalTrafficPolicy: Cluster
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-configuration
+  namespace: ingress-nginx
+data:
+  use-proxy-protocol: "true"
 {{- end }}


### PR DESCRIPTION
We are using the new configuration on dual nginx, but is missing on single flavour, adding it now