### PR TITLE
fix(netpols): minio-monitoring ingress and opensearch jobs

### DIFF
--- a/docs/network-policies/modules/logging/README.md
+++ b/docs/network-policies/modules/logging/README.md
@@ -1,15 +1,18 @@
 # Logging Module Network Policies
 
 ## Components
+
 - OpenSearch Stack
 - Loki Stack
 
 ## Namespaces
+
 - logging
 
 ## Network Policies List
 
 ### Common Policies
+
 - deny-all
 - all-egress-kube-dns
 - event-tailer-egress-kube-apiserver
@@ -20,6 +23,7 @@
 - logging-operator-egress-kube-apiserver
 
 ### OpenSearch Stack
+
 - fluentd-ingress-fluentbit
 - fluentd-ingress-prometheus-metrics
 - opensearch-discovery
@@ -31,8 +35,10 @@
 - opensearch-dashboards-ingress-nginx
 - opensearch-dashboards-ingress-jobs
 - jobs-egress-opensearch
+- jobs-egress-opensearch-dashboards
 
 ### Loki Stack
+
 - loki-distributed-ingress-fluentd
 - loki-distributed-ingress-grafana
 - loki-distributed-ingress-prometheus-metrics
@@ -40,6 +46,7 @@
 - loki-distributed-egress-all
 
 ### MinIO
+
 - minio-ingress-namespace
 - minio-buckets-setup-egress-kube-apiserver
 - minio-buckets-setup-egress-minio
@@ -48,6 +55,6 @@
 - minio-egress-https
 
 ## Configurations
+
 - [OpenSearch Stack](opensearch.md)
 - [Loki Stack](loki.md)
-

--- a/templates/distribution/manifests/auth/policies/pomerium.yaml.tpl
+++ b/templates/distribution/manifests/auth/policies/pomerium.yaml.tpl
@@ -24,7 +24,11 @@ spec:
             kubernetes.io/metadata.name: ingress-nginx
         podSelector:
           matchLabels:
+{{- if eq .spec.distribution.modules.ingress.nginx.type "dual" }}
+            app: ingress
+{{- else if eq .spec.distribution.modules.ingress.nginx.type "single" }}
             app: ingress-nginx
+{{- end }}
       ports:
         - port: 8080
           protocol: TCP

--- a/templates/distribution/manifests/logging/policies/opensearch-dashboards.yaml.tpl
+++ b/templates/distribution/manifests/logging/policies/opensearch-dashboards.yaml.tpl
@@ -47,9 +47,9 @@ spec:
   ingress:
     - from:
         - podSelector:
-            matchExpressions:
-              - key: batch.kubernetes.io/job-name
-                operator: Exists
+            matchLabels:
+              app.kubernetes.io/name: opensearch-dashboards
+              app.kubernetes.io/instance: opensearch-dashboards
       ports:
         - port: 5601
           protocol: TCP
@@ -91,4 +91,28 @@ spec:
         - port: 5601
           protocol: TCP
 ---
-
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: jobs-egress-opensearch-dashboards
+  namespace: logging
+  labels:
+    cluster.kfd.sighup.io/module: logging
+    cluster.kfd.sighup.io/logging-type: opensearch
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch-dashboards
+      app.kubernetes.io/instance: opensearch-dashboards
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: opensearch-dashboards
+              release: opensearch-dashboards
+      ports:
+        - port: 5601
+          protocol: TCP
+---

--- a/templates/distribution/manifests/logging/policies/opensearch.yaml.tpl
+++ b/templates/distribution/manifests/logging/policies/opensearch.yaml.tpl
@@ -136,9 +136,9 @@ spec:
   ingress:
     - from:
         - podSelector:
-            matchExpressions:
-              - key: batch.kubernetes.io/job-name
-                operator: Exists
+            matchLabels:
+              app.kubernetes.io/name: opensearch
+              app.kubernetes.io/instance: opensearch
       ports:
         - port: 9200
           protocol: TCP
@@ -155,18 +155,10 @@ spec:
   policyTypes:
     - Egress
   podSelector:
-    matchExpressions:
-      - key: batch.kubernetes.io/job-name
-        operator: Exists
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: opensearch
   egress:
-    - to:
-        - podSelector:
-            matchLabels:
-              app: opensearch-dashboards
-              release: opensearch-dashboards
-      ports:
-        - port: 5601
-          protocol: TCP
     - to:
         - podSelector:
             matchLabels:


### PR DESCRIPTION
- Add netpol for allowing traffic from ingresses to Minio Monitoring in single, dual and SSO.
- Use new labels for OpenSearch and OpenSearch-Dashboard job pods
- Update readme with this changes