### PR TITLE
add policy module migrations when disabled

### DIFF
--- a/rules/ekscluster-kfd-v1alpha2.yaml
+++ b/rules/ekscluster-kfd-v1alpha2.yaml
@@ -19,6 +19,13 @@ distribution:
   - path: .spec.distribution.modules.policy.type
     immutable: false
     description: "changes to the policy module type have been detected. This will cause a deletion of the current policy stack."
+    unsupported:
+      - to: gatekeeper
+        from: kyverno
+        reason: "currently, switching from gatekeeper to kyverno is not supported."
+      - to: kyverno
+        from: gatekeeper
+        reason: "currently, switching from kyverno to gatekeeper is not supported."
     reducers:
       - key: distributionModulesPolicyType
         lifecycle: pre-apply

--- a/rules/ekscluster-kfd-v1alpha2.yaml
+++ b/rules/ekscluster-kfd-v1alpha2.yaml
@@ -16,3 +16,9 @@ distribution:
     reducers:
       - key: distributionModulesLoggingType
         lifecycle: pre-apply
+  - path: .spec.distribution.modules.policy.type
+    immutable: false
+    description: "changes to the policy module type have been detected. This will cause a deletion of the current policy stack."
+    reducers:
+      - key: distributionModulesPolicyType
+        lifecycle: pre-apply

--- a/rules/kfddistribution-kfd-v1alpha2.yaml
+++ b/rules/kfddistribution-kfd-v1alpha2.yaml
@@ -19,6 +19,13 @@ distribution:
   - path: .spec.distribution.modules.policy.type
     immutable: false
     description: "changes to the policy module type have been detected. This will cause a deletion of the current policy stack."
+    unsupported:
+      - to: gatekeeper
+        from: kyverno
+        reason: "currently, switching from gatekeeper to kyverno is not supported."
+      - to: kyverno
+        from: gatekeeper
+        reason: "currently, switching from kyverno to gatekeeper is not supported."
     reducers:
       - key: distributionModulesPolicyType
         lifecycle: pre-apply

--- a/rules/kfddistribution-kfd-v1alpha2.yaml
+++ b/rules/kfddistribution-kfd-v1alpha2.yaml
@@ -16,3 +16,9 @@ distribution:
     reducers:
       - key: distributionModulesLoggingType
         lifecycle: pre-apply
+  - path: .spec.distribution.modules.policy.type
+    immutable: false
+    description: "changes to the policy module type have been detected. This will cause a deletion of the current policy stack."
+    reducers:
+      - key: distributionModulesPolicyType
+        lifecycle: pre-apply

--- a/rules/onpremises-kfd-v1alpha2.yaml
+++ b/rules/onpremises-kfd-v1alpha2.yaml
@@ -25,3 +25,9 @@ distribution:
     reducers:
       - key: distributionModulesLoggingType
         lifecycle: pre-apply
+  - path: .spec.distribution.modules.policy.type
+    immutable: false
+    description: "changes to the policy module type have been detected. This will cause a deletion of the current policy stack."
+    reducers:
+      - key: distributionModulesPolicyType
+        lifecycle: pre-apply

--- a/rules/onpremises-kfd-v1alpha2.yaml
+++ b/rules/onpremises-kfd-v1alpha2.yaml
@@ -28,6 +28,13 @@ distribution:
   - path: .spec.distribution.modules.policy.type
     immutable: false
     description: "changes to the policy module type have been detected. This will cause a deletion of the current policy stack."
+    unsupported:
+      - to: gatekeeper
+        from: kyverno
+        reason: "currently, switching from gatekeeper to kyverno is not supported."
+      - to: kyverno
+        from: gatekeeper
+        reason: "currently, switching from kyverno to gatekeeper is not supported."
     reducers:
       - key: distributionModulesPolicyType
         lifecycle: pre-apply

--- a/templates/distribution/scripts/pre-apply.sh.tpl
+++ b/templates/distribution/scripts/pre-apply.sh.tpl
@@ -50,4 +50,37 @@ deleteLoki
 
 {{- end }} # end distributionModulesLoggingType
 
+{{- if index .reducers "distributionModulesPolicyType" }}
+
+deleteGatekeeper() {
+
+  $kubectlbin delete --ignore-not-found --wait --timeout=180s ingress -n gatekeeper-system gpm
+  $kubectlbin delete --ignore-not-found --wait --timeout=180s ingress -n pomerium gpm
+  $kustomizebin build $vendorPath/modules/opa/katalog/gatekeeper | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  echo "Gatekeeper resources deleted"
+}
+
+deleteKyverno() {
+  $kustomizebin build $vendorPath/modules/opa/katalog/kyverno | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  echo "Kyverno resources deleted"
+}
+
+{{- if eq .reducers.distributionModulesPolicyType.to "none" }}
+
+{{- if eq .reducers.distributionModulesPolicyType.from "kyverno" }}
+deleteKyverno
+{{- end }}
+
+{{- end }}
+
+{{- if eq .reducers.distributionModulesPolicyType.to "none" }}
+
+{{- if eq .reducers.distributionModulesPolicyType.from "gatekeeper" }}
+deleteGatekeeper
+{{- end }}
+
+{{- end }}
+
+{{- end }} # end distributionModulesPolicyType
+
 {{- end }} # end reducers


### PR DESCRIPTION
When we change the parameter on modules.policy.type from one value to another:

- kyverno to none
- gatekeeper to none
- gatekeeper to kyverno not supported
- kyverno to gatekeeper not supported
