### PR TITLE
feat(tracing): bump to v1.1.0

### DIFF
--- a/kfd.yaml
+++ b/kfd.yaml
@@ -12,7 +12,7 @@ modules:
   monitoring: v3.2.0
   opa: v1.12.0
   networking: v1.17.0
-  tracing: v1.0.3
+  tracing: v1.1.0
 kubernetes:
   eks:
     version: 1.29

--- a/templates/distribution/manifests/tracing/patches/minio.root.env.tpl
+++ b/templates/distribution/manifests/tracing/patches/minio.root.env.tpl
@@ -1,2 +1,2 @@
-ROOT_PASSWORD={{ .spec.distribution.modules.tracing.minio.rootUser.password }}
-ROOT_USER={{ .spec.distribution.modules.tracing.minio.rootUser.username }}
+rootPassword={{ .spec.distribution.modules.tracing.minio.rootUser.password }}
+rootUser={{ .spec.distribution.modules.tracing.minio.rootUser.username }}

--- a/templates/distribution/manifests/tracing/patches/tempo.yaml.tpl
+++ b/templates/distribution/manifests/tracing/patches/tempo.yaml.tpl
@@ -86,13 +86,12 @@ querier:
     trace_by_id:
         query_timeout: 10s
 query_frontend:
+    max_outstanding_per_tenant: 2000
     max_retries: 2
     search:
         concurrent_jobs: 1000
         target_bytes_per_job: 104857600
     trace_by_id:
-        hedge_requests_at: 2s
-        hedge_requests_up_to: 2
         query_shards: 50
 server:
     grpc_server_max_recv_msg_size: 4194304


### PR DESCRIPTION
- bump tracing version to v1.1.0.
- drop deprecated fields from tempo's configuration file template.
- align nomenclature in minio's root credentials to follow the breaking change introduced in the release of the module.

> [!NOTE]
> Creating PR as draft waiting for confirmation on 1.28 compatibility