### PR TITLE
fix(minio): more specific tls secret name

### DIFF
--- a/templates/distribution/manifests/logging/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/logging/resources/ingress-infra.yml.tpl
@@ -93,4 +93,4 @@ spec:
                 port:
                   name: http
             {{ end }}
-{{- template "ingressTls" (dict "module" "logging" "package" "minio" "prefix" "minio-logging." "spec" .spec) }}
+{{- template "ingressTls" (dict "module" "logging" "package" "minio-logging" "prefix" "minio-logging." "spec" .spec) }}

--- a/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
@@ -181,7 +181,7 @@ spec:
                 port:
                   name: http
             {{ end }}
-{{- template "ingressTls" (dict "module" "monitoring" "package" "minio" "prefix" "minio-monitoring." "spec" .spec) }}
+{{- template "ingressTls" (dict "module" "monitoring" "package" "minio-monitoring" "prefix" "minio-monitoring." "spec" .spec) }}
 {{- end }}
 {{- end }}
 

--- a/templates/distribution/manifests/tracing/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/tracing/resources/ingress-infra.yml.tpl
@@ -46,4 +46,4 @@ spec:
                 port:
                   name: http
             {{ end }}
-{{- template "ingressTls" (dict "module" "tracing" "package" "minio" "prefix" "minio-tracing." "spec" .spec) }}
+{{- template "ingressTls" (dict "module" "tracing" "package" "minio-tracing" "prefix" "minio-tracing." "spec" .spec) }}


### PR DESCRIPTION
This PR is to better specify minio's tls secret name.

Now the secret is called `minio-tls` for all the variants: logging, monitoring and tracing. Most of the time this is not a problem.

The issue that we get as of today is when auth is `sso`, so all ingresses are deployed in `pomerium` namespace and in this case they are sharing all the same tls secret (and certificate).

Changing all the names solves the issue.

