### PR TITLE
feat(ekscluster): add capability to choose ami type os

### DIFF
--- a/docs/schemas/ekscluster-kfd-v1alpha2.md
+++ b/docs/schemas/ekscluster-kfd-v1alpha2.md
@@ -5437,6 +5437,21 @@ Either `launch_configurations`, `launch_templates` or `both`. For new clusters u
 |`"launch_templates"`     |
 |`"both"`                 |
 
+## .spec.kubernetes.nodePoolGlobalAmiType
+
+### Description
+
+Global default AMI type used for EKS worker nodes. This will apply to all node pools unless overridden by a specific node pool.
+
+### Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value          |
+|:---------------|
+| `"alinux2"`    |
+| `"alinux2023"` |
+
 ## .spec.kubernetes.serviceIpV4Cidr
 
 ### Description

--- a/kfd.yaml
+++ b/kfd.yaml
@@ -16,7 +16,7 @@ modules:
 kubernetes:
   eks:
     version: 1.30
-    installer: v3.1.2
+    installer: v3.2.0-rc0
   onpremises:
     version: 1.30.6
     installer: v1.30.6-rc.2

--- a/kfd.yaml
+++ b/kfd.yaml
@@ -16,7 +16,7 @@ modules:
 kubernetes:
   eks:
     version: 1.30
-    installer: v3.2.0-rc0
+    installer: v3.2.0-rc1
   onpremises:
     version: 1.30.6
     installer: v1.30.6-rc.2

--- a/schemas/private/ekscluster-kfd-v1alpha2.json
+++ b/schemas/private/ekscluster-kfd-v1alpha2.json
@@ -472,6 +472,14 @@
           ],
           "description": "Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim."
         },
+        "nodePoolGlobalAmiType": {
+          "type": "string",
+          "enum": [
+            "alinux2",
+            "alinux2023"
+          ],
+          "description": "Global default AMI type used for EKS worker nodes. This will apply to all node pools unless overridden by a specific node pool."
+        },
         "logRetentionDays": {
           "type": "integer",
           "description": "Optional Kubernetes Cluster log retention in days. Defaults to 90 days."
@@ -607,8 +615,36 @@
       "required": [
         "instance",
         "name",
-        "size"
-      ]
+        "size",
+        "type"
+      ],
+      "if": {
+        "allOf": [
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "eks-managed"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "ami": {
+            "properties": {
+              "id": {
+                "type": "null"
+              },
+              "owner": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      }
     },
     "Spec.Kubernetes.NodePool.Ami": {
       "type": "object",
@@ -621,12 +657,22 @@
         "owner": {
           "type": "string",
           "description": "The owner of the AMI"
+        },
+        "type": {
+          "type": "string",
+          "description": "The AMI type based on OS",
+          "enum": [
+            "alinux2",
+            "alinux2023"
+          ]
         }
       },
-      "required": [
-        "id",
-        "owner"
-      ]
+      "dependencies": {
+        "id": [
+          "owner"
+        ]
+      },
+      "required": []
     },
     "Spec.Kubernetes.NodePool.Instance": {
       "type": "object",

--- a/schemas/public/ekscluster-kfd-v1alpha2.json
+++ b/schemas/public/ekscluster-kfd-v1alpha2.json
@@ -472,6 +472,14 @@
           ],
           "description": "Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim."
         },
+        "nodePoolGlobalAmiType": {
+          "type": "string",
+          "enum": [
+            "alinux2",
+            "alinux2023"
+          ],
+          "description": "Global default AMI type used for EKS worker nodes. This will apply to all node pools unless overridden by a specific node pool."
+        },
         "logRetentionDays": {
           "type": "integer",
           "description": "Optional Kubernetes Cluster log retention in days. Defaults to 90 days."
@@ -607,8 +615,36 @@
       "required": [
         "instance",
         "name",
-        "size"
-      ]
+        "size",
+        "type"
+      ],
+      "if": {
+        "allOf": [
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "eks-managed"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "ami": {
+            "properties": {
+              "id": {
+                "type": "null"
+              },
+              "owner": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      }
     },
     "Spec.Kubernetes.NodePool.Ami": {
       "type": "object",
@@ -621,12 +657,22 @@
         "owner": {
           "type": "string",
           "description": "The owner of the AMI"
+        },
+        "type": {
+          "type": "string",
+          "description": "The AMI type based on OS",
+          "enum": [
+            "alinux2",
+            "alinux2023"
+          ]
         }
       },
-      "required": [
-        "id",
-        "owner"
-      ]
+      "dependencies": {
+        "id": [
+          "owner"
+        ]
+      },
+      "required": []
     },
     "Spec.Kubernetes.NodePool.Instance": {
       "type": "object",

--- a/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
@@ -85,6 +85,8 @@ spec:
     nodeAllowedSshPublicKey: "ssh-ed25519 XYZ"
     # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
     nodePoolsLaunchKind: "launch_templates"
+    # Global default AMI type used for EKS worker nodes. This will apply to all node pools unless overridden by a specific node pool. Valid values are: `alinux2`, `alinux2023`
+    nodePoolGlobalAmiType: "alinux2"
     # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
     # logRetentionDays: 90
     # This map defines the access to the Kubernetes API server
@@ -97,6 +99,7 @@ spec:
     nodePools:
         # This is the name of the nodepool
       - name: infra
+        type: self-managed
         # This map defines the max and min number of nodes in the nodepool autoscaling group
         size:
           min: 1

--- a/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
@@ -127,8 +127,8 @@ spec:
           - node.kubernetes.io/role=infra:NoSchedule
         # AWS tags that will be added to the ASG and EC2 instances, the example shows the labels needed by cluster autoscaler
         tags:
-          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
-          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: "infra"
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "infra"
         # Optional additional firewall rules that will be attached to the nodes
         #additionalFirewallRules:
         #    # The name of the rule

--- a/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
@@ -230,6 +230,9 @@ spec:
       logging:
         # can be opensearch, loki, customOutput or none. With none, the logging module won't be installed
         type: loki
+        # configurations for the loki package
+        loki:
+          tsdbStartDate: "2024-11-20"
         # configurations for the minio-ha package
         minio:
           # the PVC size for each minio disk, 6 disks total

--- a/templates/config/kfddistribution-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/kfddistribution-kfd-v1alpha2.yaml.tpl
@@ -76,6 +76,9 @@ spec:
       logging:
         # can be opensearch, loki, customOutput or none. With none, the logging module won't be installed
         type: loki
+        # configurations for the loki package
+        loki:
+          tsdbStartDate: "2024-11-20"
         # configurations for the minio-ha package
         minio:
           # the PVC size for each minio disk, 6 disks total

--- a/templates/config/onpremises-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/onpremises-kfd-v1alpha2.yaml.tpl
@@ -153,6 +153,9 @@ spec:
       logging:
         # can be opensearch, loki, customOutput or none. With none, the logging module won't be installed
         type: loki
+        # configurations for the loki package
+        loki:
+          tsdbStartDate: "2024-11-20"
         # configurations for the minio-ha package
         minio:
           # the PVC size for each minio disk, 6 disks total

--- a/templates/kubernetes/ekscluster/terraform/main.auto.tfvars.tpl
+++ b/templates/kubernetes/ekscluster/terraform/main.auto.tfvars.tpl
@@ -32,6 +32,7 @@ cluster_service_ipv4_cidr = null
 cluster_service_ipv4_cidr = {{ .spec.kubernetes.serviceIpV4Cidr | quote }}
 {{- end }}
 node_pools_launch_kind = {{ .spec.kubernetes.nodePoolsLaunchKind | quote }}
+node_pools_global_ami_type = {{ .spec.kubernetes.nodePoolGlobalAmiType | quote }}
 
 {{- if hasKeyAny .spec.kubernetes "logRetentionDays" }}
 cluster_log_retention_days = {{ .spec.kubernetes.logRetentionDays }}
@@ -97,7 +98,11 @@ workers_iam_role_name_prefix_override = {{ .spec.kubernetes.workersIAMRoleNamePr
         {{- end}}
 
         {{- if hasKeyAny $np "ami" }}
-            {{- $currNodePool = mergeOverwrite $currNodePool (dict "ami_id" $np.ami.id "ami_owners" (list $np.ami.owner)) }}
+            {{- if and (eq $np.type "self-managed") (hasKeyAny $np.ami "id") (not (hasKeyAny $np.ami "type")) }}
+                {{- $currNodePool = mergeOverwrite $currNodePool (dict "ami_id" $np.ami.id "ami_owners" (list $np.ami.owner))  }}
+            {{- else if and (hasKeyAny $np.ami "type") (not (hasKeyAny $np.ami "id")) }}
+                {{- $currNodePool = mergeOverwrite $currNodePool (dict "ami_type" $np.ami.type) }}
+            {{- end }}
         {{- end }}
 
         {{- if hasKeyAny $np.instance "spot" }}

--- a/templates/kubernetes/ekscluster/terraform/main.tf.tpl
+++ b/templates/kubernetes/ekscluster/terraform/main.tf.tpl
@@ -62,6 +62,7 @@ module "fury" {
   ssh_public_key                        = var.ssh_public_key
   node_pools                            = var.node_pools
   node_pools_launch_kind                = var.node_pools_launch_kind
+  node_pools_global_ami_type            = var.node_pools_global_ami_type
   tags                                  = var.tags
   cluster_iam_role_name                 = var.cluster_iam_role_name_prefix_override
   workers_role_name                     = var.workers_iam_role_name_prefix_override

--- a/templates/kubernetes/ekscluster/terraform/variables.tf
+++ b/templates/kubernetes/ekscluster/terraform/variables.tf
@@ -63,19 +63,21 @@ variable "ssh_public_key" {
 variable "node_pools" {
   description = "An object list defining node pools configurations"
   type = list(object({
-    name              = string
     type              = optional(string, "self-managed") # "eks-managed" or "self-managed"
+    name              = string
     ami_id            = optional(string)
-    version           = optional(string) # null to use cluster_version
+    ami_owners        = optional(list(string), ["amazon"])
+    ami_type          = optional(string, null)
+    version           = optional(string, null) # null to use cluster_version
     min_size          = number
     max_size          = number
     instance_type     = string
-    container_runtime = optional(string)
-    spot_instance     = optional(bool)
-    max_pods          = optional(number) # null to use default upstream configuration
+    container_runtime = optional(string, "containerd")
+    spot_instance     = optional(bool, false)
+    max_pods          = optional(number, null) # null to use default upstream configuration
     volume_size       = optional(number, 100)
     volume_type       = optional(string, "gp2")
-    subnets           = optional(list(string)) # null to use default upstream configuration
+    subnets           = optional(list(string), null) # null to use default upstream configuration
     labels            = optional(map(string))
     taints            = optional(list(string))
     tags              = optional(map(string))
@@ -218,4 +220,14 @@ variable "workers_iam_role_name_prefix_override" {
   description = "The name prefix of the IAM role to use for the EKS workers. If not set, a name will be generated from the cluster name."
   type        = string
   default     = ""
+}
+
+variable "node_pools_global_ami_type" {
+  type        = string
+  description = "Global default AMI type used for EKS worker nodes. This will apply to all node pools unless overridden by a specific node pool."
+  default     = "alinux2"
+  validation {
+    condition     = contains(["alinux2", "alinux2023"], var.node_pools_global_ami_type)
+    error_message = "The global AMI type must be either 'alinux2' or 'alinux2023'."
+  }
 }

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/001-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/001-no.yaml
@@ -56,6 +56,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/001-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/001-ok.yaml
@@ -50,6 +50,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/002-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/002-no.yaml
@@ -23,6 +23,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/002-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/002-ok.yaml
@@ -33,6 +33,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/003-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/003-no.yaml
@@ -50,6 +50,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/003-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/003-ok.yaml
@@ -50,6 +50,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/004-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/004-no.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/004-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/004-ok.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/005-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/005-no.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/005-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/005-ok.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/006-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/006-no.yaml
@@ -50,6 +50,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/006-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/006-ok.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/007-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/007-no.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/007-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/007-ok.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/008-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/008-no.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/008-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/008-ok.yaml
@@ -48,6 +48,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/009-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/009-no.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/009-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/009-ok.yaml
@@ -48,6 +48,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/010-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/010-no.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/010-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/010-ok.yaml
@@ -48,6 +48,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/011-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/011-no.yaml
@@ -41,6 +41,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/011-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/011-ok.yaml
@@ -42,6 +42,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/012-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/012-no.yaml
@@ -4,10 +4,9 @@
 
 # Tests the following cases:
 
-# Given "spec.distribution.customPatches" is filled
-# a configMapGenerator is filled with a 'type' that is not valid
+# Given "spec.kubernetes.nodePools.0.type" is 'eks-managed' and "spec.kubernetes.nodePools.0.ami.id" is filled
 # When I validate the config against the schema
-# Then an error "additionalProperties 'type' not allowed" is returned
+# Then an error "$ref/properties/nodePools/items/$ref/then/properties/ami/properties/id/type: expected null, but got string" is returned
 
 ---
 apiVersion: kfd.sighup.io/v1alpha2
@@ -16,18 +15,6 @@ metadata:
   name: furyctl-dev-aws-al
 spec:
   infrastructure:
-    vpc:
-      network:
-        cidr: 10.0.0.0/16
-        subnetsCidrs:
-          private:
-            - 10.0.182.0/24
-            - 10.0.172.0/24
-            - 10.0.162.0/24
-          public:
-            - 10.0.20.0/24
-            - 10.0.30.0/24
-            - 10.0.40.0/24
     vpn:
       ssh:
         allowedFromCidrs:
@@ -40,16 +27,21 @@ spec:
   kubernetes:
     apiServer:
       privateAccess: true
-      privateAccessCidrs: ["0.0.0.0/0"]
+      privateAccessCidrs: ["10.0.0.3/16"]
       publicAccessCidrs: []
       publicAccess: false
+    vpcId: vpc-0123456789abcdef0
+    subnetIds:
+      - subnet-0123456789abcdef0
+      - subnet-0123456789abcdef1
+      - subnet-0123456789abcdef2
     nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
     nodePoolsLaunchKind: both
     nodePools:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
-        type: self-managed
+        type: eks-managed
         instance:
           type: t3.large
         name: worker-eks
@@ -62,7 +54,6 @@ spec:
         - name: a-configmap
           files:
             - /path/to/config.example
-          type: Opaque
         - name: b-configmap
           envs:
             - /path/to/envs.env
@@ -91,7 +82,6 @@ spec:
         - name: b-secret
           envs:
             - /path/to/envs.env
-          type: Opaque
     common:
       provider:
         type: eks

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/012-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/012-ok.yaml
@@ -4,10 +4,9 @@
 
 # Tests the following cases:
 
-# Given "spec.distribution.customPatches" is filled
-# a configMapGenerator is filled with a 'type' that is not valid
+# Given "spec.kubernetes.nodePools.0.type" is 'eks-managed' and "spec.kubernetes.nodePools.0.ami.id" is not filled
 # When I validate the config against the schema
-# Then an error "additionalProperties 'type' not allowed" is returned
+# Then no errors are returned
 
 ---
 apiVersion: kfd.sighup.io/v1alpha2
@@ -16,19 +15,8 @@ metadata:
   name: furyctl-dev-aws-al
 spec:
   infrastructure:
-    vpc:
-      network:
-        cidr: 10.0.0.0/16
-        subnetsCidrs:
-          private:
-            - 10.0.182.0/24
-            - 10.0.172.0/24
-            - 10.0.162.0/24
-          public:
-            - 10.0.20.0/24
-            - 10.0.30.0/24
-            - 10.0.40.0/24
     vpn:
+      vpcId: vpc-0123456789abcdef0
       ssh:
         allowedFromCidrs:
           - 0.0.0.0/0
@@ -40,16 +28,21 @@ spec:
   kubernetes:
     apiServer:
       privateAccess: true
-      privateAccessCidrs: ["0.0.0.0/0"]
+      privateAccessCidrs: ["10.0.0.3/16"]
       publicAccessCidrs: []
       publicAccess: false
+    vpcId: vpc-0123456789abcdef0
+    subnetIds:
+      - subnet-0123456789abcdef0
+      - subnet-0123456789abcdef1
+      - subnet-0123456789abcdef2
     nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
     nodePoolsLaunchKind: both
     nodePools:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
-        type: self-managed
+        type: eks-managed
         instance:
           type: t3.large
         name: worker-eks
@@ -62,7 +55,6 @@ spec:
         - name: a-configmap
           files:
             - /path/to/config.example
-          type: Opaque
         - name: b-configmap
           envs:
             - /path/to/envs.env
@@ -91,24 +83,32 @@ spec:
         - name: b-secret
           envs:
             - /path/to/envs.env
-          type: Opaque
     common:
       provider:
         type: eks
     modules:
-      aws: {}
+      aws:
+        clusterAutoscaler:
+          iamRoleArn: arn:aws:iam::123456789012:role/cluster-autoscaler
+        ebsCsiDriver:
+          iamRoleArn: arn:aws:iam::123456789012:role/ebs-csi-driver
+        loadBalancerController:
+          iamRoleArn: arn:aws:iam::123456789012:role/load-balancer-controller
+        overrides: {}
       dr:
         type: eks
         velero:
           eks:
             bucketName: example-velero
             region: eu-west-1
+            iamRoleArn: arn:aws:iam::123456789012:role/velero
       ingress:
         baseDomain: furyctl-demo.sighup.io
         dns:
           private:
             create: true
             name: internal.furyctl-demo.sighup.io
+            vpcId: vpc-12345678901234567
           public:
             create: true
             name: furyctl-demo.sighup.io
@@ -123,6 +123,18 @@ spec:
                 value
               key: |
                 value
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: email@test.it
+            type: http01
+            route53:
+              region: eu-west-1
+              hostedZoneId: Z1234567890
+              iamRoleArn: arn:aws:iam::123456789012:role/cert-manager
+        externalDns:
+          privateIamRoleArn: arn:aws:iam::123456789012:role/external-dns-private
+          publicIamRoleArn: arn:aws:iam::123456789012:role/external-dns-public
       logging:
         type: opensearch
         opensearch:

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/001-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/001-no.yaml
@@ -56,6 +56,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/001-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/001-ok.yaml
@@ -50,6 +50,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/002-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/002-no.yaml
@@ -23,6 +23,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/002-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/002-ok.yaml
@@ -33,6 +33,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/003-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/003-no.yaml
@@ -50,6 +50,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/003-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/003-ok.yaml
@@ -50,6 +50,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/004-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/004-no.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/004-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/004-ok.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/005-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/005-no.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/005-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/005-ok.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/006-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/006-no.yaml
@@ -50,6 +50,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/006-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/006-ok.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/007-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/007-no.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/007-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/007-ok.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/008-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/008-no.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/008-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/008-ok.yaml
@@ -48,6 +48,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/009-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/009-ok.yaml
@@ -48,6 +48,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/010-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/010-no.yaml
@@ -49,6 +49,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/010-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/010-ok.yaml
@@ -48,6 +48,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/011-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/011-no.yaml
@@ -41,6 +41,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/011-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/011-ok.yaml
@@ -42,6 +42,7 @@ spec:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
+        type: self-managed
         instance:
           type: t3.large
         name: worker-eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/012-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/012-no.yaml
@@ -4,10 +4,9 @@
 
 # Tests the following cases:
 
-# Given "spec.distribution.customPatches" is filled
-# a configMapGenerator is filled with a 'type' that is not valid
+# Given "spec.kubernetes.nodePools.0.type" is 'eks-managed' and "spec.kubernetes.nodePools.0.ami.id" is filled
 # When I validate the config against the schema
-# Then an error "additionalProperties 'type' not allowed" is returned
+# Then an error "$ref/properties/nodePools/items/$ref/then/properties/ami/properties/id/type: expected null, but got string" is returned
 
 ---
 apiVersion: kfd.sighup.io/v1alpha2
@@ -16,18 +15,6 @@ metadata:
   name: furyctl-dev-aws-al
 spec:
   infrastructure:
-    vpc:
-      network:
-        cidr: 10.0.0.0/16
-        subnetsCidrs:
-          private:
-            - 10.0.182.0/24
-            - 10.0.172.0/24
-            - 10.0.162.0/24
-          public:
-            - 10.0.20.0/24
-            - 10.0.30.0/24
-            - 10.0.40.0/24
     vpn:
       ssh:
         allowedFromCidrs:
@@ -40,16 +27,21 @@ spec:
   kubernetes:
     apiServer:
       privateAccess: true
-      privateAccessCidrs: ["0.0.0.0/0"]
+      privateAccessCidrs: ["10.0.0.3/16"]
       publicAccessCidrs: []
       publicAccess: false
+    vpcId: vpc-0123456789abcdef0
+    subnetIds:
+      - subnet-0123456789abcdef0
+      - subnet-0123456789abcdef1
+      - subnet-0123456789abcdef2
     nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
     nodePoolsLaunchKind: both
     nodePools:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
-        type: self-managed
+        type: eks-managed
         instance:
           type: t3.large
         name: worker-eks
@@ -62,7 +54,6 @@ spec:
         - name: a-configmap
           files:
             - /path/to/config.example
-          type: Opaque
         - name: b-configmap
           envs:
             - /path/to/envs.env
@@ -91,7 +82,6 @@ spec:
         - name: b-secret
           envs:
             - /path/to/envs.env
-          type: Opaque
     common:
       provider:
         type: eks

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/012-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/012-ok.yaml
@@ -4,10 +4,9 @@
 
 # Tests the following cases:
 
-# Given "spec.distribution.customPatches" is filled
-# a configMapGenerator is filled with a 'type' that is not valid
+# Given "spec.kubernetes.nodePools.0.type" is 'eks-managed' and "spec.kubernetes.nodePools.0.ami.id" is not filled
 # When I validate the config against the schema
-# Then an error "additionalProperties 'type' not allowed" is returned
+# Then no errors are returned
 
 ---
 apiVersion: kfd.sighup.io/v1alpha2
@@ -16,18 +15,6 @@ metadata:
   name: furyctl-dev-aws-al
 spec:
   infrastructure:
-    vpc:
-      network:
-        cidr: 10.0.0.0/16
-        subnetsCidrs:
-          private:
-            - 10.0.182.0/24
-            - 10.0.172.0/24
-            - 10.0.162.0/24
-          public:
-            - 10.0.20.0/24
-            - 10.0.30.0/24
-            - 10.0.40.0/24
     vpn:
       ssh:
         allowedFromCidrs:
@@ -40,16 +27,21 @@ spec:
   kubernetes:
     apiServer:
       privateAccess: true
-      privateAccessCidrs: ["0.0.0.0/0"]
+      privateAccessCidrs: ["10.0.0.3/16"]
       publicAccessCidrs: []
       publicAccess: false
+    vpcId: vpc-0123456789abcdef0
+    subnetIds:
+      - subnet-0123456789abcdef0
+      - subnet-0123456789abcdef1
+      - subnet-0123456789abcdef2
     nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
     nodePoolsLaunchKind: both
     nodePools:
       - ami:
           id: ami-01234567890123456
           owner: "123456789012"
-        type: self-managed
+        type: eks-managed
         instance:
           type: t3.large
         name: worker-eks
@@ -62,7 +54,6 @@ spec:
         - name: a-configmap
           files:
             - /path/to/config.example
-          type: Opaque
         - name: b-configmap
           envs:
             - /path/to/envs.env
@@ -91,7 +82,6 @@ spec:
         - name: b-secret
           envs:
             - /path/to/envs.env
-          type: Opaque
     common:
       provider:
         type: eks


### PR DESCRIPTION
This PR adds support for choosing the Amazon Linux OS version of the default EKS AMI for both the `self-managed` and `eks-managed` node groups introduced into eks installer v3.2.0.

# Changelog
- update eks-installer to v3.2.0
- update eks schema introducing the property `nodePoolGlobalAmiType` into `Spec.Kubernetes`
- update eks schema docs for the property `nodePoolGlobalAmiType`
- update the furyctl config template introducing the property `nodePoolGlobalAmiType`
- update the kubernetes terraform template introducing the new variable present in eks-installer v3.2.0
- fix config template for infra nodes tags
- fix bats test to be compatible with the new `nodepool.type` required property

# Breaking changes

Due to json-schema validation, if a node pool has no type, the `if-then` condition will not be evaluated correctly. To fix it, I had to set the property `type` of nodepool as required.

# Checklist for Testing 🧪

- [x] Create a cluster with v1.29.4 and the `furyctl.yaml`

```yaml
---
apiVersion: kfd.sighup.io/v1alpha2
kind: EKSCluster
metadata:
  name: fury-on-eks
spec:
  distributionVersion: v1.29.4
  toolsConfiguration:
    terraform:
      state:
        s3:
          bucketName: BUCKET_NAME
          keyPrefix: fury-on-eks
          region: eu-west-1
  region: eu-west-1
  tags:
    env: "dev"
    k8s: "fury-on-eks"
  infrastructure:
    vpc:
      network:
        cidr: 10.1.0.0/16
        subnetsCidrs:
          private:
            - 10.1.0.0/20
            - 10.1.16.0/20
            - 10.1.32.0/20
          public:
            - 10.1.48.0/24
            - 10.1.49.0/24
            - 10.1.50.0/24
  kubernetes:
    nodeAllowedSshPublicKey: "ssh-ed25519 XYZ"
    nodePoolsLaunchKind: "launch_templates"
    apiServer:
      privateAccess: false
      publicAccess: true
      privateAccessCidrs: ['0.0.0.0/0']
      publicAccessCidrs: ['0.0.0.0/0']
    nodePools:
      - name: infra
        size:
          min: 1
          max: 3
        instance:
          type: t3.xlarge
          spot: false
          volumeSize: 50
          volumeType: gp2
        labels:
          nodepool: infra
          node.kubernetes.io/role: infra
        taints:
          - node.kubernetes.io/role=infra:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
      - name: worker
        size:
          min: 1
          max: 1
        instance:
          type: t3.medium
          spot: false
          volumeSize: 50
          volumeType: gp2
        labels:
          nodepool: worker
          node.kubernetes.io/role: worker
        taints:
          - node.kubernetes.io/role=worker:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
      - name: managed-worker
        type: eks-managed
        size:
          min: 1
          max: 1
        instance:
          type: t3.medium
          spot: false
          volumeSize: 50
          volumeType: gp2
        labels:
          nodepool: managed-worker
          node.kubernetes.io/role: managed-worker
        taints:
          - node.kubernetes.io/role=managed-worker:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "managed-worker"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "managed-worker"
    awsAuth: {}
  distribution:
    common:
      nodeSelector:
        node.kubernetes.io/role: infra
      tolerations:
        - effect: NoSchedule
          key: node.kubernetes.io/role
          value: infra
    modules:
      ingress:
        baseDomain: internal.example.dev
        nginx:
          type: dual
          tls:
            provider: certManager
        certManager:
          clusterIssuer:
            name: letsencrypt-fury
            email: example@sighup.io
            type: http01
        dns:
          public:
            name: "example.dev"
            create: true
          private:
            name: "internal.example.dev"
            create: true
      logging:
        type: loki
        minio:
          storageSize: "20Gi"
      monitoring:
        type: "prometheus"
      tracing:
        type: tempo
        minio:
          storageSize: "20Gi"
      policy:
        type: gatekeeper
        gatekeeper:
          additionalExcludedNamespaces: []
          installDefaultPolicies: true
          enforcementAction: deny
      dr:
        type: eks
        velero:
          eks:
            bucketName: example-velero
            region: eu-west-1
      auth:
        provider:
          type: none
        baseDomain: example.dev
```
- [x] update the `furyctl.yaml` as shown below
```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/feat/support-eks-installer-3-2-0/schemas/public/ekscluster-kfd-v1alpha2.json
---
apiVersion: kfd.sighup.io/v1alpha2
kind: EKSCluster
metadata:
  name: fury-on-eks
spec:
  distributionVersion: v1.29.4
  toolsConfiguration:
    terraform:
      state:
        s3:
          bucketName: BUCKET_NAME
          keyPrefix: fury-on-eks
          region: eu-west-1
  region: eu-west-1
  tags:
    env: "dev"
    k8s: "fury-on-eks"
  infrastructure:
    vpc:
      network:
        cidr: 10.1.0.0/16
        subnetsCidrs:
          private:
            - 10.1.0.0/20
            - 10.1.16.0/20
            - 10.1.32.0/20
          public:
            - 10.1.48.0/24
            - 10.1.49.0/24
            - 10.1.50.0/24
  kubernetes:
    nodeAllowedSshPublicKey: "ssh-ed25519 XYZ"
    nodePoolsLaunchKind: "launch_templates"
    nodePoolGlobalAmiType: "alinux2"
    apiServer:
      privateAccess: false
      publicAccess: true
      privateAccessCidrs: ['0.0.0.0/0']
      publicAccessCidrs: ['0.0.0.0/0']
        nodePools:
      - name: infra
        type: self-managed
        size:
          min: 1
          max: 3
        instance:
          type: t3.xlarge
          spot: false
          volumeSize: 50
          volumeType: gp2
        labels:
          nodepool: infra
          node.kubernetes.io/role: infra
        taints:
          - node.kubernetes.io/role=infra:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "infra"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "infra"
      - name: worker
        type: self-managed
        size:
          min: 1
          max: 1
        instance:
          type: t3.medium
          spot: false
          volumeSize: 50
          volumeType: gp2
        labels:
          nodepool: worker
          node.kubernetes.io/role: worker
        taints:
          - node.kubernetes.io/role=worker:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
      - name: managed-worker
        type: eks-managed
        size:
          min: 1
          max: 1
        instance:
          type: t3.medium
          spot: false
          volumeSize: 50
          volumeType: gp2
        labels:
          nodepool: managed-worker
          node.kubernetes.io/role: managed-worker
        taints:
          - node.kubernetes.io/role=managed-worker:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "managed-worker"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "managed-worker"
      - name: worker-alinux2
        type: self-managed
        size:
          min: 1
          max: 1
        instance:
          type: t3.medium
          spot: false
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2
        labels:
          nodepool: worker-alinux2
          node.kubernetes.io/role: worker-alinux2
        taints:
          - node.kubernetes.io/role=worker-alinux2:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker-alinux2"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker-alinux2"
      - name: worker-alinux2023
        type: self-managed
        size:
          min: 1
          max: 1
        instance:
          type: t3.medium
          spot: false
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2023
        labels:
          nodepool: worker-alinux2023
          node.kubernetes.io/role: worker-alinux2023
        taints:
          - node.kubernetes.io/role=worker-alinux2023:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker-alinux2023"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker-alinux2023"
      - name: worker-customami
        type: self-managed
        size:
          min: 1
          max: 1
        instance:
          type: t4g.medium
          spot: false
          volumeSize: 50
          volumeType: gp2
        ami:
          id: ami-0460bcf8e9927a1df # amazon-eks-node-al2023-arm64-standard-1.29-v20240514
          owner: amazon
        labels:
          nodepool: worker-customami
          node.kubernetes.io/role: worker-customami
        taints:
          - node.kubernetes.io/role=worker-customami:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker-customami"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker-customami"
      - name: worker-arm64-alinux2
        type: self-managed
        size:
          min: 1
          max: 1
        instance:
          type: t4g.medium
          spot: false
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2
        labels:
          nodepool: worker-arm64-alinux2
          node.kubernetes.io/role: worker-arm64-alinux2
        taints:
          - node.kubernetes.io/role=worker-arm64-alinux2:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker-arm64-alinux2"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker-arm64-alinux2"
      - name: worker-arm64-alinux2023
        type: self-managed
        size:
          min: 1
          max: 1
        instance:
          type: t4g.medium
          spot: false
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2023
        labels:
          nodepool: worker-arm64-alinux2023
          node.kubernetes.io/role: worker-arm64-alinux2023
        taints:
          - node.kubernetes.io/role=worker-arm64-alinux2023:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker-arm64-alinux2023"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker-arm64-alinux2023"
      - name: worker-alinux2-spot
        type: self-managed
        size:
          min: 1
          max: 1
        instance:
          type: t3.small
          spot: true
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2
        labels:
          nodepool: worker-alinux2-spot
          node.kubernetes.io/role: worker-alinux2-spot
        taints:
          - node.kubernetes.io/role=worker-alinux2-spot:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker-alinux2-spot"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker-alinux2-spot"
      - name: worker-alinux2023-spot
        type: self-managed
        size:
          min: 1
          max: 1
        instance:
          type: t3.small
          spot: true
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2023
        labels:
          nodepool: worker-alinux2023-spot
          node.kubernetes.io/role: worker-alinux2023-spot
        taints:
          - node.kubernetes.io/role=worker-alinux2023-spot:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker-alinux2023-spot"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker-alinux2023-spot"
      - name: worker-arm64-alinux2-spot
        type: self-managed
        size:
          min: 1
          max: 1
        instance:
          type: t4g.small
          spot: true
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2
        labels:
          nodepool: worker-arm64-alinux2-spot
          node.kubernetes.io/role: worker-arm64-alinux2-spot
        taints:
          - node.kubernetes.io/role=worker-arm64-alinux2-spot:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker-arm64-alinux2-spot"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker-arm64-alinux2-spot"
      - name: worker-arm64-alinux2023-spot
        type: self-managed
        size:
          min: 1
          max: 1
        instance:
          type: t4g.small
          spot: true
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2023
        labels:
          nodepool: worker-arm64-alinux2023-spot
          node.kubernetes.io/role: worker-arm64-alinux2023-spot
        taints:
          - node.kubernetes.io/role=worker-arm64-alinux2023-spot:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker-arm64-alinux2023-spot"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker-arm64-alinux2023-spot"
      - name: managed-worker-alinux2
        type: eks-managed
        size:
          min: 1
          max: 1
        instance:
          type: t3.medium
          spot: false
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2
        labels:
          nodepool: managed-worker-alinux2
          node.kubernetes.io/role: managed-worker-alinux2
        taints:
          - node.kubernetes.io/role=managed-worker-alinux2:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "managed-worker-alinux2"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "managed-worker-alinux2"
      - name: managed-worker-alinux2023
        type: eks-managed
        size:
          min: 1
          max: 1
        instance:
          type: t3.medium
          spot: false
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2023
        labels:
          nodepool: managed-worker-alinux2023
          node.kubernetes.io/role: managed-worker-alinux2023
        taints:
          - node.kubernetes.io/role=managed-worker-alinux2023:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "managed-worker-alinux2023"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "managed-worker-alinux2023"
      - name: managed-worker-arm64-alinux2
        type: eks-managed
        size:
          min: 1
          max: 1
        instance:
          type: t4g.medium
          spot: false
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2
        labels:
          nodepool: managed-worker-arm64-alinux2
          node.kubernetes.io/role: managed-worker-arm64-alinux2
        taints:
          - node.kubernetes.io/role=managed-worker-arm64-alinux2:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "managed-worker-arm64-alinux2"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "managed-worker-arm64-alinux2"
      - name: managed-worker-arm64-alinux2023
        type: eks-managed
        size:
          min: 1
          max: 1
        instance:
          type: t4g.medium
          spot: false
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2023
        labels:
          nodepool: managed-worker-arm64-alinux2023
          node.kubernetes.io/role: managed-worker-arm64-alinux2023
        taints:
          - node.kubernetes.io/role=managed-worker-arm64-alinux2023:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "managed-worker-arm64-alinux2023"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "managed-worker-arm64-alinux2023"
      - name: managed-worker-alinux2-spot
        type: eks-managed
        size:
          min: 1
          max: 1
        instance:
          type: t3.small
          spot: true
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2
        labels:
          nodepool: managed-worker-alinux2-spot
          node.kubernetes.io/role: managed-worker-alinux2-spot
        taints:
          - node.kubernetes.io/role=managed-worker-alinux2-spot:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "managed-worker-alinux2-spot"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "managed-worker-alinux2-spot"
      - name: managed-worker-alinux2023-spot
        type: eks-managed
        size:
          min: 1
          max: 1
        instance:
          type: t3.small
          spot: true
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2023
        labels:
          nodepool: managed-worker-alinux2023-spot
          node.kubernetes.io/role: managed-worker-alinux2023-spot
        taints:
          - node.kubernetes.io/role=managed-worker-alinux2023-spot:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "managed-worker-alinux2023-spot"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "managed-worker-alinux2023-spot"
      - name: managed-worker-arm64-alinux2-spot
        type: eks-managed
        size:
          min: 1
          max: 1
        instance:
          type: t4g.small
          spot: true
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2
        labels:
          nodepool: managed-worker-arm64-alinux2-spot
          node.kubernetes.io/role: managed-worker-arm64-alinux2-spot
        taints:
          - node.kubernetes.io/role=managed-worker-arm64-alinux2-spot:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "managed-worker-arm64-alinux2-spot"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "managed-worker-arm64-alinux2-spot"
      - name: managed-worker-arm64-alinux2023-spot
        type: eks-managed
        size:
          min: 1
          max: 1
        instance:
          type: t4g.small
          spot: true
          volumeSize: 50
          volumeType: gp2
        ami:
          type: alinux2023
        labels:
          nodepool: managed-worker-arm64-alinux2023-spot
          node.kubernetes.io/role: managed-worker-arm64-alinux2023-spot
        taints:
          - node.kubernetes.io/role=managed-worker-arm64-alinux2023-spot:NoSchedule
        tags:
          k8s.io/cluster-autoscaler/node-template/label/nodepool: "managed-worker-arm64-alinux2023-spot"
          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "managed-worker-arm64-alinux2023-spot"
#      - name: managed-worker-customami
#        type: eks-managed
#        size:
#          min: 1
#          max: 1
#        instance:
#          type: t4g.medium
#          spot: false
#          volumeSize: 50
#          volumeType: gp2
#        ami:
#          id: ami-0460bcf8e9927a1df #amazon-eks-node-al2023-arm64-standard-1.29-v20240514
#          owner: amazon
#        labels:
#          nodepool: managed-worker-customami
#          node.kubernetes.io/role: managed-worker-customami
#        taints:
#          - node.kubernetes.io/role=managed-worker-customami:NoSchedule
#        tags:
#          k8s.io/cluster-autoscaler/node-template/label/nodepool: "managed-worker-customami"
#          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "managed-worker-customami"
    awsAuth: {}
  distribution:
    common:
      nodeSelector:
        node.kubernetes.io/role: infra
      tolerations:
        - effect: NoSchedule
          key: node.kubernetes.io/role
          value: infra
    modules:
      ingress:
        baseDomain: internal.example.dev
        nginx:
          type: dual
          tls:
            provider: certManager
        certManager:
          clusterIssuer:
            name: letsencrypt-fury
            email: example@sighup.io
            type: http01
        dns:
          public:
            name: "example.dev"
            create: true
          private:
            name: "internal.example.dev"
            create: true
      logging:
        type: loki
        minio:
          storageSize: "20Gi"
      monitoring:
        type: "prometheus"
      tracing:
        type: tempo
        minio:
          storageSize: "20Gi"
      policy:
        type: gatekeeper
        gatekeeper:
          additionalExcludedNamespaces: []
          installDefaultPolicies: true
          enforcementAction: deny
      dr:
        type: eks
        velero:
          eks:
            bucketName: example-velero
            region: eu-west-1
      auth:
        provider:
          type: none
        baseDomain: example.dev

```
- [x] update the cluster using the `furyctl apply --distro-location CURRENT_BRANCH_FOLDER`