### PR TITLE
fix(templates/auth/pomerium): route for minio-tracing missing

### DIFF
--- a/templates/distribution/manifests/auth/resources/pomerium-policy.yml.tpl
+++ b/templates/distribution/manifests/auth/resources/pomerium-policy.yml.tpl
@@ -99,6 +99,8 @@ routes:
           and:
             - authenticated_user: true
       {{- end }}
+  {{- end }}
+  {{- if and (eq .spec.distribution.modules.tracing.type "tempo") (eq .spec.distribution.modules.tracing.tempo.backend "minio") (.checks.storageClassAvailable) }}
   - from: https://{{ template "minioTracingUrl" .spec }}
     to: http://minio-tracing-console.tracing.svc.cluster.local:9001
     allow_websockets: true


### PR DESCRIPTION
Fix login in Pomerium routes definition, minio-tracing route was not being added when logging is set to `none`.