### PR TITLE
Add Forecastle groups in ingress with SSO enabled

### DIFF
--- a/templates/distribution/manifests/ingress/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/ingress/resources/ingress-infra.yml.tpl
@@ -13,6 +13,9 @@ metadata:
     cluster.kfd.sighup.io/useful-link.name: "Forecastle"
     forecastle.stakater.com/expose: "true"
     forecastle.stakater.com/appName: "Forecastle"
+    {{ if and (not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+    forecastle.stakater.com/group: "ingress-nginx"
+    {{ end }}
     forecastle.stakater.com/icon: "https://raw.githubusercontent.com/stakater/Forecastle/master/assets/web/forecastle-round-100px.png"
     {{ if not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}

--- a/templates/distribution/manifests/logging/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/logging/resources/ingress-infra.yml.tpl
@@ -14,6 +14,9 @@ metadata:
     cluster.kfd.sighup.io/useful-link.name: "Opensearch Dashboards"
     forecastle.stakater.com/expose: "true"
     forecastle.stakater.com/appName: "Opensearch Dashboards"
+    {{ if and (not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+    forecastle.stakater.com/group: "logging"
+    {{ end }}
     forecastle.stakater.com/icon: "https://opensearch.org/assets/brand/PNG/Mark/opensearch_mark_default.png"
     {{ if not .spec.distribution.modules.logging.overrides.ingresses.opensearchDashboards.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
@@ -56,6 +59,9 @@ metadata:
     cluster.kfd.sighup.io/useful-link.name: "MinIO Logging"
     forecastle.stakater.com/expose: "true"
     forecastle.stakater.com/appName: "MinIO Logging"
+    {{ if and (not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+    forecastle.stakater.com/group: "logging"
+    {{ end }}
     forecastle.stakater.com/icon: "https://min.io/resources/img/logo/MINIO_Bird.png"
     {{ if not .spec.distribution.modules.logging.overrides.ingresses.minio.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}

--- a/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
@@ -13,6 +13,9 @@ metadata:
     cluster.kfd.sighup.io/useful-link.name: "Alertmanager"
     forecastle.stakater.com/expose: "true"
     forecastle.stakater.com/appName: "Alertmanager"
+    {{ if and (not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+    forecastle.stakater.com/group: "monitoring"
+    {{ end }}
     forecastle.stakater.com/icon: "https://github.com/stakater/ForecastleIcons/raw/master/alert-manager.png"
     {{ if not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
@@ -54,6 +57,9 @@ metadata:
     cluster.kfd.sighup.io/useful-link.name: "Grafana"
     forecastle.stakater.com/expose: "true"
     forecastle.stakater.com/appName: "Grafana"
+    {{ if and (not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+    forecastle.stakater.com/group: "monitoring"
+    {{ end }}
     forecastle.stakater.com/icon: "https://github.com/stakater/ForecastleIcons/raw/master/grafana.png"
     {{ if not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
@@ -95,6 +101,9 @@ metadata:
     cluster.kfd.sighup.io/useful-link.name: "Prometheus"
     forecastle.stakater.com/expose: "true"
     forecastle.stakater.com/appName: "Prometheus"
+    {{ if and (not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+    forecastle.stakater.com/group: "monitoring"
+    {{ end }}
     forecastle.stakater.com/icon: "https://github.com/stakater/ForecastleIcons/raw/master/prometheus.png"
     {{ if not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
@@ -138,6 +147,9 @@ metadata:
     cluster.kfd.sighup.io/useful-link.name: "MinIO Monitoring"
     forecastle.stakater.com/expose: "true"
     forecastle.stakater.com/appName: "MinIO Monitoring"
+    {{ if and (not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+    forecastle.stakater.com/group: "monitoring"
+    {{ end }}
     forecastle.stakater.com/icon: "https://min.io/resources/img/logo/MINIO_Bird.png"
     {{ if not .spec.distribution.modules.monitoring.overrides.ingresses.minio.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}

--- a/templates/distribution/manifests/opa/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/opa/resources/ingress-infra.yml.tpl
@@ -13,6 +13,9 @@ metadata:
     cluster.kfd.sighup.io/useful-link.name: "Gatekeeper Policy Manager"
     forecastle.stakater.com/expose: "true"
     forecastle.stakater.com/appName: "Gatekeeper Policy Manager"
+    {{ if and (not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+    forecastle.stakater.com/group: "gatekeeper-system"
+    {{ end }}
     forecastle.stakater.com/icon: "https://raw.githubusercontent.com/sighupio/gatekeeper-policy-manager/master/app/static-content/logo.svg"
     {{ if not .spec.distribution.modules.policy.overrides.ingresses.gpm.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}

--- a/templates/distribution/manifests/tracing/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/tracing/resources/ingress-infra.yml.tpl
@@ -13,6 +13,9 @@ metadata:
     cluster.kfd.sighup.io/useful-link.name: "MinIO Tracing"
     forecastle.stakater.com/expose: "true"
     forecastle.stakater.com/appName: "MinIO Tracing"
+    {{ if and (not .spec.distribution.modules.ingress.overrides.ingresses.forecastle.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
+    forecastle.stakater.com/group: "tracing"
+    {{ end }}
     forecastle.stakater.com/icon: "https://min.io/resources/img/logo/MINIO_Bird.png"
     {{ if not .spec.distribution.modules.tracing.overrides.ingresses.minio.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}


### PR DESCRIPTION
Hello guys 👋 
This proposal aims to add the annotation `forecastle.stakater.com/group` to ingresses when we use Pomerium.

In this way we can have a web view similar to this one, even if all ingresses are in the same namespace.
![Screenshot 2024-06-07 at 11 38 19](https://github.com/sighupio/fury-distribution/assets/79833334/7c80bb5e-0cb7-4b69-8cb8-3ced21779c81)

I hope you like it 😄 