### PR TITLE
feat: add support for custom registry

### DIFF
--- a/docs/releases/v1.27.9.md
+++ b/docs/releases/v1.27.9.md
@@ -1,0 +1,45 @@
+# Kubernetes Fury Distribution Release v1.27.9
+
+Welcome to KFD release `v1.27.9`.
+
+The distribution is maintained with ❤️ by the team [SIGHUP](https://sighup.io/) it is battle tested in production environments.
+
+## New Features since `v1.27.8`
+
+### Installer Updates
+
+No changes
+
+### Module updates
+
+No changes
+
+## New features 🌟
+
+- **Configurable distribution registry**: Now the registry used by the distribution can be configured. An example configuration:
+
+  ```yaml
+  ---
+  spec:
+    distribution:
+      common:
+        registry: myregistry.mydomain.ext
+  ```
+
+- **Configurable onpremises registry**: Now the registry used by the onpremises kind can be configured. An example configuration:
+
+  ```yaml
+  ---
+  spec:
+    kubernetes:
+      advanced:
+        registry: myregistry.mydomain.ext
+  ```
+
+## Fixes 🐞
+
+No changes
+
+## Upgrade procedure
+
+Check the [upgrade docs](https://github.com/sighupio/furyctl/tree/main/docs/upgrades/kfd/README.md) for the detailed procedure.

--- a/docs/releases/v1.28.4.md
+++ b/docs/releases/v1.28.4.md
@@ -1,0 +1,45 @@
+# Kubernetes Fury Distribution Release v1.28.4
+
+Welcome to KFD release `v1.28.4`.
+
+The distribution is maintained with ❤️ by the team [SIGHUP](https://sighup.io/) it is battle tested in production environments.
+
+## New Features since `v1.28.3`
+
+### Installer Updates
+
+No changes
+
+### Module updates
+
+No changes
+
+## New features 🌟
+
+- **Configurable distribution registry**: Now the registry used by the distribution can be configured. An example configuration:
+
+  ```yaml
+  ---
+  spec:
+    distribution:
+      common:
+        registry: myregistry.mydomain.ext
+  ```
+
+- **Configurable onpremises registry**: Now the registry used by the onpremises kind can be configured. An example configuration:
+
+  ```yaml
+  ---
+  spec:
+    kubernetes:
+      advanced:
+        registry: myregistry.mydomain.ext
+  ```
+
+## Fixes 🐞
+
+No changes
+
+## Upgrade procedure
+
+Check the [upgrade docs](https://github.com/sighupio/furyctl/tree/main/docs/upgrades/kfd/README.md) for the detailed procedure.

--- a/docs/releases/v1.29.4.md
+++ b/docs/releases/v1.29.4.md
@@ -8,11 +8,36 @@ The distribution is maintained with ❤️ by the team [SIGHUP](https://sighup.i
 
 ### Installer Updates
 
+No changes
+
 ### Module updates
+
+No changes
 
 ## New features 🌟
 
+- **Configurable distribution registry**: Now the registry used by the distribution can be configured. An example configuration:
+  ```yaml
+  ...
+  spec:
+    distribution:
+      common:
+        registry: myregistry.mydomain.ext
+  ...
+  ```
+- **Configurable onpremises registry**: Now the registry used by the onpremises kind can be configured. An example configuration:
+  ```yaml
+  ...
+  spec:
+    kubernetes:
+      advanced:
+        registry: myregistry.mydomain.ext
+  ...
+  ```
+
 ## Fixes 🐞
+
+No changes
 
 ## Upgrade procedure
 

--- a/docs/releases/v1.29.4.md
+++ b/docs/releases/v1.29.4.md
@@ -1,0 +1,19 @@
+# Kubernetes Fury Distribution Release v1.29.4
+
+Welcome to KFD release `v1.29.4`.
+
+The distribution is maintained with ❤️ by the team [SIGHUP](https://sighup.io/) it is battle tested in production environments.
+
+## New Features since `v1.29.3`
+
+### Installer Updates
+
+### Module updates
+
+## New features 🌟
+
+## Fixes 🐞
+
+## Upgrade procedure
+
+Check the [upgrade docs](https://github.com/sighupio/furyctl/tree/main/docs/upgrades/kfd/README.md) for the detailed procedure.

--- a/docs/schemas/ekscluster-kfd-v1alpha2.md
+++ b/docs/schemas/ekscluster-kfd-v1alpha2.md
@@ -86,10 +86,17 @@ A Fury Cluster deployed through AWS's Elastic Kubernetes Service
 
 | Property                                                        | Type     | Required |
 |:----------------------------------------------------------------|:---------|:---------|
+| [customRegistry](#specdistributioncommoncustomregistry)         | `string` | Optional |
 | [nodeSelector](#specdistributioncommonnodeselector)             | `object` | Optional |
 | [provider](#specdistributioncommonprovider)                     | `object` | Optional |
 | [relativeVendorPath](#specdistributioncommonrelativevendorpath) | `string` | Optional |
 | [tolerations](#specdistributioncommontolerations)               | `array`  | Optional |
+
+## .spec.distribution.common.customRegistry
+
+### Description
+
+The custom registry to use for the images
 
 ## .spec.distribution.common.nodeSelector
 

--- a/docs/schemas/ekscluster-kfd-v1alpha2.md
+++ b/docs/schemas/ekscluster-kfd-v1alpha2.md
@@ -86,17 +86,11 @@ A Fury Cluster deployed through AWS's Elastic Kubernetes Service
 
 | Property                                                        | Type     | Required |
 |:----------------------------------------------------------------|:---------|:---------|
-| [customRegistry](#specdistributioncommoncustomregistry)         | `string` | Optional |
 | [nodeSelector](#specdistributioncommonnodeselector)             | `object` | Optional |
 | [provider](#specdistributioncommonprovider)                     | `object` | Optional |
+| [registry](#specdistributioncommonregistry)                     | `string` | Optional |
 | [relativeVendorPath](#specdistributioncommonrelativevendorpath) | `string` | Optional |
 | [tolerations](#specdistributioncommontolerations)               | `array`  | Optional |
-
-## .spec.distribution.common.customRegistry
-
-### Description
-
-The custom registry to use for the images
 
 ## .spec.distribution.common.nodeSelector
 
@@ -117,6 +111,12 @@ The node selector to use to place the pods for all the KFD modules
 ### Description
 
 The type of the provider, must be EKS if specified
+
+## .spec.distribution.common.registry
+
+### Description
+
+URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury).
 
 ## .spec.distribution.common.relativeVendorPath
 

--- a/docs/schemas/ekscluster-kfd-v1alpha2.md
+++ b/docs/schemas/ekscluster-kfd-v1alpha2.md
@@ -118,6 +118,8 @@ The type of the provider, must be EKS if specified
 
 URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury).
 
+NOTE: If plugins are pulling from the default registry, the registry will be replaced for these plugins too.
+
 ## .spec.distribution.common.relativeVendorPath
 
 ### Description

--- a/docs/schemas/kfddistribution-kfd-v1alpha2.md
+++ b/docs/schemas/kfddistribution-kfd-v1alpha2.md
@@ -110,6 +110,8 @@ The type of the provider
 
 URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury).
 
+NOTE: If plugins are pulling from the default registry, the registry will be replaced for the plugin too.
+
 ## .spec.distribution.common.relativeVendorPath
 
 ### Description

--- a/docs/schemas/kfddistribution-kfd-v1alpha2.md
+++ b/docs/schemas/kfddistribution-kfd-v1alpha2.md
@@ -78,10 +78,17 @@ An example file can be found [here](https://github.com/sighupio/fury-distributio
 
 | Property                                                        | Type     | Required |
 |:----------------------------------------------------------------|:---------|:---------|
+| [customRegistry](#specdistributioncommoncustomregistry)         | `string` | Optional |
 | [nodeSelector](#specdistributioncommonnodeselector)             | `object` | Optional |
 | [provider](#specdistributioncommonprovider)                     | `object` | Optional |
 | [relativeVendorPath](#specdistributioncommonrelativevendorpath) | `string` | Optional |
 | [tolerations](#specdistributioncommontolerations)               | `array`  | Optional |
+
+## .spec.distribution.common.customRegistry
+
+### Description
+
+The custom registry to use for the images
 
 ## .spec.distribution.common.nodeSelector
 

--- a/docs/schemas/kfddistribution-kfd-v1alpha2.md
+++ b/docs/schemas/kfddistribution-kfd-v1alpha2.md
@@ -78,17 +78,11 @@ An example file can be found [here](https://github.com/sighupio/fury-distributio
 
 | Property                                                        | Type     | Required |
 |:----------------------------------------------------------------|:---------|:---------|
-| [customRegistry](#specdistributioncommoncustomregistry)         | `string` | Optional |
 | [nodeSelector](#specdistributioncommonnodeselector)             | `object` | Optional |
 | [provider](#specdistributioncommonprovider)                     | `object` | Optional |
+| [registry](#specdistributioncommonregistry)                     | `string` | Optional |
 | [relativeVendorPath](#specdistributioncommonrelativevendorpath) | `string` | Optional |
 | [tolerations](#specdistributioncommontolerations)               | `array`  | Optional |
-
-## .spec.distribution.common.customRegistry
-
-### Description
-
-The custom registry to use for the images
 
 ## .spec.distribution.common.nodeSelector
 
@@ -109,6 +103,12 @@ The node selector to use to place the pods for all the KFD modules
 ### Description
 
 The type of the provider
+
+## .spec.distribution.common.registry
+
+### Description
+
+URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury).
 
 ## .spec.distribution.common.relativeVendorPath
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -78,17 +78,11 @@ An example file can be found [here](https://github.com/sighupio/fury-distributio
 
 | Property                                                        | Type     | Required |
 |:----------------------------------------------------------------|:---------|:---------|
-| [customRegistry](#specdistributioncommoncustomregistry)         | `string` | Optional |
 | [nodeSelector](#specdistributioncommonnodeselector)             | `object` | Optional |
 | [provider](#specdistributioncommonprovider)                     | `object` | Optional |
+| [registry](#specdistributioncommonregistry)                     | `string` | Optional |
 | [relativeVendorPath](#specdistributioncommonrelativevendorpath) | `string` | Optional |
 | [tolerations](#specdistributioncommontolerations)               | `array`  | Optional |
-
-## .spec.distribution.common.customRegistry
-
-### Description
-
-The custom registry to use for the images
 
 ## .spec.distribution.common.nodeSelector
 
@@ -109,6 +103,12 @@ The node selector to use to place the pods for all the KFD modules
 ### Description
 
 The type of the provider
+
+## .spec.distribution.common.registry
+
+### Description
+
+URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury).
 
 ## .spec.distribution.common.relativeVendorPath
 
@@ -4087,15 +4087,15 @@ The type of tracing to use, either ***none*** or ***tempo***
 
 ### Properties
 
-| Property                                                | Type     | Required |
-|:--------------------------------------------------------|:---------|:---------|
-| [airGap](#speckubernetesadvancedairgap)                 | `object` | Optional |
-| [cloud](#speckubernetesadvancedcloud)                   | `object` | Optional |
-| [containerd](#speckubernetesadvancedcontainerd)         | `object` | Optional |
-| [customRegistry](#speckubernetesadvancedcustomregistry) | `string` | Optional |
-| [encryption](#speckubernetesadvancedencryption)         | `object` | Optional |
-| [oidc](#speckubernetesadvancedoidc)                     | `object` | Optional |
-| [users](#speckubernetesadvancedusers)                   | `object` | Optional |
+| Property                                        | Type     | Required |
+|:------------------------------------------------|:---------|:---------|
+| [airGap](#speckubernetesadvancedairgap)         | `object` | Optional |
+| [cloud](#speckubernetesadvancedcloud)           | `object` | Optional |
+| [containerd](#speckubernetesadvancedcontainerd) | `object` | Optional |
+| [encryption](#speckubernetesadvancedencryption) | `object` | Optional |
+| [oidc](#speckubernetesadvancedoidc)             | `object` | Optional |
+| [registry](#speckubernetesadvancedregistry)     | `string` | Optional |
+| [users](#speckubernetesadvancedusers)           | `object` | Optional |
 
 ## .spec.kubernetes.advanced.airGap
 
@@ -4275,12 +4275,6 @@ This feature can be used for example to authenticate to a private registry at co
 
 ## .spec.kubernetes.advanced.containerd.registryConfigs.username
 
-## .spec.kubernetes.advanced.customRegistry
-
-### Description
-
-The custom registry to use for the images
-
 ## .spec.kubernetes.advanced.encryption
 
 ### Properties
@@ -4341,6 +4335,12 @@ The issuer url of the oidc provider
 ## .spec.kubernetes.advanced.oidc.username_claim
 
 ## .spec.kubernetes.advanced.oidc.username_prefix
+
+## .spec.kubernetes.advanced.registry
+
+### Description
+
+URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury/on-premises).
 
 ## .spec.kubernetes.advanced.users
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -78,10 +78,17 @@ An example file can be found [here](https://github.com/sighupio/fury-distributio
 
 | Property                                                        | Type     | Required |
 |:----------------------------------------------------------------|:---------|:---------|
+| [customRegistry](#specdistributioncommoncustomregistry)         | `string` | Optional |
 | [nodeSelector](#specdistributioncommonnodeselector)             | `object` | Optional |
 | [provider](#specdistributioncommonprovider)                     | `object` | Optional |
 | [relativeVendorPath](#specdistributioncommonrelativevendorpath) | `string` | Optional |
 | [tolerations](#specdistributioncommontolerations)               | `array`  | Optional |
+
+## .spec.distribution.common.customRegistry
+
+### Description
+
+The custom registry to use for the images
 
 ## .spec.distribution.common.nodeSelector
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -4087,14 +4087,15 @@ The type of tracing to use, either ***none*** or ***tempo***
 
 ### Properties
 
-| Property                                        | Type     | Required |
-|:------------------------------------------------|:---------|:---------|
-| [airGap](#speckubernetesadvancedairgap)         | `object` | Optional |
-| [cloud](#speckubernetesadvancedcloud)           | `object` | Optional |
-| [containerd](#speckubernetesadvancedcontainerd) | `object` | Optional |
-| [encryption](#speckubernetesadvancedencryption) | `object` | Optional |
-| [oidc](#speckubernetesadvancedoidc)             | `object` | Optional |
-| [users](#speckubernetesadvancedusers)           | `object` | Optional |
+| Property                                                | Type     | Required |
+|:--------------------------------------------------------|:---------|:---------|
+| [airGap](#speckubernetesadvancedairgap)                 | `object` | Optional |
+| [cloud](#speckubernetesadvancedcloud)                   | `object` | Optional |
+| [containerd](#speckubernetesadvancedcontainerd)         | `object` | Optional |
+| [customRegistry](#speckubernetesadvancedcustomregistry) | `string` | Optional |
+| [encryption](#speckubernetesadvancedencryption)         | `object` | Optional |
+| [oidc](#speckubernetesadvancedoidc)                     | `object` | Optional |
+| [users](#speckubernetesadvancedusers)                   | `object` | Optional |
 
 ## .spec.kubernetes.advanced.airGap
 
@@ -4273,6 +4274,12 @@ This feature can be used for example to authenticate to a private registry at co
 ## .spec.kubernetes.advanced.containerd.registryConfigs.registry
 
 ## .spec.kubernetes.advanced.containerd.registryConfigs.username
+
+## .spec.kubernetes.advanced.customRegistry
+
+### Description
+
+The custom registry to use for the images
 
 ## .spec.kubernetes.advanced.encryption
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -4340,7 +4340,7 @@ The issuer url of the oidc provider
 
 ### Description
 
-URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury/on-premises).
+URL of the registry where to pull images from for the Kubernetes phase. (Default is registry.sighup.io/fury/on-premises).
 
 ## .spec.kubernetes.advanced.users
 

--- a/pkg/apis/ekscluster/v1alpha2/private/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/private/schema.go
@@ -79,6 +79,9 @@ type SpecDistributionCommon struct {
 
 	// URL of the registry where to pull images from for the Distribution phase.
 	// (Default is registry.sighup.io/fury).
+	//
+	// NOTE: If plugins are pulling from the default registry, the registry will be
+	// replaced for these plugins too.
 	Registry *string `json:"registry,omitempty" yaml:"registry,omitempty" mapstructure:"registry,omitempty"`
 
 	// The relative path to the vendor directory, does not need to be changed

--- a/pkg/apis/ekscluster/v1alpha2/private/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/private/schema.go
@@ -71,14 +71,15 @@ type SpecDistribution struct {
 }
 
 type SpecDistributionCommon struct {
-	// The custom registry to use for the images
-	CustomRegistry *string `json:"customRegistry,omitempty" yaml:"customRegistry,omitempty" mapstructure:"customRegistry,omitempty"`
-
 	// The node selector to use to place the pods for all the KFD modules
 	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
 
 	// Provider corresponds to the JSON schema field "provider".
 	Provider *SpecDistributionCommonProvider `json:"provider,omitempty" yaml:"provider,omitempty" mapstructure:"provider,omitempty"`
+
+	// URL of the registry where to pull images from for the Distribution phase.
+	// (Default is registry.sighup.io/fury).
+	Registry *string `json:"registry,omitempty" yaml:"registry,omitempty" mapstructure:"registry,omitempty"`
 
 	// The relative path to the vendor directory, does not need to be changed
 	RelativeVendorPath *string `json:"relativeVendorPath,omitempty" yaml:"relativeVendorPath,omitempty" mapstructure:"relativeVendorPath,omitempty"`

--- a/pkg/apis/ekscluster/v1alpha2/private/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/private/schema.go
@@ -71,6 +71,9 @@ type SpecDistribution struct {
 }
 
 type SpecDistributionCommon struct {
+	// The custom registry to use for the images
+	CustomRegistry *string `json:"customRegistry,omitempty" yaml:"customRegistry,omitempty" mapstructure:"customRegistry,omitempty"`
+
 	// The node selector to use to place the pods for all the KFD modules
 	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
 

--- a/pkg/apis/ekscluster/v1alpha2/public/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/public/schema.go
@@ -79,6 +79,9 @@ type SpecDistributionCommon struct {
 
 	// URL of the registry where to pull images from for the Distribution phase.
 	// (Default is registry.sighup.io/fury).
+	//
+	// NOTE: If plugins are pulling from the default registry, the registry will be
+	// replaced for these plugins too.
 	Registry *string `json:"registry,omitempty" yaml:"registry,omitempty" mapstructure:"registry,omitempty"`
 
 	// The relative path to the vendor directory, does not need to be changed

--- a/pkg/apis/ekscluster/v1alpha2/public/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/public/schema.go
@@ -71,14 +71,15 @@ type SpecDistribution struct {
 }
 
 type SpecDistributionCommon struct {
-	// The custom registry to use for the images
-	CustomRegistry *string `json:"customRegistry,omitempty" yaml:"customRegistry,omitempty" mapstructure:"customRegistry,omitempty"`
-
 	// The node selector to use to place the pods for all the KFD modules
 	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
 
 	// Provider corresponds to the JSON schema field "provider".
 	Provider *SpecDistributionCommonProvider `json:"provider,omitempty" yaml:"provider,omitempty" mapstructure:"provider,omitempty"`
+
+	// URL of the registry where to pull images from for the Distribution phase.
+	// (Default is registry.sighup.io/fury).
+	Registry *string `json:"registry,omitempty" yaml:"registry,omitempty" mapstructure:"registry,omitempty"`
 
 	// The relative path to the vendor directory, does not need to be changed
 	RelativeVendorPath *string `json:"relativeVendorPath,omitempty" yaml:"relativeVendorPath,omitempty" mapstructure:"relativeVendorPath,omitempty"`

--- a/pkg/apis/ekscluster/v1alpha2/public/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/public/schema.go
@@ -71,6 +71,9 @@ type SpecDistribution struct {
 }
 
 type SpecDistributionCommon struct {
+	// The custom registry to use for the images
+	CustomRegistry *string `json:"customRegistry,omitempty" yaml:"customRegistry,omitempty" mapstructure:"customRegistry,omitempty"`
+
 	// The node selector to use to place the pods for all the KFD modules
 	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
 

--- a/pkg/apis/kfddistribution/v1alpha2/public/schema.go
+++ b/pkg/apis/kfddistribution/v1alpha2/public/schema.go
@@ -65,6 +65,9 @@ type SpecDistributionCommon struct {
 
 	// URL of the registry where to pull images from for the Distribution phase.
 	// (Default is registry.sighup.io/fury).
+	//
+	// NOTE: If plugins are pulling from the default registry, the registry will be
+	// replaced for the plugin too.
 	Registry *string `json:"registry,omitempty" yaml:"registry,omitempty" mapstructure:"registry,omitempty"`
 
 	// The relative path to the vendor directory, does not need to be changed

--- a/pkg/apis/kfddistribution/v1alpha2/public/schema.go
+++ b/pkg/apis/kfddistribution/v1alpha2/public/schema.go
@@ -57,6 +57,9 @@ type SpecDistribution struct {
 }
 
 type SpecDistributionCommon struct {
+	// The custom registry to use for the images
+	CustomRegistry *string `json:"customRegistry,omitempty" yaml:"customRegistry,omitempty" mapstructure:"customRegistry,omitempty"`
+
 	// The node selector to use to place the pods for all the KFD modules
 	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
 

--- a/pkg/apis/kfddistribution/v1alpha2/public/schema.go
+++ b/pkg/apis/kfddistribution/v1alpha2/public/schema.go
@@ -57,14 +57,15 @@ type SpecDistribution struct {
 }
 
 type SpecDistributionCommon struct {
-	// The custom registry to use for the images
-	CustomRegistry *string `json:"customRegistry,omitempty" yaml:"customRegistry,omitempty" mapstructure:"customRegistry,omitempty"`
-
 	// The node selector to use to place the pods for all the KFD modules
 	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
 
 	// Provider corresponds to the JSON schema field "provider".
 	Provider *SpecDistributionCommonProvider `json:"provider,omitempty" yaml:"provider,omitempty" mapstructure:"provider,omitempty"`
+
+	// URL of the registry where to pull images from for the Distribution phase.
+	// (Default is registry.sighup.io/fury).
+	Registry *string `json:"registry,omitempty" yaml:"registry,omitempty" mapstructure:"registry,omitempty"`
 
 	// The relative path to the vendor directory, does not need to be changed
 	RelativeVendorPath *string `json:"relativeVendorPath,omitempty" yaml:"relativeVendorPath,omitempty" mapstructure:"relativeVendorPath,omitempty"`

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -1278,7 +1278,7 @@ type SpecKubernetesAdvanced struct {
 	// Oidc corresponds to the JSON schema field "oidc".
 	Oidc *SpecKubernetesAdvancedOIDC `json:"oidc,omitempty" yaml:"oidc,omitempty" mapstructure:"oidc,omitempty"`
 
-	// URL of the registry where to pull images from for the Distribution phase.
+	// URL of the registry where to pull images from for the Kubernetes phase.
 	// (Default is registry.sighup.io/fury/on-premises).
 	Registry *string `json:"registry,omitempty" yaml:"registry,omitempty" mapstructure:"registry,omitempty"`
 

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -57,6 +57,9 @@ type SpecDistribution struct {
 }
 
 type SpecDistributionCommon struct {
+	// The custom registry to use for the images
+	CustomRegistry *string `json:"customRegistry,omitempty" yaml:"customRegistry,omitempty" mapstructure:"customRegistry,omitempty"`
+
 	// The node selector to use to place the pods for all the KFD modules
 	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
 

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -57,14 +57,15 @@ type SpecDistribution struct {
 }
 
 type SpecDistributionCommon struct {
-	// The custom registry to use for the images
-	CustomRegistry *string `json:"customRegistry,omitempty" yaml:"customRegistry,omitempty" mapstructure:"customRegistry,omitempty"`
-
 	// The node selector to use to place the pods for all the KFD modules
 	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
 
 	// Provider corresponds to the JSON schema field "provider".
 	Provider *SpecDistributionCommonProvider `json:"provider,omitempty" yaml:"provider,omitempty" mapstructure:"provider,omitempty"`
+
+	// URL of the registry where to pull images from for the Distribution phase.
+	// (Default is registry.sighup.io/fury).
+	Registry *string `json:"registry,omitempty" yaml:"registry,omitempty" mapstructure:"registry,omitempty"`
 
 	// The relative path to the vendor directory, does not need to be changed
 	RelativeVendorPath *string `json:"relativeVendorPath,omitempty" yaml:"relativeVendorPath,omitempty" mapstructure:"relativeVendorPath,omitempty"`
@@ -1271,14 +1272,15 @@ type SpecKubernetesAdvanced struct {
 	// Containerd corresponds to the JSON schema field "containerd".
 	Containerd *SpecKubernetesAdvancedContainerd `json:"containerd,omitempty" yaml:"containerd,omitempty" mapstructure:"containerd,omitempty"`
 
-	// The custom registry to use for the images
-	CustomRegistry *string `json:"customRegistry,omitempty" yaml:"customRegistry,omitempty" mapstructure:"customRegistry,omitempty"`
-
 	// Encryption corresponds to the JSON schema field "encryption".
 	Encryption *SpecKubernetesAdvancedEncryption `json:"encryption,omitempty" yaml:"encryption,omitempty" mapstructure:"encryption,omitempty"`
 
 	// Oidc corresponds to the JSON schema field "oidc".
 	Oidc *SpecKubernetesAdvancedOIDC `json:"oidc,omitempty" yaml:"oidc,omitempty" mapstructure:"oidc,omitempty"`
+
+	// URL of the registry where to pull images from for the Distribution phase.
+	// (Default is registry.sighup.io/fury/on-premises).
+	Registry *string `json:"registry,omitempty" yaml:"registry,omitempty" mapstructure:"registry,omitempty"`
 
 	// Users corresponds to the JSON schema field "users".
 	Users *SpecKubernetesAdvancedUsers `json:"users,omitempty" yaml:"users,omitempty" mapstructure:"users,omitempty"`

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -1271,6 +1271,9 @@ type SpecKubernetesAdvanced struct {
 	// Containerd corresponds to the JSON schema field "containerd".
 	Containerd *SpecKubernetesAdvancedContainerd `json:"containerd,omitempty" yaml:"containerd,omitempty" mapstructure:"containerd,omitempty"`
 
+	// The custom registry to use for the images
+	CustomRegistry *string `json:"customRegistry,omitempty" yaml:"customRegistry,omitempty" mapstructure:"customRegistry,omitempty"`
+
 	// Encryption corresponds to the JSON schema field "encryption".
 	Encryption *SpecKubernetesAdvancedEncryption `json:"encryption,omitempty" yaml:"encryption,omitempty" mapstructure:"encryption,omitempty"`
 

--- a/schemas/private/ekscluster-kfd-v1alpha2.json
+++ b/schemas/private/ekscluster-kfd-v1alpha2.json
@@ -208,7 +208,7 @@
         },
         "registry": {
           "type": "string",
-          "description": "URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury)."
+          "description": "URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury).\n\nNOTE: If plugins are pulling from the default registry, the registry will be replaced for these plugins too."
         }
       }
     },

--- a/schemas/private/ekscluster-kfd-v1alpha2.json
+++ b/schemas/private/ekscluster-kfd-v1alpha2.json
@@ -206,9 +206,9 @@
           "type": "string",
           "description": "The relative path to the vendor directory, does not need to be changed"
         },
-        "customRegistry": {
+        "registry": {
           "type": "string",
-          "description": "The custom registry to use for the images"
+          "description": "URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury)."
         }
       }
     },

--- a/schemas/private/ekscluster-kfd-v1alpha2.json
+++ b/schemas/private/ekscluster-kfd-v1alpha2.json
@@ -205,6 +205,10 @@
         "relativeVendorPath": {
           "type": "string",
           "description": "The relative path to the vendor directory, does not need to be changed"
+        },
+        "customRegistry": {
+          "type": "string",
+          "description": "The custom registry to use for the images"
         }
       }
     },

--- a/schemas/public/ekscluster-kfd-v1alpha2.json
+++ b/schemas/public/ekscluster-kfd-v1alpha2.json
@@ -909,7 +909,7 @@
         },
         "registry": {
           "type": "string",
-          "description": "URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury)."
+          "description": "URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury).\n\nNOTE: If plugins are pulling from the default registry, the registry will be replaced for these plugins too."
         }
       }
     },

--- a/schemas/public/ekscluster-kfd-v1alpha2.json
+++ b/schemas/public/ekscluster-kfd-v1alpha2.json
@@ -906,6 +906,10 @@
         "relativeVendorPath": {
           "type": "string",
           "description": "The relative path to the vendor directory, does not need to be changed"
+        },
+        "customRegistry": {
+          "type": "string",
+          "description": "The custom registry to use for the images"
         }
       }
     },

--- a/schemas/public/ekscluster-kfd-v1alpha2.json
+++ b/schemas/public/ekscluster-kfd-v1alpha2.json
@@ -907,9 +907,9 @@
           "type": "string",
           "description": "The relative path to the vendor directory, does not need to be changed"
         },
-        "customRegistry": {
+        "registry": {
           "type": "string",
-          "description": "The custom registry to use for the images"
+          "description": "URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury)."
         }
       }
     },

--- a/schemas/public/kfddistribution-kfd-v1alpha2.json
+++ b/schemas/public/kfddistribution-kfd-v1alpha2.json
@@ -132,9 +132,9 @@
           "type": "string",
           "description": "The relative path to the vendor directory, does not need to be changed"
         },
-        "customRegistry": {
+        "registry": {
           "type": "string",
-          "description": "The custom registry to use for the images"
+          "description": "URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury)."
         }
       }
     },

--- a/schemas/public/kfddistribution-kfd-v1alpha2.json
+++ b/schemas/public/kfddistribution-kfd-v1alpha2.json
@@ -134,7 +134,7 @@
         },
         "registry": {
           "type": "string",
-          "description": "URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury)."
+          "description": "URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury).\n\nNOTE: If plugins are pulling from the default registry, the registry will be replaced for the plugin too."
         }
       }
     },

--- a/schemas/public/kfddistribution-kfd-v1alpha2.json
+++ b/schemas/public/kfddistribution-kfd-v1alpha2.json
@@ -131,6 +131,10 @@
         "relativeVendorPath": {
           "type": "string",
           "description": "The relative path to the vendor directory, does not need to be changed"
+        },
+        "customRegistry": {
+          "type": "string",
+          "description": "The custom registry to use for the images"
         }
       }
     },

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -358,7 +358,7 @@
         },
         "registry": {
           "type": "string",
-          "description": "URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury/on-premises)."
+          "description": "URL of the registry where to pull images from for the Kubernetes phase. (Default is registry.sighup.io/fury/on-premises)."
         }
       }
     },

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -355,6 +355,10 @@
         },
         "airGap": {
           "$ref": "#/$defs/Spec.Kubernetes.Advanced.AirGap"
+        },
+        "customRegistry": {
+          "type": "string",
+          "description": "The custom registry to use for the images"
         }
       }
     },

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -635,6 +635,10 @@
         "relativeVendorPath": {
           "type": "string",
           "description": "The relative path to the vendor directory, does not need to be changed"
+        },
+        "customRegistry": {
+          "type": "string",
+          "description": "The custom registry to use for the images"
         }
       }
     },

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -356,9 +356,9 @@
         "airGap": {
           "$ref": "#/$defs/Spec.Kubernetes.Advanced.AirGap"
         },
-        "customRegistry": {
+        "registry": {
           "type": "string",
-          "description": "The custom registry to use for the images"
+          "description": "URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury/on-premises)."
         }
       }
     },
@@ -640,9 +640,9 @@
           "type": "string",
           "description": "The relative path to the vendor directory, does not need to be changed"
         },
-        "customRegistry": {
+        "registry": {
           "type": "string",
-          "description": "The custom registry to use for the images"
+          "description": "URL of the registry where to pull images from for the Distribution phase. (Default is registry.sighup.io/fury)."
         }
       }
     },

--- a/templates/distribution/scripts/apply.sh.tpl
+++ b/templates/distribution/scripts/apply.sh.tpl
@@ -7,7 +7,17 @@ kubectlbin="{{ .paths.kubectl }}"
 yqbin="{{ .paths.yq }}"
 vendorPath="{{ .paths.vendorPath }}"
 
+if command -v gsed >/dev/null 2>&1; then
+  sedbin="gsed"
+else
+  sedbin="sed"
+fi
+
 $kustomizebin build --load_restrictor LoadRestrictionsNone . > out.yaml
+
+{{- if and (index .spec.distribution.common "customRegistry") (ne .spec.distribution.common.customRegistry "") }}
+$sedbin -i 's#registry.sighup.io/fury#{{.spec.distribution.common.customRegistry}}#g' out.yaml
+{{- end }}
 
 {{- if eq .spec.distribution.modules.monitoring.type "none" }}
 if ! $kubectlbin get apiservice v1.monitoring.coreos.com; then

--- a/templates/distribution/scripts/apply.sh.tpl
+++ b/templates/distribution/scripts/apply.sh.tpl
@@ -7,16 +7,14 @@ kubectlbin="{{ .paths.kubectl }}"
 yqbin="{{ .paths.yq }}"
 vendorPath="{{ .paths.vendorPath }}"
 
-if command -v gsed >/dev/null 2>&1; then
-  sedbin="gsed"
-else
-  sedbin="sed"
-fi
-
 $kustomizebin build --load_restrictor LoadRestrictionsNone . > out.yaml
 
 {{- if and (index .spec.distribution.common "customRegistry") (ne .spec.distribution.common.customRegistry "") }}
-$sedbin -i 's#registry.sighup.io/fury#{{.spec.distribution.common.customRegistry}}#g' out.yaml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i "" 's#registry.sighup.io/fury#{{.spec.distribution.common.customRegistry}}#g' out.yaml
+else
+  sed -i 's#registry.sighup.io/fury#{{.spec.distribution.common.customRegistry}}#g' out.yaml
+fi
 {{- end }}
 
 {{- if eq .spec.distribution.modules.monitoring.type "none" }}

--- a/templates/distribution/scripts/apply.sh.tpl
+++ b/templates/distribution/scripts/apply.sh.tpl
@@ -9,11 +9,11 @@ vendorPath="{{ .paths.vendorPath }}"
 
 $kustomizebin build --load_restrictor LoadRestrictionsNone . > out.yaml
 
-{{- if and (index .spec.distribution.common "customRegistry") (ne .spec.distribution.common.customRegistry "") }}
+{{- if and (index .spec.distribution.common "registry") (ne .spec.distribution.common.registry "") }}
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i "" 's#registry.sighup.io/fury#{{.spec.distribution.common.customRegistry}}#g' out.yaml
+  sed -i "" 's#registry.sighup.io/fury#{{.spec.distribution.common.registry}}#g' out.yaml
 else
-  sed -i 's#registry.sighup.io/fury#{{.spec.distribution.common.customRegistry}}#g' out.yaml
+  sed -i 's#registry.sighup.io/fury#{{.spec.distribution.common.registry}}#g' out.yaml
 fi
 {{- end }}
 

--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -77,6 +77,10 @@ all:
         {{- end }}
 
         {{- end }}
+
+        {{- if and (index .spec.kubernetes.advanced "customRegistry") (ne .spec.kubernetes.advanced.customRegistry "") }}
+        kubernetes_image_registry: "{{ .spec.kubernetes.advanced.customRegistry }}"
+        {{- end }}
     nodes:
       children:
         {{- range $n := .spec.kubernetes.nodes }}

--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -78,8 +78,8 @@ all:
 
         {{- end }}
 
-        {{- if and (index .spec.kubernetes.advanced "customRegistry") (ne .spec.kubernetes.advanced.customRegistry "") }}
-        kubernetes_image_registry: "{{ .spec.kubernetes.advanced.customRegistry }}"
+        {{- if and (index .spec.kubernetes.advanced "registry") (ne .spec.kubernetes.advanced.registry "") }}
+        kubernetes_image_registry: "{{ .spec.kubernetes.advanced.registry }}"
         {{- end }}
     nodes:
       children:


### PR DESCRIPTION
Added an optional parameter to configure the registry.

```yaml
spec:
  distribution:
    common:
      registry: myregistry.mydomain.ext
  ...
  kubernetes:
    advanced:
      registry: myregistry.mydomain.ext
```

Related to https://github.com/sighupio/furyctl/pull/537.