### PR TITLE
fix: do not install x509 data planes on EKS

### DIFF
--- a/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
@@ -56,6 +56,15 @@ resources:
 
 patchesStrategicMerge:
   - patches/infra-nodes.yml
+{{- if eq .spec.distribution.common.provider.type "eks" }}{{/* in EKS there are no files to monitor on nodes */}}
+  - |-
+    $patch: delete
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      namespace: monitoring
+      name: x509-certificate-exporter-data-plane
+{{- end }}
 {{- if or (eq $monitoringType "prometheus") (eq $monitoringType "mimir") }}
   - patches/alertmanager-operated.yml
   {{- if .checks.storageClassAvailable }}

--- a/templates/distribution/manifests/monitoring/patches/infra-nodes.yml.tpl
+++ b/templates/distribution/manifests/monitoring/patches/infra-nodes.yml.tpl
@@ -114,6 +114,7 @@ spec:
         {{ template "nodeSelector" $x509ExporterArgs }}
       tolerations:
         {{ template "tolerations" $x509ExporterArgs }}
+{{- if ne .spec.distribution.common.provider.type "eks" }}{{/* in EKS there are no files to monitor on nodes */}}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -127,6 +128,7 @@ spec:
         {{ template "nodeSelector" $x509ExporterArgs }}
       tolerations:
         {{ template "tolerations" $x509ExporterArgs }}
+{{- end }}
 
 {{ if eq $monitoringType "mimir" -}}
 {{- $mimirArgs := dict "module" "monitoring" "package" "mimir" "spec" .spec -}}


### PR DESCRIPTION
This component is not needed on EKS and it will just give false alerting