### PR TITLE
fix(templates): don't filter out scrapeConfigs

### DIFF
--- a/templates/distribution/scripts/apply.sh.tpl
+++ b/templates/distribution/scripts/apply.sh.tpl
@@ -18,7 +18,8 @@ fi
 
 {{- if and (ne .spec.distribution.modules.monitoring.type "prometheusAgent") (not .spec.distribution.modules.monitoring.alertmanager.installDefaultRules) }}
 if $kubectlbin get apiservice v1alpha1.monitoring.coreos.com > /dev/null 2>&1; then
-  cat out.yaml | $yqbin 'select(.apiVersion != "monitoring.coreos.com/v1alpha1" and .kind != "AlertmanagerConfig")' > out-filtered.yaml
+  # filter out the Alertmanger Configuration custom resources from the build.
+  cat out.yaml | $yqbin 'select(.kind != "AlertmanagerConfig")' > out-filtered.yaml
   cp out-filtered.yaml out.yaml
 fi
 {{- end }}


### PR DESCRIPTION
fix an issue in the `yq` filtering command used in the apply script that was excluding scrapeConfigs together with `AlertmanagerConfigs` when `distribution.modules.monitoring.alertmanager.installDefaultRules` was set to `false`.

Now it only filters out `AlertmanagerConfig` resources.

>[!NOTE]
> - For 1.29.3, 1.29.2, 1.28.2, and 1.27.7 this has been patched in furyctl distro-patches.
> - For 1.28.3 and 1.27.8 the fix is already included in the distro release.