### PR TITLE
fix(auth): make Hubble Ingress work with basicAuth

### DIFF
--- a/templates/distribution/manifests/auth/secrets/basic-auth.yml.tpl
+++ b/templates/distribution/manifests/auth/secrets/basic-auth.yml.tpl
@@ -52,4 +52,15 @@ type: Opaque
 stringData:
   auth: {{ htpasswd $username $password }}
 {{- end }}
+{{ if eq .spec.distribution.modules.networking.type "cilium" }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: basic-auth
+  namespace: kube-system
+type: Opaque
+stringData:
+  auth: {{ htpasswd $username $password }}
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
Add missing secret for making basicAuth work for the Hubble Ingress created in the kube-system namespace when Networking type is cilium.

Fixes #276 