### PR TITLE
Feat/e2e-1.31.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,7 +59,7 @@ steps:
   #     - schema-check
 
   - name: test-schema
-    image: quay.io/sighup/e2e-testing:1.1.0_1.30.5_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:1.1.0_1.31.1_3.10.0_4.33.3
     pull: always
     depends_on:
       - license-check
@@ -72,7 +72,7 @@ steps:
       - bats -t tests/schema.sh
 
   - name: render
-    image: quay.io/sighup/e2e-testing:1.1.0_1.30.5_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:1.1.0_1.31.1_3.10.0_4.33.3
     pull: always
     depends_on:
       - license-check
@@ -80,7 +80,7 @@ steps:
     environment:
       NETRC_FILE:
         from_secret: NETRC_FILE
-      FURYCTL_VERSION: v0.30.0-rc.1
+      FURYCTL_VERSION: v0.31.0-rc.0
       FURYCTL_CONFIG: tests/e2e/kfddistribution/furyctl-init-cluster.yaml
       FURYCTL_DISTRO_LOCATION: ./
       FURYCTL_OUTDIR: ./
@@ -103,10 +103,10 @@ steps:
       - render
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect distribution.yml --ignore-deprecations --target-versions=k8s=v1.30.0
+      - /pluto detect distribution.yml --ignore-deprecations --target-versions=k8s=v1.31.0
 
 ---
-name: e2e-kubernetes-1.30
+name: e2e-kubernetes-1.31
 kind: pipeline
 type: docker
 
@@ -129,13 +129,13 @@ trigger:
 
 steps:
   - name: create Kind cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.30.5_3.10.0
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.31.1_3.10.0
     pull: always
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
     environment:
-      CLUSTER_VERSION: v1.30.6
+      CLUSTER_VERSION: v1.31.0
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
@@ -161,7 +161,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e-kfddistribution
-    image: quay.io/sighup/e2e-testing:1.1.0_1.30.5_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:1.1.0_1.31.1_3.10.0_4.33.3
     pull: always
     # we need to use host network to access Kind API port that is listening on the worker's loopback
     # beacuse we mount the host's Docker socket to run Kind.
@@ -169,7 +169,7 @@ steps:
     environment:
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}
       KUBECONFIG: /drone/src/kubeconfig
-      FURYCTL_VERSION: v0.30.0-rc.1
+      FURYCTL_VERSION: v0.31.0-rc.0
     depends_on: [create Kind cluster]
     commands:
       - export KUBECONFIG=/drone/src/kubeconfig
@@ -187,7 +187,7 @@ steps:
       - tests/e2e-kfddistribution.sh
 
   - name: delete-kind-cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.30.5_3.10.0
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.31.1_3.10.0
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
@@ -208,13 +208,13 @@ volumes:
     host:
       path: /var/run/docker.sock
 ---
-name: e2e-kubernetes-1.29.4-to-1.30.0
+name: e2e-kubernetes-1.30.0-to-1.31.0
 kind: pipeline
 type: docker
 
 depends_on:
   - qa
-  - e2e-kubernetes-1.30
+  - e2e-kubernetes-1.31
 
 clone:
   depth: 1
@@ -232,13 +232,13 @@ trigger:
 
 steps:
   - name: create Kind cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.30.5_3.10.0
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.31.1_3.10.0
     pull: always
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
     environment:
-      CLUSTER_VERSION: v1.30.6
+      CLUSTER_VERSION: v1.31.0
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-upgrades
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
@@ -264,7 +264,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e-kfddistribution
-    image: quay.io/sighup/e2e-testing:1.1.0_1.30.5_3.10.0_4.33.3
+    image: quay.io/sighup/e2e-testing:1.1.0_1.31.1_3.10.0_4.33.3
     pull: always
     # we need to use host network to access Kind API port that is listening on the worker's loopback
     # beacuse we mount the host's Docker socket to run Kind.
@@ -272,7 +272,7 @@ steps:
     environment:
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-upgrades
       KUBECONFIG: /drone/src/kubeconfig-upgrades
-      FURYCTL_VERSION: v0.30.0-rc.1
+      FURYCTL_VERSION: v0.31.0-rc.0
     depends_on: [create Kind cluster]
     commands:
       - export KUBECONFIG=/drone/src/kubeconfig-upgrades
@@ -290,7 +290,7 @@ steps:
       - tests/e2e-kfddistribution-upgrades.sh
 
   - name: delete-kind-cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.30.5_3.10.0
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.31.1_3.10.0
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
@@ -316,8 +316,8 @@ kind: pipeline
 type: docker
 
 depends_on:
-  - e2e-kubernetes-1.30
-  - e2e-kubernetes-1.29.4-to-1.30.0
+  - e2e-kubernetes-1.31
+  - e2e-kubernetes-1.30.0-to-1.31.0
 
 platform:
   os: linux

--- a/.drone.yml
+++ b/.drone.yml
@@ -214,7 +214,8 @@ type: docker
 
 depends_on:
   - qa
-  - e2e-kubernetes-1.31
+  #  I comment out the following dependency because we have now 2 workers, so we can run both pipelines in paralel.
+  # - e2e-kubernetes-1.31
 
 clone:
   depth: 1

--- a/tests/e2e-kfddistribution-upgrades.sh
+++ b/tests/e2e-kfddistribution-upgrades.sh
@@ -6,12 +6,9 @@
 set -e
 
 echo "----------------------------------------------------------------------------"
-echo "Executing furyctl for the initial setup 1.29.4"
-/tmp/furyctl apply --config tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.29.4.yaml --outdir "$PWD" --disable-analytics
+echo "Executing furyctl for the initial setup 1.30.0"
+/tmp/furyctl apply --config tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.30.0.yaml --outdir "$PWD" --disable-analytics
 
 echo "----------------------------------------------------------------------------"
-echo "Executing upgrade to 1.30.0"
-# we set the switch date for Loki to "tomorrow". Notice that `-d flag` does not work on Darwin, you need to use `-v +1d` instead.
-# this is needed only when upgrading from 1.29.4 to 1.30.0 (and equivalent versions)
-yq -i ".spec.distribution.modules.logging.loki.tsdbStartDate=\"$(date -I -d '+1 day')\"" tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.30.0.yaml
-/tmp/furyctl apply --upgrade --config tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.30.0.yaml --outdir "$PWD" --distro-location ./ --force upgrades --disable-analytics
+echo "Executing upgrade to 1.31.0"
+/tmp/furyctl apply --upgrade --config tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.31.0.yaml --outdir "$PWD" --distro-location ./ --force upgrades --disable-analytics

--- a/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.30.0.yaml
+++ b/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.30.0.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.30.0/schemas/public/kfddistribution-kfd-v1alpha2.json
 ---
 apiVersion: kfd.sighup.io/v1alpha2
 kind: KFDDistribution
@@ -33,7 +33,7 @@ spec:
       logging:
         type: loki
         loki:
-          tsdbStartDate: "2024-11-28" # this should be a day in the future when upgrading
+          tsdbStartDate: "2024-12-18"
         minio:
           storageSize: 20Gi
           rootUser:

--- a/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.31.0.yaml
+++ b/tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.31.0.yaml
@@ -1,14 +1,14 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-
+# yaml-language-server: $schema=../../../schemas/public/kfddistribution-kfd-v1alpha2.json
 ---
 apiVersion: kfd.sighup.io/v1alpha2
 kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.29.4
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
@@ -32,6 +32,8 @@ spec:
             type: http01
       logging:
         type: loki
+        loki:
+          tsdbStartDate: "2024-12-18"
         minio:
           storageSize: 20Gi
           rootUser:
@@ -52,7 +54,7 @@ spec:
         type: kyverno
         kyverno:
           additionalExcludedNamespaces: ["local-path-storage"]
-          validationFailureAction: enforce
+          validationFailureAction: Enforce
           installDefaultPolicies: true
       dr:
         type: on-premises

--- a/tests/e2e/kfddistribution/furyctl-10-migrate-from-none-to-safe-values.yaml
+++ b/tests/e2e/kfddistribution/furyctl-10-migrate-from-none-to-safe-values.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"

--- a/tests/e2e/kfddistribution/furyctl-11-migrate-from-kyverno-default-policies-to-disabled.yaml
+++ b/tests/e2e/kfddistribution/furyctl-11-migrate-from-kyverno-default-policies-to-disabled.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"

--- a/tests/e2e/kfddistribution/furyctl-12-migrate-from-alertmanagerconfigs-to-disabled.yaml
+++ b/tests/e2e/kfddistribution/furyctl-12-migrate-from-alertmanagerconfigs-to-disabled.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"

--- a/tests/e2e/kfddistribution/furyctl-2-migrate-from-tempo-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-2-migrate-from-tempo-to-none.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"

--- a/tests/e2e/kfddistribution/furyctl-3-migrate-from-kyverno-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-3-migrate-from-kyverno-to-none.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"

--- a/tests/e2e/kfddistribution/furyctl-4-migrate-from-velero-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-4-migrate-from-velero-to-none.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"

--- a/tests/e2e/kfddistribution/furyctl-5-migrate-from-loki-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-5-migrate-from-loki-to-none.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"

--- a/tests/e2e/kfddistribution/furyctl-6-migrate-from-mimir-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-6-migrate-from-mimir-to-none.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"

--- a/tests/e2e/kfddistribution/furyctl-7-migrate-from-basicAuth-to-sso.yaml
+++ b/tests/e2e/kfddistribution/furyctl-7-migrate-from-basicAuth-to-sso.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"

--- a/tests/e2e/kfddistribution/furyctl-8-migrate-from-sso-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-8-migrate-from-sso-to-none.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"

--- a/tests/e2e/kfddistribution/furyctl-9-migrate-from-nginx-to-none.yaml
+++ b/tests/e2e/kfddistribution/furyctl-9-migrate-from-nginx-to-none.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"

--- a/tests/e2e/kfddistribution/furyctl-cleanup-all.yaml
+++ b/tests/e2e/kfddistribution/furyctl-cleanup-all.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"
@@ -16,7 +16,7 @@ spec:
     common: {}
     # This section contains all the configurations for all the KFD core modules
     modules:
-      networking: 
+      networking:
         type: calico
       # This section contains all the configurations for the ingress module
       ingress:
@@ -44,4 +44,3 @@ spec:
       auth:
         provider:
           type: none
-      

--- a/tests/e2e/kfddistribution/furyctl-init-cluster.yaml
+++ b/tests/e2e/kfddistribution/furyctl-init-cluster.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"

--- a/tests/e2e/kfddistribution/furyctl-init-with-values-from-nil.yaml
+++ b/tests/e2e/kfddistribution/furyctl-init-with-values-from-nil.yaml
@@ -8,7 +8,7 @@ kind: KFDDistribution
 metadata:
   name: sighup
 spec:
-  distributionVersion: v1.30.0
+  distributionVersion: v1.31.0
   # This section describes how the KFD distribution will be installed
   distribution:
     kubeconfig: "{env://KUBECONFIG}"


### PR DESCRIPTION
- Update all e2e to use v1.31.0 (to be released) and test migration from 1.30.0
- Bump furyctl to `v0.31.0-rc.0`
- Tagged `v1.31.0-rc.0`, e2e are passing: https://ci.sighup.io/sighupio/fury-distribution/2588 (the release step fails because there are no release notes)