### PR TITLE
fix: adding a new field on plugins spec to permit a new field

### DIFF
--- a/schemas/public/spec-plugins.json
+++ b/schemas/public/spec-plugins.json
@@ -87,6 +87,10 @@
               "type": "string"
             },
             "description": "The values of the release"
+          },
+          "disableValidationOnInstall": {
+            "type": "boolean",
+            "description": "Disable helm diff validation on install"
           }
         },
         "required": ["name", "namespace", "chart"]

--- a/schemas/public/spec-plugins.json
+++ b/schemas/public/spec-plugins.json
@@ -90,7 +90,7 @@
           },
           "disableValidationOnInstall": {
             "type": "boolean",
-            "description": "Disable helm diff validation on install"
+            "description": "Disable running `helm diff` validation when installing the plugin, it will still be done when upgrading."
           }
         },
         "required": ["name", "namespace", "chart"]


### PR DESCRIPTION
This is needed to disable helmfile validation (helm diff command) during installation, when installin CR that depends on CRD deployed by the chart itself (for example, the netapp trident driver)