### PR TITLE
chore(templates/on-prem): fix usage of deprecated flag in drain command

### DIFF
--- a/templates/kubernetes/onpremises/56.upgrade-worker-nodes.yml.tpl
+++ b/templates/kubernetes/onpremises/56.upgrade-worker-nodes.yml.tpl
@@ -21,7 +21,7 @@
         node_name: "{{ print "{{ kubernetes_hostname }}" }}"
     - name: Drain node
       delegate_to: localhost
-      shell: "{{ .paths.kubectl }} {{ print "drain --grace-period=60 --timeout=360s --force --ignore-daemonsets --delete-local-data {{ node_name }} --kubeconfig={{ kubernetes_kubeconfig_path }}admin.conf" }}"
+      shell: "{{ .paths.kubectl }} {{ print "drain --grace-period=60 --timeout=360s --force --ignore-daemonsets --delete-emptydir-data {{ node_name }} --kubeconfig={{ kubernetes_kubeconfig_path }}admin.conf" }}"
 
 - name: Kubernetes kubeadm upgrade node
   become: true


### PR DESCRIPTION
stop using the `--delete-local-data` flag for the drain command that has been deprecated in 2020 and use `--delete-emptydir-data` instead.

Ref: https://github.com/kubernetes/kubernetes/pull/95076
