### PR TITLE
fix(templates/ingress): always apply nodeSelector and Tolerations for certmanager

### DIFF
--- a/templates/distribution/manifests/ingress/patches/infra-nodes.yml.tpl
+++ b/templates/distribution/manifests/ingress/patches/infra-nodes.yml.tpl
@@ -7,7 +7,6 @@
 {{- $dnsArgs := dict "module" "ingress" "package" "dns"  "spec" .spec -}}
 {{- $forecastleArgs := dict "module" "ingress" "package" "forecastle" "spec" .spec -}}
 
-{{ if eq .spec.distribution.modules.ingress.nginx.tls.provider "certManager" -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -47,7 +46,6 @@ spec:
         {{ template "nodeSelector" $certManagerArgs }}
       tolerations:
         {{ template "tolerations" $certManagerArgs }}
-{{- end }}
 {{- if ne .spec.distribution.modules.ingress.nginx.type "none" }}
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
certmanager is always installed as a dependency of the distribution, so we always apply nodeSelectors and Tolerations to certmanager instead of checking if ingress.tls.type is certmanager.