### PR TITLE
feature(templates): YAML language server schema autompletion

### DIFF
--- a/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/{{.DistributionVersion}}/schemas/public/ekscluster-kfd-v1alpha2.json
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.

--- a/templates/config/kfddistribution-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/kfddistribution-kfd-v1alpha2.yaml.tpl
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/{{.DistributionVersion}}/schemas/public/kfddistribution-kfd-v1alpha2.json
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.

--- a/templates/config/onpremises-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/onpremises-kfd-v1alpha2.yaml.tpl
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/{{.DistributionVersion}}/schemas/public/onpremises-kfd-v1alpha2.json
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.


### PR DESCRIPTION
add directive to the configuration templates to point the YAML LSP language server to the right schema, so you'll get validation and autocomplete in your editor. At least until we publish the schemas on schema.org.