### PR TITLE
fix(templates/monitoring): don't apply grafana config when type is pr…

### DIFF
--- a/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
@@ -115,10 +115,12 @@ secretGenerator:
       - patches/minio.root.env
   {{- end }}
 {{- end }}
-{{- if eq .spec.distribution.modules.auth.provider.type "sso" }}
+{{- if or (eq $monitoringType "prometheus") (eq $monitoringType "mimir") }}
+  {{- if eq .spec.distribution.modules.auth.provider.type "sso" }}
   - name: grafana-config
     behavior: merge
     namespace: monitoring
     files:
       - grafana.ini=patches/grafana.ini
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
…ometheusAgent

Grafana config secret must only be created when grafana is being installed (monitoring types prometheus and mimir, not when it is none or prometheusAgent)