### PR TITLE
fix(templates/auth): make websockets work with Pomerium

### DIFF
--- a/templates/distribution/manifests/auth/resources/pomerium-policy.yml.tpl
+++ b/templates/distribution/manifests/auth/resources/pomerium-policy.yml.tpl
@@ -25,6 +25,8 @@ routes:
   - from: https://{{ template "grafanaUrl" .spec }}
     to: http://grafana.monitoring.svc.cluster.local:3000
     allow_websockets: true
+    host_rewrite_header: true
+    preserve_host_header: true
     policy:
       - allow:
           and:
@@ -43,18 +45,24 @@ routes:
             - authenticated_user: true
   - from: https://{{ template "minioLoggingUrl" .spec }}
     to: http://minio-logging-console.logging.svc.cluster.local:9001
+    allow_websockets: true
+    preserve_host_header: true
     policy:
       - allow:
           and:
             - authenticated_user: true
   - from: https://{{ template "minioTracingUrl" .spec }}
     to: http://minio-tracing-console.tracing.svc.cluster.local:9001
+    allow_websockets: true
+    preserve_host_header: true
     policy:
       - allow:
           and:
             - authenticated_user: true
   - from: https://{{ template "minioMonitoringUrl" .spec }}
     to: http://minio-monitoring-console.monitoring.svc.cluster.local:9001
+    allow_websockets: true
+    preserve_host_header: true
     policy:
       - allow:
           and:


### PR DESCRIPTION
Add needed configuration to Pomerium policy so websockets in Grafana and Minio ingresses work.