### PR TITLE
feat(on-premises): allow clusters without nodes

### DIFF
--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -4914,10 +4914,6 @@ A name to identify the host. This value will be concatenated to `.spec.kubernete
 
 Configuration for the node hosts
 
-### Constraints
-
-**minimum number of items**: the minimum number of items for this array is: `1`
-
 ## .spec.kubernetes.nodes.hosts
 
 ### Properties

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -325,7 +325,7 @@
     "Spec.Kubernetes.Nodes": {
       "type": "array",
       "description": "Configuration for the node hosts",
-      "minItems": 1,
+      "minItems": 0,
       "items": {
         "$ref": "#/$defs/Spec.Kubernetes.Nodes.Node"
       }


### PR DESCRIPTION
Allow creating on-premises clusters with only control-plane hosts and no additional nodes, for minimal cluster installations.