### PR TITLE
fix(templates/monitoring): add nodeSelectors and Tolerations to mimir

### DIFF
--- a/templates/distribution/manifests/monitoring/patches/infra-nodes.yml.tpl
+++ b/templates/distribution/manifests/monitoring/patches/infra-nodes.yml.tpl
@@ -124,3 +124,138 @@ spec:
         {{ template "nodeSelector" $x509ExporterArgs }}
       tolerations:
         {{ template "tolerations" $x509ExporterArgs }}
+
+{{ if eq .spec.distribution.modules.monitoring.type "mimir" -}}
+{{- $mimirArgs := dict "module" "monitoring" "package" "mimir" "spec" .spec -}}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mimir-distributed-compactor
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      nodeSelector:
+        {{ template "nodeSelector" $mimirArgs }}
+      tolerations:
+        {{ template "tolerations" $mimirArgs }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mimir-distributed-ingester
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      nodeSelector:
+        {{ template "nodeSelector" $mimirArgs }}
+      tolerations:
+        {{ template "tolerations" $mimirArgs }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mimir-distributed-store-gateway
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      nodeSelector:
+        {{ template "nodeSelector" $mimirArgs }}
+      tolerations:
+        {{ template "tolerations" $mimirArgs }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: minio-monitoring
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      nodeSelector:
+        {{ template "nodeSelector" $mimirArgs }}
+      tolerations:
+        {{ template "tolerations" $mimirArgs }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mimir-distributed-continuous-test
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      nodeSelector:
+        {{ template "nodeSelector" $mimirArgs }}
+      tolerations:
+        {{ template "tolerations" $mimirArgs }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mimir-distributed-distributor
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      nodeSelector:
+        {{ template "nodeSelector" $mimirArgs }}
+      tolerations:
+        {{ template "tolerations" $mimirArgs }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mimir-distributed-gateway
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      nodeSelector:
+        {{ template "nodeSelector" $mimirArgs }}
+      tolerations:
+        {{ template "tolerations" $mimirArgs }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mimir-distributed-querier
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      nodeSelector:
+        {{ template "nodeSelector" $mimirArgs }}
+      tolerations:
+        {{ template "tolerations" $mimirArgs }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mimir-distributed-query-frontend
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      nodeSelector:
+        {{ template "nodeSelector" $mimirArgs }}
+      tolerations:
+        {{ template "tolerations" $mimirArgs }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mimir-distributed-query-scheduler
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      nodeSelector:
+        {{ template "nodeSelector" $mimirArgs }}
+      tolerations:
+        {{ template "tolerations" $mimirArgs }}
+---
+{{ end }}


### PR DESCRIPTION
Add missing nodeSelector and Tolerations to mimir, so it is deployed in the desired nodes like the rest of the infra components.