### PR TITLE
feat(ingress): add label to clusterissuer

### DIFF
--- a/templates/distribution/manifests/ingress/resources/cert-manager-clusterissuer.yml.tpl
+++ b/templates/distribution/manifests/ingress/resources/cert-manager-clusterissuer.yml.tpl
@@ -31,6 +31,9 @@ spec:
         ingress:
           class: {{ template "globalIngressClass" (dict "type" "external" "spec" .spec) }}
           podTemplate:
+            metadata:
+              labels:
+                app: cert-manager
             spec:
               nodeSelector:
                 {{ template "nodeSelector" $certManagerArgs }}


### PR DESCRIPTION
I'm adding a default label `app=cert-manager` to the `ClusterIssuer` provisioned with `furyctl`, so it's easier to address the challenge pods (e.g. for Network Policies).