### PR TITLE
fix(migrations/policy): delete objects before crds

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -25,6 +25,7 @@ The distribution is maintained with ❤️ by the team [SIGHUP](https://sighup.i
 ## Fixes 🐞
 
 - [[#334](https://github.com/sighupio/fury-distribution/pull/334)] **Fix to policy module templates**: setting the policy module type to `gatekeeper` and the `additionalExcludedNamespaces` option for Kyverno at the same time resulted in an error do to an bug in the templates logic, this has been fixed.
+- [[#336](https://github.com/sighupio/fury-distribution/pull/336)] **Fix race condition when deleting Kyverno**: changing the policy module type from `kyverno` to `none` could, sometimes, end up in a race condition where the API for ClusterPolicy CRD is unregistered before the deletion of the ClusterPolicy objects, resulting in an error in the deletion command execution. The deletion command has been tweaked to avoid this condition.
 
 ## Upgrade procedure
 

--- a/templates/distribution/scripts/pre-apply.sh.tpl
+++ b/templates/distribution/scripts/pre-apply.sh.tpl
@@ -189,7 +189,8 @@ deleteGatekeeper() {
 }
 
 deleteKyverno() {
-  $kustomizebin build $vendorPath/modules/opa/katalog/kyverno | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/opa/katalog/kyverno/policies | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
+  $kustomizebin build $vendorPath/modules/opa/katalog/kyverno/core | $kubectlbin delete --ignore-not-found --wait --timeout=180s -f -
   $kubectlbin delete --ignore-not-found --wait --timeout=180s validatingwebhookconfiguration -l webhook.kyverno.io/managed-by=kyverno
   $kubectlbin delete --ignore-not-found --wait --timeout=180s mutatingwebhookconfiguration -l webhook.kyverno.io/managed-by=kyverno
   $kubectlbin delete --ignore-not-found --wait --timeout=180s -A networkpolicy -l cluster.kfd.sighup.io/policy-type=kyverno


### PR DESCRIPTION
### Summary 💡

<!-- Write a short summary of the changes that this PR introduces and the motivations -->

When switching policy type from `kyverno` to `none`, delete first the objects using the APIs of the CRDs and then the CRDs. Otherwise we could sometimes end up in a race condition where the objects cannot be deleted because the APIs are not available anymore.

<!--
If there's an existing issue for your change, please link to it below inserting a link or the issue number.
If there's _not_ an existing issue, please open one first if the problem you are solving needs to be clearly identified,
for example is an error message that other users could get and google it.
-->
Closes #335

### Description 📝

<!--
Let us know what you are changing. Share anything that could provide the most context.
Feel free to add screenshots, code examples, the Description could end up in the release notes to help users adopt
the new feature or changes that you are introducing.

Expand on the reasoning behind some decision that you could have made to help reviewers understand the diff in the PR.

-->

Instead of building the whole kustomize base for Kyverno and piping it to the kubectl delete, the command that deletes Kyverno resources has been split into 2 commands that are applied separately, one after the other: `policies` and `core`, respectively.

See the issue #335 for more details on the reasoning behind this PR.

### Breaking Changes 💔

None

### Tests performed 🧪

- [X] Tested the change with KFD version v1.31.0.
- [x] Tested migrating from kyverno to none several times, the race condition did not present again.
- [x] Tested migration with `installDefaultPolicies` set to `false`


### Future work 🔧

None, notice that now that we switched to kapp, the migration could be dropped entirely and let kapp handle the deletion.