### PR TITLE
fix(on-prem): use the `.spec.kubernetes.advanced.users.org` parameter for kubernetes users creation

### DIFF
--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -50,6 +50,9 @@ all:
         kubernetes_users_names:
 {{ .spec.kubernetes.advanced.users.names | toYaml | indent 10 }}
         {{- end }}
+        {{- if index .spec.kubernetes.advanced.users "org" }}
+        kubernetes_users_org: "{{ .spec.kubernetes.advanced.users.org }}"
+        {{- end }}
         {{- end }}
 
         {{- if and (index .spec.kubernetes "advanced") (index .spec.kubernetes.advanced "oidc") }}


### PR DESCRIPTION
Closes #265 