### PR TITLE
Feat(networking): update networking to v2.0.0 rc

### DIFF
--- a/kfd.yaml
+++ b/kfd.yaml
@@ -11,7 +11,7 @@ modules:
   logging: v3.4.1
   monitoring: v3.2.0
   opa: v1.13.0
-  networking: v1.17.0
+  networking: v2.0.0-rc.1
   tracing: v1.1.0
 kubernetes:
   eks:


### PR DESCRIPTION
This PR updates the networking module to v2.0.0-rc.1 version.

There are no changes on the template or the distribution, just applying the new version will work. It's a major version because we removed calico manifests only package from the module (not used by the distribution itself).

### Checklist

Cilium:
- [x] Tested upgrade from fury-distribution 1.29.4 to 1.30.0 with v2.0.0-rc.1 networking package
- [x] Tested cilium and hubble

Calico:
- [x] Tested installation on a 1.30 cluster with the new tigera operator version