### PR TITLE
feat(templates/policy): install Gatekeeper monitoring if needed

### DIFF
--- a/templates/distribution/manifests/opa/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/opa/kustomization.yaml.tpl
@@ -13,7 +13,9 @@ resources:
 {{- if .spec.distribution.modules.policy.gatekeeper.installDefaultPolicies }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/opa/katalog/gatekeeper/rules" }}
 {{- end }}
+{{- if ne .spec.distribution.modules.monitoring.type "none" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/opa/katalog/gatekeeper/monitoring" }}
+{{- end }}
 {{- if ne .spec.distribution.modules.ingress.nginx.type "none" }}
   - resources/ingress-infra.yml
 {{- end }}


### PR DESCRIPTION
Deploy the monitoring options for Gatekeeper only when the monitoring module is enabled. Otherwise the installation may fail because of missing APIs from Prometheus.