### PR TITLE
fix(templates/ingress): nginx type none and tls secret, migration to none

### DIFF
--- a/templates/distribution/manifests/ingress/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/ingress/kustomization.yaml.tpl
@@ -37,7 +37,7 @@ resources:
   - resources/ingress-infra.yml
 {{- end }}
 
-{{ if eq .spec.distribution.modules.ingress.nginx.tls.provider "secret" }}
+{{ if and (eq .spec.distribution.modules.ingress.nginx.tls.provider "secret") (ne .spec.distribution.modules.ingress.nginx.type "none") }}
   - secrets/tls.yml
 {{- end }}
 

--- a/templates/distribution/scripts/pre-apply.sh.tpl
+++ b/templates/distribution/scripts/pre-apply.sh.tpl
@@ -587,6 +587,7 @@ deleteNginxIngresses() {
   $kubectlbin delete --ignore-not-found --wait --timeout=180s ingress -n logging --all
   $kubectlbin delete --ignore-not-found --wait --timeout=180s ingress -n gatekeeper-system --all
   $kubectlbin delete --ignore-not-found --wait --timeout=180s ingress -n ingress-nginx --all
+  $kubectlbin delete --ignore-not-found --wait --timeout=180s ingress -n kube-system --all # hubble, gangplank, dex
   echo "All the infrastructural ingresses associated with nginx have been deleted"
 }
 


### PR DESCRIPTION
- Don't create `ingress-nginx-global-tls-cert` secret in `ingress-nginx` namespace when `nginx.tls.provider` is set to `secret` and `nginx.type: none` at the same time, it results in an error bacause the namespace does not exist.
- Migration for `nginx.type -> none`: ingresses in `kube-system` namespace (dex, gangway, hubble) were not being deleted. Delete all the ingresses in the `kube-system` namespace as part of the migration.


> [!NOTE]
> This PR is branched off #280 because it modifies some of the same files. You may see changes from both PRs here until 280 is merged.