### PR TITLE
fix(templates): fix ingress tlsSecret name generation

### DIFF
--- a/templates/distribution/_helpers.tpl
+++ b/templates/distribution/_helpers.tpl
@@ -125,7 +125,7 @@
     - hosts:
       - {{ template "ingressHost" . }}
     {{- if eq .spec.distribution.modules.ingress.nginx.tls.provider "certManager" }}
-      secretName: {{ lower .package }}-tls
+      secretName: {{ lower .prefix | trimSuffix "." }}-tls
     {{- end }}
 {{- end }}
 {{- end -}}

--- a/templates/distribution/manifests/logging/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/logging/resources/ingress-infra.yml.tpl
@@ -65,7 +65,7 @@ metadata:
     forecastle.stakater.com/icon: "https://min.io/resources/img/logo/MINIO_Bird.png"
     {{ if not .spec.distribution.modules.logging.overrides.ingresses.minio.disableAuth }}{{ template "ingressAuth" . }}{{ end }}
     {{ template "certManagerClusterIssuer" . }}
-  
+
   {{ if and (not .spec.distribution.modules.logging.overrides.ingresses.minio.disableAuth) (eq .spec.distribution.modules.auth.provider.type "sso") }}
   name: minio-logging
   namespace: pomerium
@@ -93,4 +93,4 @@ spec:
                 port:
                   name: http
             {{ end }}
-{{- template "ingressTls" (dict "module" "logging" "package" "minio-logging" "prefix" "minio-logging." "spec" .spec) }}
+{{- template "ingressTls" (dict "module" "logging" "package" "minio" "prefix" "minio-logging." "spec" .spec) }}

--- a/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
@@ -181,7 +181,7 @@ spec:
                 port:
                   name: http
             {{ end }}
-{{- template "ingressTls" (dict "module" "monitoring" "package" "minio-monitoring" "prefix" "minio-monitoring." "spec" .spec) }}
+{{- template "ingressTls" (dict "module" "monitoring" "package" "minio" "prefix" "minio-monitoring." "spec" .spec) }}
 {{- end }}
 {{- end }}
 

--- a/templates/distribution/manifests/tracing/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/tracing/resources/ingress-infra.yml.tpl
@@ -46,4 +46,4 @@ spec:
                 port:
                   name: http
             {{ end }}
-{{- template "ingressTls" (dict "module" "tracing" "package" "minio-tracing" "prefix" "minio-tracing." "spec" .spec) }}
+{{- template "ingressTls" (dict "module" "tracing" "package" "minio" "prefix" "minio-tracing." "spec" .spec) }}


### PR DESCRIPTION
- Fix a bug introduced in #294 that broke templates for ingresses.
- Change the logic to generate the TLS secretName, instead of using the package name use the prefix (the first part of the ingress hostname).

This will change the TLS secretName for the several MinIOs ingresses that we have from `minio` to `minio-ingress`, `minio-logging`, `minio-monitoring`.

As a side effect, Forecastle's TLS secretName will also be changed, from `forecastle-tls` to `directory-tls`.


I think it is actually better this way than what we had originally, i.e. is better to use the prefix to generate the tlsSecretName than the package name, but if there are downsides that I'm not seeing we could revert to how it was originally (but the several minio ingresses will be broken)