### PR TITLE
feature/upgrade terraform to 1.x

### DIFF
--- a/kfd.yaml
+++ b/kfd.yaml
@@ -5,8 +5,8 @@
 version: v1.25.2
 modules:
   auth: v0.0.3
-  aws: v2.2.0
-  dr: v1.11.0
+  aws: feat/product-management/39-upgrade-terraform-to-1.4
+  dr: feat/product-management/39-upgrade-terraform-to-1.4
   ingress: v1.14.1
   logging: v3.1.3
   monitoring: v2.1.0
@@ -15,7 +15,7 @@ modules:
 kubernetes:
   eks:
     version: 1.25
-    installer: v2.0.0-alpha.1
+    installer: develop
 furyctlSchemas:
   eks:
     - apiVersion: kfd.sighup.io/v1alpha2
@@ -37,19 +37,19 @@ tools:
         linux/amd64: 80e70448455f3d19c3cb49bd6ff6fc913677f4f240d368fa2b9f0d400c8cd16e
         linux/arm64: 28cf5f666cb0c11a8a2b3e5ae4bf93e56b74ab6051720c72bb231887bfc1a7c6
     kustomize:
-      version: 3.5.3
+      version: 3.10.0
       checksums:
-        darwin/amd64: cd820a4918a0674bfe34990d44673e7522588bfb277bd0848f27bcf11b795b6b
+        darwin/amd64: 7a4508c63e3cf1b34af960b08db55ab89e78376d943e285191efb813970fa51f
         darwin/arm64: ""
-        linux/amd64: dc17dfbae6e14f2dd03e664702b5bcfd9cfcfc435fe1a35f3e8efc9a6cee0d42
-        linux/arm64: ""
+        linux/amd64: 5fe65421c415333489f09bc9b60537f107793d2c901deedd6a679b2cbd9bbd02
+        linux/arm64: a3e3b022c7f009a907e241bb8702681f50e4b4d0ba415e6109b42816cd241de0
     terraform:
-      version: 0.15.4
+      version: 1.4.6
       checksums:
-        darwin/amd64: 069362d5d4084c03329621ec3bd5f2a336ba32a31ef4fcbef8d5bad050c599ea
-        darwin/arm64: ""
-        linux/amd64: 278a0f66c7404ceb426e6f2db7f0f3a1b5b3d8373e7024640e7bc238389bab74
-        linux/arm64: e80a745a56e0e803c757b2d56c9d6aaf673adbc72a69858a9da064edb776551c
+        darwin/amd64: 5f2dd67d0b81819f07a4154803bfa3dffa8daf52ae0b16fa5950285d45562c5f
+        darwin/arm64: 590fb5a60f122b4dd4aebbcd8cac11dc45ccaa6fc4ea0db071990ba34ebb4be4
+        linux/amd64: 84f8bd27772df3d7b12059c00aad35695f29a1bd40f6610a0c54003f7d93f18d
+        linux/arm64: a4a478890ce0ca4764463f0488999b085398dba0d88fd7760bbfcee4eeb1c84b
   eks:
     awscli:
       version: 2.8.12

--- a/kfd.yaml
+++ b/kfd.yaml
@@ -5,8 +5,8 @@
 version: v1.25.2
 modules:
   auth: v0.0.3
-  aws: feat/product-management/39-upgrade-terraform-to-1.4
-  dr: feat/product-management/39-upgrade-terraform-to-1.4
+  aws: main
+  dr: main
   ingress: v1.14.1
   logging: v3.1.3
   monitoring: v2.1.0


### PR DESCRIPTION
- chore: update kfd yaml
- update aws and dr modules versions in kfd yaml to point at terraform-1-compatible versions
