### PR TITLE
fix eks terraform template with missing ami_owners

### DIFF
--- a/templates/kubernetes/ekscluster/terraform/main.auto.tfvars.tpl
+++ b/templates/kubernetes/ekscluster/terraform/main.auto.tfvars.tpl
@@ -97,7 +97,7 @@ workers_iam_role_name_prefix_override = {{ .spec.kubernetes.workersIAMRoleNamePr
         {{- end}}
 
         {{- if hasKeyAny $np "ami" }}
-            {{- $currNodePool = mergeOverwrite $currNodePool (dict "ami_id" $np.ami.id) }}
+            {{- $currNodePool = mergeOverwrite $currNodePool (dict "ami_id" $np.ami.id "ami_owners" (list $np.ami.owner)) }}
         {{- end }}
 
         {{- if hasKeyAny $np.instance "spot" }}


### PR DESCRIPTION
As the `ami_owners` has been introduced in https://github.com/sighupio/fury-eks-installer/pull/80 now it's possible to use the value of `nodePools.ami.owner` in the eks installer