### PR TITLE
fix(template/distribution/monitoring/mimir): set max_global_series_per_user to unlimited

### DIFF
--- a/templates/distribution/manifests/monitoring/patches/mimir.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/patches/mimir.yaml.tpl
@@ -70,6 +70,7 @@ ingester_client:
     max_recv_msg_size: 104857600
     max_send_msg_size: 104857600
 limits:
+  max_global_series_per_user: 0 # we disable the limit on series a user can push because we have only Prometheus pushing with the fury user.
   max_cache_freshness: 10m
   max_query_parallelism: 240
   max_total_query_length: 12000h


### PR DESCRIPTION
Mimir limits by default the amount of time series a user can push to 150000 to protect from a single user DoSing the service.

In our installation, we have just one "fury" user, used by Prometheus to push all the time series to Mimir. So, as a maximum we will push all the time series available in Prometheus, making it a practical limit.

In a "small" KFD installation (without all the modules) we are already very close to or over the default 150000 limit.