### PR TITLE
feat(templates/monitoring): use kubeadm-sm for on-prem

### DIFF
--- a/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
@@ -9,7 +9,12 @@ kind: Kustomization
 resources:
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/alertmanager-operated" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/blackbox-exporter" }}
+{{- if eq .spec.distribution.common.provider.type "none" }}{{/* none === on-premises */}}
+  - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/kubeadm-sm" }}
+{{- end }}
+{{- if eq .spec.distribution.common.provider.type "eks" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/eks-sm" }}
+{{- end }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/grafana" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/kube-proxy-metrics" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/kube-state-metrics" }}
@@ -22,7 +27,7 @@ resources:
   {{- if eq .spec.distribution.modules.monitoring.type "mimir" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/mimir" }}
     {{- if eq .spec.distribution.modules.monitoring.mimir.backend "minio" }}
-  - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/minio-ha" }}  
+  - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/monitoring/katalog/minio-ha" }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
use kubeadm-sm instead of eks-sm when kind is OnPremises.

Note: we don't access (yet) to the `.kind` key of the configuration file from the templates, so we use `common.provider` instead. This is set to "eks" when the kind is EKSCluster.