### PR TITLE
feat(auth): bump to v0.4.0-rc.0

### DIFF
--- a/kfd.yaml
+++ b/kfd.yaml
@@ -4,7 +4,7 @@
 
 version: v1.30.0
 modules:
-  auth: v0.3.0
+  auth: v0.4.0.rc.0
   aws: v4.2.1
   dr: v3.0.0-rc.1
   ingress: v3.0.1-rc.1


### PR DESCRIPTION
- bump Auth module to `v0.4.0-rc.0`

No other changes are necessary to switch to this version, no migrations or upgrade paths are necessary.