### PR TITLE
feat: default policies migration

### DIFF
--- a/rules/ekscluster-kfd-v1alpha2.yaml
+++ b/rules/ekscluster-kfd-v1alpha2.yaml
@@ -3,10 +3,9 @@
 # license that can be found in the LICENSE file.
 
 ---
-
 infrastructure: []
 kubernetes: []
-distribution: 
+distribution:
   - path: .spec.distribution.modules.logging.type
     immutable: false
     description: "changes to the logging module type have been detected. This will cause the reconfiguration or deletion of the current logging stack."
@@ -28,6 +27,18 @@ distribution:
         reason: "currently, switching from gatekeeper to kyverno is not supported. You need to first remove the current stack with type: none."
     reducers:
       - key: distributionModulesPolicyType
+        lifecycle: pre-apply
+  - path: .spec.distribution.modules.policy.gatekeeper.installDefaultPolicies
+    immutable: false
+    description: "changes to Gatekeeper default policies option in the policy module have been detected. This will cause the installation or deletion of the default policies."
+    reducers:
+      - key: distributionModulesPolicyGatekeeperInstallDefaultPolicies
+        lifecycle: pre-apply
+  - path: .spec.distribution.modules.policy.kyverno.installDefaultPolicies
+    immutable: false
+    description: "changes to Kyverno default policies option in the policy module have been detected. This will cause the installation or deletion of the default policies."
+    reducers:
+      - key: distributionModulesPolicyKyvernoInstallDefaultPolicies
         lifecycle: pre-apply
   - path: .spec.distribution.modules.tracing.type
     immutable: false

--- a/rules/kfddistribution-kfd-v1alpha2.yaml
+++ b/rules/kfddistribution-kfd-v1alpha2.yaml
@@ -3,8 +3,7 @@
 # license that can be found in the LICENSE file.
 
 ---
-
-distribution: 
+distribution:
   - path: .spec.distribution.modules.networking.type
     immutable: true
   - path: .spec.distribution.modules.logging.type
@@ -28,6 +27,18 @@ distribution:
         reason: "currently, switching from gatekeeper to kyverno is not supported. You need to first remove the current stack with type: none."
     reducers:
       - key: distributionModulesPolicyType
+        lifecycle: pre-apply
+  - path: .spec.distribution.modules.policy.gatekeeper.installDefaultPolicies
+    immutable: false
+    description: "changes to Gatekeeper default policies option in the policy module have been detected. This will cause the installation or deletion of the default policies."
+    reducers:
+      - key: distributionModulesPolicyGatekeeperInstallDefaultPolicies
+        lifecycle: pre-apply
+  - path: .spec.distribution.modules.policy.kyverno.installDefaultPolicies
+    immutable: false
+    description: "changes to Kyverno default policies option in the policy module have been detected. This will cause the installation or deletion of the default policies."
+    reducers:
+      - key: distributionModulesPolicyKyvernoInstallDefaultPolicies
         lifecycle: pre-apply
   - path: .spec.distribution.modules.tracing.type
     immutable: false

--- a/rules/onpremises-kfd-v1alpha2.yaml
+++ b/rules/onpremises-kfd-v1alpha2.yaml
@@ -3,8 +3,7 @@
 # license that can be found in the LICENSE file.
 
 ---
-
-kubernetes: 
+kubernetes:
   - path: .spec.kubernetes.dnsZone
     immutable: true
   - path: .spec.kubernetes.controlPlaneAddress
@@ -13,7 +12,7 @@ kubernetes:
     immutable: true
   - path: .spec.kubernetes.svcCidr
     immutable: true
-distribution: 
+distribution:
   - path: .spec.distribution.modules.networking.type
     immutable: true
   - path: .spec.distribution.modules.logging.type
@@ -37,6 +36,18 @@ distribution:
         reason: "currently, switching from gatekeeper to kyverno is not supported. You need to first remove the current stack with type: none."
     reducers:
       - key: distributionModulesPolicyType
+        lifecycle: pre-apply
+  - path: .spec.distribution.modules.policy.gatekeeper.installDefaultPolicies
+    immutable: false
+    description: "changes to Gatekeeper default policies option in the policy module have been detected. This will cause the installation or deletion of the default policies."
+    reducers:
+      - key: distributionModulesPolicyGatekeeperInstallDefaultPolicies
+        lifecycle: pre-apply
+  - path: .spec.distribution.modules.policy.kyverno.installDefaultPolicies
+    immutable: false
+    description: "changes to Kyverno default policies option in the policy module have been detected. This will cause the installation or deletion of the default policies."
+    reducers:
+      - key: distributionModulesPolicyKyvernoInstallDefaultPolicies
         lifecycle: pre-apply
   - path: .spec.distribution.modules.tracing.type
     immutable: false

--- a/templates/distribution/scripts/pre-apply.sh.tpl
+++ b/templates/distribution/scripts/pre-apply.sh.tpl
@@ -95,6 +95,44 @@ deleteGatekeeper
 
 {{- end }} # end distributionModulesPolicyType
 
+{{- if index .reducers "distributionModulesPolicyGatekeeperInstallDefaultPolicies" }}
+
+deleteGatekeeperDefaultPolicies() {
+  $kustomizebin build $vendorPath/modules/opa/katalog/gatekeeper/rules/constraints | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/opa/katalog/gatekeeper/rules/config | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/opa/katalog/gatekeeper/rules/templates | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  echo "Gatekeeper default policies resources deleted"
+}
+
+# from enabled
+{{- if .reducers.distributionModulesPolicyGatekeeperInstallDefaultPolicies.from }}
+# to disabled
+{{- if not .reducers.distributionModulesPolicyGatekeeperInstallDefaultPolicies.to }}
+# changing from true to false -> delete the policies
+deleteGatekeeperDefaultPolicies
+{{- end }}
+{{- end }}
+
+{{- end }} # end distributionModulesPolicyGatekeeperInstallDefaultPolicies
+
+{{- if index .reducers "distributionModulesPolicyKyvernoInstallDefaultPolicies" }}
+
+deleteKyvernoDefaultPolicies() {
+  $kustomizebin build $vendorPath/modules/opa/katalog/kyverno/policies | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  echo "Kyverno default policies resources deleted"
+}
+
+# from enabled
+{{- if .reducers.distributionModulesPolicyKyvernoInstallDefaultPolicies.from }}
+# to disabled
+{{- if not .reducers.distributionModulesPolicyKyvernoInstallDefaultPolicies.to }}
+# changing from true to false -> delete the policies
+deleteKyvernoDefaultPolicies
+{{- end }}
+{{- end }}
+
+{{- end }} # end distributionModulesPolicyKyvernoInstallDefaultPolicies
+
 {{- if index .reducers "distributionModulesTracingType" }}
 
 deleteTempo() {


### PR DESCRIPTION
Handle migrations for changing the installation of default policies in the policy module.

Add migrations for Gatekeeper and Kyverno.

Tested with an on-prem cluster:
- Ran furyctl with Gatekeeper as policy type with the default policies enabled, checked that they were working. Then disabled the default policies, ran furyctl and verified that the Constraints, Constraints Templates and Configs were deleted.
- Disabled Gatekeeper (policy type -> None) ran furyctl, re ran furyctl with Kyverno enabled with the defaults policies set to true. Checked that they were deployed and working. Then disabled the default policies and checked that they were removed from the cluster.

Fixes https://github.com/sighupio/product-management/issues/321

> [!IMPORTANT]
> Depends on https://github.com/sighupio/furyctl/pull/465 because the values to and from are booleans.