### PR TITLE
feat(monitoring): update to monitoring v3.3.0-rc.1

### DIFF
--- a/kfd.yaml
+++ b/kfd.yaml
@@ -9,8 +9,8 @@ modules:
   dr: v2.3.0
   ingress: v2.3.3
   logging: v3.4.1
-  opa: v1.13.0
   monitoring: v3.3.0-rc.1
+  opa: v1.13.0
   networking: v1.17.0
   tracing: v1.1.0
 kubernetes:

--- a/kfd.yaml
+++ b/kfd.yaml
@@ -9,8 +9,8 @@ modules:
   dr: v2.3.0
   ingress: v2.3.3
   logging: v3.4.1
-  monitoring: v3.2.0
   opa: v1.12.0
+  monitoring: v3.3.0-rc.1
   networking: v1.17.0
   tracing: v1.1.0
 kubernetes:

--- a/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/ingress-infra.yml.tpl
@@ -177,7 +177,7 @@ spec:
                   number: 80
             {{ else }}
               service:
-                name: minio-tracing-console
+                name: minio-monitoring-console
                 port:
                   name: http
             {{ end }}

--- a/templates/distribution/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml.tpl
@@ -30,9 +30,7 @@ spec:
   probeSelector: {}
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
-  scrapeConfigSelector:
-    matchLabels:
-      prometheus: k8s
+  scrapeConfigSelector: {}
 
   {{- $prometheusAgentArgs := dict "module" "monitoring" "package" "prometheusAgent" "spec" .spec }}
   tolerations:


### PR DESCRIPTION
- Update kfd.yaml to use monitoring v3.3.0-rc1.
- Update templates to align the scrapeConfigs to what has been done in the monitoring module. We pick all of them instead of selecting an specific label.
- No other changes are necessary. Upgrade does not need special steps to follow other than the usual apply of the new manifests.


Bonus:
- Fix a bug on minio-monitoring ingress template. Ingress was pointing to the service of minio-tracing instead of monitoring. Fixes #308 