### PR TITLE
[BREAKING] fix(policy/kyverno)!: use `Enforce` and `Audit` instead of all lowercase

### DIFF
--- a/defaults/ekscluster-kfd-v1alpha2.yaml
+++ b/defaults/ekscluster-kfd-v1alpha2.yaml
@@ -229,7 +229,7 @@ data:
       kyverno:
         # this configuration adds namespaces to the excluded list, actually whitelisting them
         additionalExcludedNamespaces: []
-        validationFailureAction: enforce
+        validationFailureAction: Enforce
         installDefaultPolicies: true
     # dr module configuration
     dr:

--- a/defaults/kfddistribution-kfd-v1alpha2.yaml
+++ b/defaults/kfddistribution-kfd-v1alpha2.yaml
@@ -221,7 +221,7 @@ data:
       kyverno:
         # this configuration adds namespaces to the excluded list, actually whitelisting them
         additionalExcludedNamespaces: []
-        validationFailureAction: enforce
+        validationFailureAction: Enforce
         installDefaultPolicies: true
     # dr module configuration
     dr:

--- a/defaults/onpremises-kfd-v1alpha2.yaml
+++ b/defaults/onpremises-kfd-v1alpha2.yaml
@@ -221,7 +221,7 @@ data:
       kyverno:
         # this configuration adds namespaces to the excluded list, actually whitelisting them
         additionalExcludedNamespaces: []
-        validationFailureAction: enforce
+        validationFailureAction: Enforce
         installDefaultPolicies: true
     # dr module configuration
     dr:

--- a/docs/schemas/ekscluster-kfd-v1alpha2.md
+++ b/docs/schemas/ekscluster-kfd-v1alpha2.md
@@ -4018,8 +4018,8 @@ The validation failure action to use for the kyverno module
 
 | Value     |
 |:----------|
-|`"audit"`  |
-|`"enforce"`|
+|`"Audit"`  |
+|`"Enforce"`|
 
 ## .spec.distribution.modules.policy.overrides
 

--- a/docs/schemas/kfddistribution-kfd-v1alpha2.md
+++ b/docs/schemas/kfddistribution-kfd-v1alpha2.md
@@ -3603,8 +3603,8 @@ The validation failure action to use for the kyverno module
 
 | Value     |
 |:----------|
-|`"audit"`  |
-|`"enforce"`|
+|`"Audit"`  |
+|`"Enforce"`|
 
 ## .spec.distribution.modules.policy.overrides
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -3880,7 +3880,7 @@ The value of the toleration
 
 ### Description
 
-The validation failure action to use for the policies, `enforce` will block when a request does not comply with the policies and `audit` will not block but log when a request does not comply with the policies.
+The validation failure action to use for the policies, `Enforce` will block when a request does not comply with the policies and `Audit` will not block but log when a request does not comply with the policies.
 
 ### Constraints
 
@@ -3888,8 +3888,8 @@ The validation failure action to use for the policies, `enforce` will block when
 
 | Value     |
 |:----------|
-|`"audit"`  |
-|`"enforce"`|
+|`"Audit"`  |
+|`"Enforce"`|
 
 ## .spec.distribution.modules.policy.overrides
 

--- a/pkg/apis/ekscluster/v1alpha2/private/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/private/schema.go
@@ -1222,8 +1222,8 @@ type SpecDistributionModulesPolicyKyverno struct {
 type SpecDistributionModulesPolicyKyvernoValidationFailureAction string
 
 const (
-	SpecDistributionModulesPolicyKyvernoValidationFailureActionAudit   SpecDistributionModulesPolicyKyvernoValidationFailureAction = "audit"
-	SpecDistributionModulesPolicyKyvernoValidationFailureActionEnforce SpecDistributionModulesPolicyKyvernoValidationFailureAction = "enforce"
+	SpecDistributionModulesPolicyKyvernoValidationFailureActionAudit   SpecDistributionModulesPolicyKyvernoValidationFailureAction = "Audit"
+	SpecDistributionModulesPolicyKyvernoValidationFailureActionEnforce SpecDistributionModulesPolicyKyvernoValidationFailureAction = "Enforce"
 )
 
 type SpecDistributionModulesPolicyType string
@@ -2100,8 +2100,8 @@ var enumValues_SpecDistributionModulesPolicyGatekeeperEnforcementAction = []inte
 }
 
 var enumValues_SpecDistributionModulesPolicyKyvernoValidationFailureAction = []interface{}{
-	"audit",
-	"enforce",
+	"Audit",
+	"Enforce",
 }
 
 var enumValues_SpecDistributionModulesPolicyType = []interface{}{

--- a/pkg/apis/ekscluster/v1alpha2/public/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/public/schema.go
@@ -1175,8 +1175,8 @@ type SpecDistributionModulesPolicyKyverno struct {
 type SpecDistributionModulesPolicyKyvernoValidationFailureAction string
 
 const (
-	SpecDistributionModulesPolicyKyvernoValidationFailureActionAudit   SpecDistributionModulesPolicyKyvernoValidationFailureAction = "audit"
-	SpecDistributionModulesPolicyKyvernoValidationFailureActionEnforce SpecDistributionModulesPolicyKyvernoValidationFailureAction = "enforce"
+	SpecDistributionModulesPolicyKyvernoValidationFailureActionAudit   SpecDistributionModulesPolicyKyvernoValidationFailureAction = "Audit"
+	SpecDistributionModulesPolicyKyvernoValidationFailureActionEnforce SpecDistributionModulesPolicyKyvernoValidationFailureAction = "Enforce"
 )
 
 type SpecDistributionModulesPolicyType string
@@ -2843,8 +2843,8 @@ func (j *SpecDistributionModulesPolicyKyvernoValidationFailureAction) UnmarshalJ
 }
 
 var enumValues_SpecDistributionModulesPolicyKyvernoValidationFailureAction = []interface{}{
-	"audit",
-	"enforce",
+	"Audit",
+	"Enforce",
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/pkg/apis/kfddistribution/v1alpha2/public/schema.go
+++ b/pkg/apis/kfddistribution/v1alpha2/public/schema.go
@@ -1133,8 +1133,8 @@ type SpecDistributionModulesPolicyKyverno struct {
 type SpecDistributionModulesPolicyKyvernoValidationFailureAction string
 
 const (
-	SpecDistributionModulesPolicyKyvernoValidationFailureActionAudit   SpecDistributionModulesPolicyKyvernoValidationFailureAction = "audit"
-	SpecDistributionModulesPolicyKyvernoValidationFailureActionEnforce SpecDistributionModulesPolicyKyvernoValidationFailureAction = "enforce"
+	SpecDistributionModulesPolicyKyvernoValidationFailureActionAudit   SpecDistributionModulesPolicyKyvernoValidationFailureAction = "Audit"
+	SpecDistributionModulesPolicyKyvernoValidationFailureActionEnforce SpecDistributionModulesPolicyKyvernoValidationFailureAction = "Enforce"
 )
 
 type SpecDistributionModulesPolicyType string
@@ -1703,8 +1703,8 @@ func (j *SpecDistributionModulesIngress) UnmarshalJSON(b []byte) error {
 }
 
 var enumValues_SpecDistributionModulesPolicyKyvernoValidationFailureAction = []interface{}{
-	"audit",
-	"enforce",
+	"Audit",
+	"Enforce",
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -1275,8 +1275,8 @@ type SpecDistributionModulesPolicyKyverno struct {
 	// Overrides corresponds to the JSON schema field "overrides".
 	Overrides *TypesFuryModuleComponentOverrides `json:"overrides,omitempty" yaml:"overrides,omitempty" mapstructure:"overrides,omitempty"`
 
-	// The validation failure action to use for the policies, `enforce` will block
-	// when a request does not comply with the policies and `audit` will not block but
+	// The validation failure action to use for the policies, `Enforce` will block
+	// when a request does not comply with the policies and `Audit` will not block but
 	// log when a request does not comply with the policies.
 	ValidationFailureAction SpecDistributionModulesPolicyKyvernoValidationFailureAction `json:"validationFailureAction" yaml:"validationFailureAction" mapstructure:"validationFailureAction"`
 }
@@ -1284,8 +1284,8 @@ type SpecDistributionModulesPolicyKyverno struct {
 type SpecDistributionModulesPolicyKyvernoValidationFailureAction string
 
 const (
-	SpecDistributionModulesPolicyKyvernoValidationFailureActionAudit   SpecDistributionModulesPolicyKyvernoValidationFailureAction = "audit"
-	SpecDistributionModulesPolicyKyvernoValidationFailureActionEnforce SpecDistributionModulesPolicyKyvernoValidationFailureAction = "enforce"
+	SpecDistributionModulesPolicyKyvernoValidationFailureActionAudit   SpecDistributionModulesPolicyKyvernoValidationFailureAction = "Audit"
+	SpecDistributionModulesPolicyKyvernoValidationFailureActionEnforce SpecDistributionModulesPolicyKyvernoValidationFailureAction = "Enforce"
 )
 
 type SpecDistributionModulesPolicyType string
@@ -2709,8 +2709,8 @@ func (j *SpecKubernetes) UnmarshalJSON(b []byte) error {
 }
 
 var enumValues_SpecDistributionModulesPolicyKyvernoValidationFailureAction = []interface{}{
-	"audit",
-	"enforce",
+	"Audit",
+	"Enforce",
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/schemas/private/ekscluster-kfd-v1alpha2.json
+++ b/schemas/private/ekscluster-kfd-v1alpha2.json
@@ -1541,8 +1541,8 @@
         "validationFailureAction": {
           "type": "string",
           "enum": [
-            "audit",
-            "enforce"
+            "Audit",
+            "Enforce"
           ],
           "description": "The validation failure action to use for the kyverno module"
         },

--- a/schemas/public/ekscluster-kfd-v1alpha2.json
+++ b/schemas/public/ekscluster-kfd-v1alpha2.json
@@ -2049,8 +2049,8 @@
         "validationFailureAction": {
           "type": "string",
           "enum": [
-            "audit",
-            "enforce"
+            "Audit",
+            "Enforce"
           ],
           "description": "The validation failure action to use for the kyverno module"
         },

--- a/schemas/public/kfddistribution-kfd-v1alpha2.json
+++ b/schemas/public/kfddistribution-kfd-v1alpha2.json
@@ -1166,8 +1166,8 @@
         "validationFailureAction": {
           "type": "string",
           "enum": [
-            "audit",
-            "enforce"
+            "Audit",
+            "Enforce"
           ],
           "description": "The validation failure action to use for the kyverno module"
         },

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -1743,10 +1743,10 @@
         "validationFailureAction": {
           "type": "string",
           "enum": [
-            "audit",
-            "enforce"
+            "Audit",
+            "Enforce"
           ],
-          "description": "The validation failure action to use for the policies, `enforce` will block when a request does not comply with the policies and `audit` will not block but log when a request does not comply with the policies."
+          "description": "The validation failure action to use for the policies, `Enforce` will block when a request does not comply with the policies and `Audit` will not block but log when a request does not comply with the policies."
         },
         "installDefaultPolicies": {
           "type": "boolean",

--- a/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.29.0.yaml
+++ b/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.29.0.yaml
@@ -52,7 +52,7 @@ spec:
         type: kyverno
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
           installDefaultPolicies: true
       dr:
         type: on-premises

--- a/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.29.1.yaml
+++ b/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.29.1.yaml
@@ -52,7 +52,7 @@ spec:
         type: kyverno
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
           installDefaultPolicies: true
       dr:
         type: on-premises

--- a/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.29.2.yaml
+++ b/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.29.2.yaml
@@ -52,7 +52,7 @@ spec:
         type: kyverno
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
           installDefaultPolicies: true
       dr:
         type: on-premises

--- a/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.29.3.yaml
+++ b/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.29.3.yaml
@@ -52,7 +52,7 @@ spec:
         type: kyverno
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
           installDefaultPolicies: true
       dr:
         type: on-premises

--- a/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.29.4.yaml
+++ b/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.29.4.yaml
@@ -52,7 +52,7 @@ spec:
         type: kyverno
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
           installDefaultPolicies: true
       dr:
         type: on-premises

--- a/tests/e2e/kfddistribution/furyctl-10-migrate-from-none-to-safe-values.yaml
+++ b/tests/e2e/kfddistribution/furyctl-10-migrate-from-none-to-safe-values.yaml
@@ -69,7 +69,7 @@ spec:
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
           installDefaultPolicies: true
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
       dr:
         type: on-premises
         velero: 

--- a/tests/e2e/kfddistribution/furyctl-11-migrate-from-kyverno-default-policies-to-disabled.yaml
+++ b/tests/e2e/kfddistribution/furyctl-11-migrate-from-kyverno-default-policies-to-disabled.yaml
@@ -69,7 +69,7 @@ spec:
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
           installDefaultPolicies: false
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
       dr:
         type: on-premises
         velero: 

--- a/tests/e2e/kfddistribution/furyctl-12-migrate-from-alertmanagerconfigs-to-disabled.yaml
+++ b/tests/e2e/kfddistribution/furyctl-12-migrate-from-alertmanagerconfigs-to-disabled.yaml
@@ -71,7 +71,7 @@ spec:
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
           installDefaultPolicies: false
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
       dr:
         type: on-premises
         velero: 

--- a/tests/e2e/kfddistribution/furyctl-2-migrate-from-tempo-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-2-migrate-from-tempo-to-none.yaml
@@ -69,7 +69,7 @@ spec:
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
           installDefaultPolicies: true
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
       dr:
         type: on-premises
         velero: 

--- a/tests/e2e/kfddistribution/furyctl-3-migrate-from-kyverno-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-3-migrate-from-kyverno-to-none.yaml
@@ -69,7 +69,7 @@ spec:
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
           installDefaultPolicies: true
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
       dr:
         type: on-premises
         velero: 

--- a/tests/e2e/kfddistribution/furyctl-4-migrate-from-velero-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-4-migrate-from-velero-to-none.yaml
@@ -69,7 +69,7 @@ spec:
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
           installDefaultPolicies: true
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
       dr:
         type: none
         velero: 

--- a/tests/e2e/kfddistribution/furyctl-5-migrate-from-loki-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-5-migrate-from-loki-to-none.yaml
@@ -69,7 +69,7 @@ spec:
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
           installDefaultPolicies: true
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
       dr:
         type: none
         velero: 

--- a/tests/e2e/kfddistribution/furyctl-6-migrate-from-mimir-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-6-migrate-from-mimir-to-none.yaml
@@ -69,7 +69,7 @@ spec:
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
           installDefaultPolicies: true
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
       dr:
         type: none
         velero:

--- a/tests/e2e/kfddistribution/furyctl-7-migrate-from-basicAuth-to-sso.yaml
+++ b/tests/e2e/kfddistribution/furyctl-7-migrate-from-basicAuth-to-sso.yaml
@@ -69,7 +69,7 @@ spec:
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
           installDefaultPolicies: true
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
       dr:
         type: none
         velero: 

--- a/tests/e2e/kfddistribution/furyctl-8-migrate-from-sso-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-8-migrate-from-sso-to-none.yaml
@@ -69,7 +69,7 @@ spec:
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
           installDefaultPolicies: true
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
       dr:
         type: none
         velero: 

--- a/tests/e2e/kfddistribution/furyctl-9-migrate-from-nginx-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-9-migrate-from-nginx-to-none.yaml
@@ -69,7 +69,7 @@ spec:
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
           installDefaultPolicies: true
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
       dr:
         type: none
         velero: 

--- a/tests/e2e/kfddistribution/furyctl-init-cluster.yaml
+++ b/tests/e2e/kfddistribution/furyctl-init-cluster.yaml
@@ -62,7 +62,7 @@ spec:
         type: kyverno
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
           installDefaultPolicies: true
       dr:
         type: on-premises

--- a/tests/e2e/kfddistribution/furyctl-init-with-values-from-nil.yaml
+++ b/tests/e2e/kfddistribution/furyctl-init-with-values-from-nil.yaml
@@ -65,7 +65,7 @@ spec:
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
           installDefaultPolicies: false
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
       dr:
         type: on-premises
         velero: 


### PR DESCRIPTION
Changes the possible values for the `validationFailureAction` field of Kyverno from `audit` and `enforce` to `Audit` and `Enforce`.

Previously we were using `audit` and `enforce`, all in lowercase, as the possible values. These values were triggering the following deprecation warning:

```
Warning: Validation failure actions enforce/audit are deprecated, use
Enforce/Audit instead.
```

After this change, the possible values will match the ones expected by Kyverno.

BREAKING CHANGE: users that have Kyverno enabled and have manually set the `validationFailureAction` value will need to adjust it, otherwise the schema validation fails with:

```
ERRO error while validating configuration file: error while validating
against schema: jsonschema:
'/spec/distribution/modules/policy/kyverno/validationFailureAction' does
not validate with
file:///var/folders/lb/zscvwt_s6fx6qdrfv4g51dsc0000gn/T/furyctl-1755893597/data/schemas/public/onpremises-kfd-v1alpha2.json#/properties/spec/$ref/properties/distribution/$ref/properties/modules/$ref/properties/policy/$ref/properties/kyverno/$ref/properties/validationFailureAction/enum:
value must be one of "Audit", "Enforce"
```