### PR TITLE
feat(migrations): support monitoring.type to none

### DIFF
--- a/rules/ekscluster-kfd-v1alpha2.yaml
+++ b/rules/ekscluster-kfd-v1alpha2.yaml
@@ -64,3 +64,16 @@ distribution:
     reducers:
       - key: distributionModulesDRType
         lifecycle: pre-apply
+  - path: .spec.distribution.modules.monitoring.type
+    immutable: false
+    description: "changes to the Monitoring module type have been detected. This will cause the reconfiguration or deletion of the current monitoring stack."
+    reducers:
+      - key: distributionModulesMonitoringType
+        lifecycle: pre-apply
+    unsupported:
+      - from: mimir
+        to: prometheus
+        reason: "switching from Mimir to Prometheus is not currently supported. You need to first remove the current stack with type: none."
+      - from: prometheus
+        to: mimir
+        reason: "switching from Prometheus to Mimir is not currently supported. You need to first remove the current stack with type: none."

--- a/rules/kfddistribution-kfd-v1alpha2.yaml
+++ b/rules/kfddistribution-kfd-v1alpha2.yaml
@@ -70,3 +70,16 @@ distribution:
     reducers:
       - key: distributionModulesDRVeleroBackend
         lifecycle: pre-apply
+  - path: .spec.distribution.modules.monitoring.type
+    immutable: false
+    description: "changes to the Monitoring module type have been detected. This will cause the reconfiguration or deletion of the current monitoring stack."
+    reducers:
+      - key: distributionModulesMonitoringType
+        lifecycle: pre-apply
+    unsupported:
+      - from: mimir
+        to: prometheus
+        reason: "switching from Mimir to Prometheus is not currently supported. You need to first remove the current stack with type: none."
+      - from: prometheus
+        to: mimir
+        reason: "switching from Prometheus to Mimir is not currently supported. You need to first remove the current stack with type: none."

--- a/rules/onpremises-kfd-v1alpha2.yaml
+++ b/rules/onpremises-kfd-v1alpha2.yaml
@@ -79,3 +79,16 @@ distribution:
     reducers:
       - key: distributionModulesDRVeleroBackend
         lifecycle: pre-apply
+  - path: .spec.distribution.modules.monitoring.type
+    immutable: false
+    description: "changes to the Monitoring module type have been detected. This will cause the reconfiguration or deletion of the current monitoring stack."
+    reducers:
+      - key: distributionModulesMonitoringType
+        lifecycle: pre-apply
+    unsupported:
+      - from: mimir
+        to: prometheus
+        reason: "switching from Mimir to Prometheus is not currently supported. You need to first remove the current stack with type: none."
+      - from: prometheus
+        to: mimir
+        reason: "switching from Prometheus to Mimir is not currently supported. You need to first remove the current stack with type: none."

--- a/templates/distribution/scripts/pre-apply.sh.tpl
+++ b/templates/distribution/scripts/pre-apply.sh.tpl
@@ -324,6 +324,79 @@ deleteVeleroMinio
 
 {{- end }} # end distributionModulesDRVeleroBackend
 
+{{- if index .reducers "distributionModulesMonitoringType" }}
+
+
+# ███    ███  ██████  ███    ██ ██ ████████  ██████  ██████  ██ ███    ██  ██████      ████████ ██    ██ ██████  ███████ 
+# ████  ████ ██    ██ ████   ██ ██    ██    ██    ██ ██   ██ ██ ████   ██ ██              ██     ██  ██  ██   ██ ██      
+# ██ ████ ██ ██    ██ ██ ██  ██ ██    ██    ██    ██ ██████  ██ ██ ██  ██ ██   ███        ██      ████   ██████  █████   
+# ██  ██  ██ ██    ██ ██  ██ ██ ██    ██    ██    ██ ██   ██ ██ ██  ██ ██ ██    ██        ██       ██    ██      ██      
+# ██      ██  ██████  ██   ████ ██    ██     ██████  ██   ██ ██ ██   ████  ██████         ██       ██    ██      ███████ 
+
+deleteMonitoringCommon() {
+  # packages that are installed always when monitoring type!=none, so they always
+  # need to be uninstalled.
+  # delete alertmanager first to avoid false positive alerts and notifications.
+  $kustomizebin build $vendorPath/modules/monitoring/katalog/alertmanager-operated | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/monitoring/katalog/blackbox-exporter | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/monitoring/katalog/eks-sm | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/monitoring/katalog/grafana | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/monitoring/katalog/kube-proxy-metrics | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/monitoring/katalog/kube-state-metrics | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/monitoring/katalog/node-exporter | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/monitoring/katalog/x509-exporter | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/monitoring/katalog/prometheus-adapter | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  echo "Monitoring common resources deleted."
+}
+
+deletePrometheusOperator() {
+  $kustomizebin build $vendorPath/modules/monitoring/katalog/prometheus-operator | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  echo "Prometheus Operator resources deleted"
+}
+
+deletePrometheusOperated() {
+  # we first delete the CRs before deleting the CRDs to avoid the `kubectl delete` command from failing due to unexisting APIs.
+  $kustomizebin build $vendorPath/modules/monitoring/katalog/prometheus-operated | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  echo "Waiting 3 minutes for PVCs to liberate"
+  sleep 180
+  $kubectlbin delete -l app.kubernetes.io/name=prometheus,app.kubernetes.io/instance=k8s pvc -n monitoring --wait --timeout=180s
+  echo "Prometheus Operated resources deleted"
+}
+
+deleteMimir() {
+  $kustomizebin build $vendorPath/modules/monitoring/katalog/mimir | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/monitoring/katalog/minio-ha | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  echo "Waiting 3 minutes for PVCs to liberate"
+  sleep 180
+  $kubectlbin delete -l app.kubernetes.io/name=mimir pvc -n monitoring --wait --timeout=180s
+  $kubectlbin delete -l app=minio,release=minio-monitoring pvc -n monitoring --wait --timeout=180s
+  echo "Mimir resources deleted"
+}
+
+{{- if eq .reducers.distributionModulesMonitoringType.from "mimir" }}
+  {{- if eq .reducers.distributionModulesMonitoringType.to "none" }}
+  deleteMonitoringCommon
+  deleteMimir
+  # we delete the operator package last because it includes the CRDs. If we
+  # delete first the CRDs, then the subsequent `kubectl delete` commands will
+  # fail because they'll try to use APIs that don't exist anymore.
+  # prometheus-operator includes also the namespace, so it will be deleted with
+  # all the remaining resources like configmaps and secrets that may remain.
+  deletePrometheusOperator
+  echo "Monitoring module resources deleted"
+  {{- end }}
+{{- end }}
+
+{{- if eq .reducers.distributionModulesMonitoringType.from "prometheus" }}
+  {{- if eq .reducers.distributionModulesMonitoringType.to "none" }}
+  deleteMonitoringCommon
+  deletePrometheusOperated
+  deletePrometheusOperator
+  echo "Monitoring module resources deleted"
+  {{- end }}
+{{- end }}
+
+{{- end }} # end distributionModulesMonitoringType
 
 # ███████ ███    ██ ██████  
 # ██      ████   ██ ██   ██ 

--- a/tests/e2e-kfddistribution-5-migrate-from-mimir-to-none.sh
+++ b/tests/e2e-kfddistribution-5-migrate-from-mimir-to-none.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+@test "Monitoring NS has been deleted" {
+    info
+    test() {
+        kubectl get namespace > check.txt
+        if ! grep -q "monitoring" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}

--- a/tests/e2e-kfddistribution.sh
+++ b/tests/e2e-kfddistribution.sh
@@ -25,3 +25,8 @@ echo "--------------------------------------------------------------------------
 echo "Executing furyctl with the velero migration to none"
 /tmp/furyctl create cluster --config tests/e2e/kfddistribution/furyctl-4-migrate-from-velero-to-none.yaml --outdir "$PWD" -H --distro-location ./ --force
 bats -t tests/e2e-kfddistribution-4-migrate-from-velero-to-none.sh
+
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl with the mimir migration to none"
+/tmp/furyctl create cluster --config tests/e2e/kfddistribution/furyctl-5-migrate-from-mimir-to-none.yaml --outdir "$PWD" -H --distro-location ./ --force
+bats -t tests/e2e-kfddistribution-5-migrate-from-mimir-to-none.sh

--- a/tests/e2e/kfddistribution/furyctl-5-migrate-from-mirmir-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-5-migrate-from-mirmir-to-none.yaml
@@ -1,0 +1,149 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: KFDDistribution
+metadata:
+  name: sighup
+spec:
+  distributionVersion: v1.27.2
+  # This section describes how the KFD distribution will be installed
+  distribution:
+    kubeconfig: "/tmp/kubeconfig"
+    #kubeconfig: "{env://KUBECONFIG}" TODO to be fixed
+    # This common configuration will be applied to all the packages that will be installed in the cluster
+    common: {}
+    # This section contains all the configurations for all the KFD core modules
+    modules:
+      networking:
+        type: calico
+      # This section contains all the configurations for the ingress module
+      ingress:
+        baseDomain: fury.sighup.cc
+        nginx:
+          type: single
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: sighup@sighup.cc
+            type: http01
+      logging:
+        type: loki
+        loki:
+          backend: minio
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+      monitoring:
+        type: none
+        mimir:
+          backend: minio
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: none
+        tempo:
+          backend: minio
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: none
+        kyverno:
+          additionalExcludedNamespaces: ["local-path-storage"]
+          installDefaultPolicies: true
+          validationFailureAction: enforce
+      dr:
+        type: none
+        velero:
+          backend: minio
+      auth:
+        provider:
+          type: none
+    # patches for kind compatibility and resource setting
+    customPatches:
+      patchesStrategicMerge:
+        - |
+          apiVersion: apps/v1
+          kind: StatefulSet
+          metadata:
+            name: minio-logging
+            namespace: logging
+          spec:
+            template:
+              spec:
+                containers:
+                - name: minio
+                  resources:
+                    requests:
+                      cpu: 10m
+                      memory: 50Mi
+        - |
+          apiVersion: apps/v1
+          kind: StatefulSet
+          metadata:
+            name: minio-monitoring
+            namespace: monitoring
+          spec:
+            template:
+              spec:
+                containers:
+                - name: minio
+                  resources:
+                    requests:
+                      cpu: 10m
+                      memory: 50Mi
+        #- |
+        #  apiVersion: apps/v1
+        #  kind: StatefulSet
+        #  metadata:
+        #    name: minio-tracing
+        #    namespace: tracing
+        #  spec:
+        #    template:
+        #      spec:
+        #        containers:
+        #        - name: minio
+        #          resources:
+        #            requests:
+        #              cpu: 10m
+        #              memory: 50Mi
+        - |
+          $patch: delete
+          apiVersion: logging-extensions.banzaicloud.io/v1alpha1
+          kind: HostTailer
+          metadata:
+            name: systemd-common
+            namespace: logging
+        - |
+          $patch: delete
+          apiVersion: logging-extensions.banzaicloud.io/v1alpha1
+          kind: HostTailer
+          metadata:
+            name: systemd-etcd
+            namespace: logging
+        - |
+          $patch: delete
+          apiVersion: apps/v1
+          kind: DaemonSet
+          metadata:
+            name: x509-certificate-exporter-control-plane
+            namespace: monitoring


### PR DESCRIPTION
- Add support for changing the monitoring type from prometheus to none and from mimir to none. This will effectively delete the monitoring stack from the cluster.
- Prometheus to Mimir, and Mimir to Prometheus are not supported.
- Add e2e test for Mimir to None.

scenario tested with an on-prem cluster:
- deployed with `montioring.type = prometheus`, verified monitoring stack working.
- changed to `monitoring.type = none`, verified removal of monitoring stack.
- changed to `monitoring.type = mimir`, verified monitoring stack working.
- changed to `monitoring.type = none`, verified removal of monitoring stack.

Fixes https://github.com/sighupio/product-management/issues/324
