### PR TITLE
chore(ci): trigger release pipeline only when needed

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -326,7 +326,7 @@ platform:
 trigger:
   ref:
     include:
-      - refs/tags/**
+      - refs/tags/v**
     exclude:
       - refs/tags/**-docs*
 
@@ -339,7 +339,7 @@ steps:
     when:
       ref:
         include:
-          - refs/tags/**
+          - refs/tags/v**
         exclude:
           - refs/tags/**-docs*
 


### PR DESCRIPTION
Trigger the release pipeline only when needed, i.e. when tagging with a tag starting with `v`.

Before, the release pipeline was always triggered when tagging, even when tagging to only run the e2e tests without wanting to do a release, so there may be no release notes available. In this case the CI could fail because it will not find the release notes file.