### PR TITLE
feat(on-prem): support etcd cluster provisioning on dedicated nodes

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -22,6 +22,10 @@ The distribution is maintained with ❤️ by the team [SIGHUP](https://sighup.i
 
 - [[#355](https://github.com/sighupio/fury-distribution/pull/355)] **Support for etcd cluster on dedicated nodes**: adding support for deploying etcd on dedicated nodes instead of control plane nodes to the OnPremises provider. For the new clusters, users can define specific hosts for etcd, each with a name and IP. If the etcd key is omitted, etcd will be provisioned on control plane nodes. No migration paths are supported.
 
+To make use of this new feature, you need to define the hosts where etcd will be deployed in your configuration file using the `.spec.kubernetes.etcd` key, for example:
+
+
+
   ```yaml
   ...
   spec:

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -20,7 +20,7 @@ The distribution is maintained with ❤️ by the team [SIGHUP](https://sighup.i
 
 ## New features 🌟
 
-- TBD
+- [[#355](https://github.com/sighupio/fury-distribution/pull/355)] **Support for etcd cluster on dedicated nodes**: adding support for deploying etcd on dedicated nodes instead of control plane nodes on the OnPremises provider.
 
 ## Fixes 🐞
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -20,7 +20,35 @@ The distribution is maintained with ❤️ by the team [SIGHUP](https://sighup.i
 
 ## New features 🌟
 
-- [[#355](https://github.com/sighupio/fury-distribution/pull/355)] **Support for etcd cluster on dedicated nodes**: adding support for deploying etcd on dedicated nodes instead of control plane nodes on the OnPremises provider.
+- [[#355](https://github.com/sighupio/fury-distribution/pull/355)] **Support for etcd cluster on dedicated nodes**: adding support for deploying etcd on dedicated nodes instead of control plane nodes to the OnPremises provider. For the new clusters, users can define specific hosts for etcd, each with a name and IP. If the etcd key is omitted, etcd will be provisioned on control plane nodes. No migration paths are supported.
+
+  ```yaml
+  ...
+  spec:
+    kubernetes:
+      masters:
+        hosts:
+          - name: master1
+            ip: 192.168.66.29
+          - name: master2
+            ip: 192.168.66.30
+          - name: master3
+            ip: 192.168.66.31
+      etcd:
+        hosts:
+          - name: etcd1
+            ip: 192.168.66.39
+          - name: etcd2
+            ip: 192.168.66.40
+          - name: etcd3
+            ip: 192.168.66.41
+      nodes:
+        - name: worker
+          hosts:
+            - name: worker1
+              ip: 192.168.66.49
+  ...
+  ```
 
 ## Fixes 🐞
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -4500,6 +4500,7 @@ Defines which KFD version will be installed and, in consequence, the Kubernetes 
 | [advancedAnsible](#speckubernetesadvancedansible)         | `object` | Optional |
 | [controlPlaneAddress](#speckubernetescontrolplaneaddress) | `string` | Required |
 | [dnsZone](#speckubernetesdnszone)                         | `string` | Required |
+| [etcd](#speckubernetesetcd)                               | `object` | Optional |
 | [loadBalancers](#speckubernetesloadbalancers)             | `object` | Required |
 | [masters](#speckubernetesmasters)                         | `object` | Required |
 | [nodes](#speckubernetesnodes)                             | `array`  | Required |
@@ -4900,6 +4901,47 @@ The address for the Kubernetes control plane. Usually a DNS entry pointing to a 
 ### Description
 
 The DNS zone of the machines. It will be appended to the name of each host to generate the `kubernetes_hostname` in the Ansible inventory file. It is also used to calculate etcd's initial cluster value.
+
+## .spec.kubernetes.etcd
+
+### Properties
+
+| Property                          | Type    | Required |
+|:----------------------------------|:--------|:---------|
+| [hosts](#speckubernetesetcdhosts) | `array` | Required |
+
+### Description
+
+Optional configuration for an etcd cluster on dedicated nodes. If omitted, etcd will run on control plane nodes.
+
+## .spec.kubernetes.etcd.hosts
+
+### Properties
+
+| Property                             | Type     | Required |
+|:-------------------------------------|:---------|:---------|
+| [ip](#speckubernetesetcdhostsip)     | `string` | Required |
+| [name](#speckubernetesetcdhostsname) | `string` | Required |
+
+### Description
+
+List of nodes of the dedicated etcd cluster.
+
+### Constraints
+
+**minimum number of items**: the minimum number of items for this array is: `1`
+
+## .spec.kubernetes.etcd.hosts.ip
+
+### Description
+
+The IP address of the etcd node.
+
+## .spec.kubernetes.etcd.hosts.name
+
+### Description
+
+A name to identify the etcd node. This value will be concatenated to `.spec.kubernetes.dnsZone` to calculate the FQDN for the host as `<name>.<dnsZone>`.
 
 ## .spec.kubernetes.loadBalancers
 

--- a/kfd.yaml
+++ b/kfd.yaml
@@ -19,7 +19,7 @@ kubernetes:
     installer: v3.2.0
   onpremises:
     version: 1.31.4
-    installer: v1.31.4
+    installer: v1.32.0-rc.0
 furyctlSchemas:
   eks:
     - apiVersion: kfd.sighup.io/v1alpha2

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -1199,71 +1199,60 @@ type SpecDistributionModulesMonitoringMimirExternalEndpoint struct {
 	SecretAccessKey *string `json:"secretAccessKey,omitempty" yaml:"secretAccessKey,omitempty" mapstructure:"secretAccessKey,omitempty"`
 }
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesTracingType) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_SpecDistributionModulesTracingType {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesTracingType, v)
-	}
-	*j = SpecDistributionModulesTracingType(v)
-	return nil
+// Configuration for Monitoring's MinIO deployment.
+type SpecDistributionModulesMonitoringMinio struct {
+	// Overrides corresponds to the JSON schema field "overrides".
+	Overrides *TypesFuryModuleComponentOverrides `json:"overrides,omitempty" yaml:"overrides,omitempty" mapstructure:"overrides,omitempty"`
+
+	// RootUser corresponds to the JSON schema field "rootUser".
+	RootUser *SpecDistributionModulesMonitoringMinioRootUser `json:"rootUser,omitempty" yaml:"rootUser,omitempty" mapstructure:"rootUser,omitempty"`
+
+	// The PVC size for each MinIO disk, 6 disks total.
+	StorageSize *string `json:"storageSize,omitempty" yaml:"storageSize,omitempty" mapstructure:"storageSize,omitempty"`
+}
+
+type SpecDistributionModulesMonitoringMinioRootUser struct {
+	// The password for the default MinIO root user.
+	Password *string `json:"password,omitempty" yaml:"password,omitempty" mapstructure:"password,omitempty"`
+
+	// The username for the default MinIO root user.
+	Username *string `json:"username,omitempty" yaml:"username,omitempty" mapstructure:"username,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesIngress) UnmarshalJSON(b []byte) error {
+func (j *SpecDistributionModulesTracing) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
-	if v, ok := raw["baseDomain"]; !ok || v == nil {
-		return fmt.Errorf("field baseDomain in SpecDistributionModulesIngress: required")
+	if v, ok := raw["type"]; !ok || v == nil {
+		return fmt.Errorf("field type in SpecDistributionModulesTracing: required")
 	}
-	if v, ok := raw["nginx"]; !ok || v == nil {
-		return fmt.Errorf("field nginx in SpecDistributionModulesIngress: required")
-	}
-	type Plain SpecDistributionModulesIngress
+	type Plain SpecDistributionModulesTracing
 	var plain Plain
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	*j = SpecDistributionModulesIngress(plain)
+	*j = SpecDistributionModulesTracing(plain)
 	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesIngressNginxType) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+func (j *SpecDistributionModulesIngressNginx) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
-	var ok bool
-	for _, expected := range enumValues_SpecDistributionModulesIngressNginxType {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
+	if v, ok := raw["type"]; !ok || v == nil {
+		return fmt.Errorf("field type in SpecDistributionModulesIngressNginx: required")
 	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesIngressNginxType, v)
+	type Plain SpecDistributionModulesIngressNginx
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
 	}
-	*j = SpecDistributionModulesIngressNginxType(v)
+	*j = SpecDistributionModulesIngressNginx(plain)
 	return nil
-}
-
-var enumValues_SpecDistributionModulesIngressNginxType = []interface{}{
-	"none",
-	"single",
-	"dual",
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -1306,20 +1295,22 @@ func (j *SpecDistributionModulesLoggingCustomOutputs) UnmarshalJSON(b []byte) er
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesIngressNginxTLS) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+func (j *SpecDistributionModulesIngressNginxType) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
-	if v, ok := raw["provider"]; !ok || v == nil {
-		return fmt.Errorf("field provider in SpecDistributionModulesIngressNginxTLS: required")
+	var ok bool
+	for _, expected := range enumValues_SpecDistributionModulesIngressNginxType {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
 	}
-	type Plain SpecDistributionModulesIngressNginxTLS
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesIngressNginxType, v)
 	}
-	*j = SpecDistributionModulesIngressNginxTLS(plain)
+	*j = SpecDistributionModulesIngressNginxType(v)
 	return nil
 }
 
@@ -1348,6 +1339,30 @@ func (j *SpecDistributionModulesLoggingLokiBackend) UnmarshalJSON(b []byte) erro
 	return nil
 }
 
+var enumValues_SpecDistributionModulesIngressNginxType = []interface{}{
+	"none",
+	"single",
+	"dual",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SpecDistributionModulesIngressNginxTLS) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["provider"]; !ok || v == nil {
+		return fmt.Errorf("field provider in SpecDistributionModulesIngressNginxTLS: required")
+	}
+	type Plain SpecDistributionModulesIngressNginxTLS
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = SpecDistributionModulesIngressNginxTLS(plain)
+	return nil
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *SpecDistributionModulesIngressNginxTLSSecret) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
@@ -1370,32 +1385,6 @@ func (j *SpecDistributionModulesIngressNginxTLSSecret) UnmarshalJSON(b []byte) e
 	}
 	*j = SpecDistributionModulesIngressNginxTLSSecret(plain)
 	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesIngressNginxTLSProvider) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_SpecDistributionModulesIngressNginxTLSProvider {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesIngressNginxTLSProvider, v)
-	}
-	*j = SpecDistributionModulesIngressNginxTLSProvider(v)
-	return nil
-}
-
-var enumValues_SpecDistributionModulesIngressNginxTLSProvider = []interface{}{
-	"certManager",
-	"secret",
-	"none",
 }
 
 type TypesKubeResourcesLimits struct {
@@ -1423,20 +1412,22 @@ type TypesKubeResources struct {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesIngressCertManager) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+func (j *SpecDistributionModulesIngressNginxTLSProvider) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
-	if v, ok := raw["clusterIssuer"]; !ok || v == nil {
-		return fmt.Errorf("field clusterIssuer in SpecDistributionModulesIngressCertManager: required")
+	var ok bool
+	for _, expected := range enumValues_SpecDistributionModulesIngressNginxTLSProvider {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
 	}
-	type Plain SpecDistributionModulesIngressCertManager
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesIngressNginxTLSProvider, v)
 	}
-	*j = SpecDistributionModulesIngressCertManager(plain)
+	*j = SpecDistributionModulesIngressNginxTLSProvider(v)
 	return nil
 }
 
@@ -1455,6 +1446,30 @@ func (j *SpecDistributionModulesLoggingLoki) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	*j = SpecDistributionModulesLoggingLoki(plain)
+	return nil
+}
+
+var enumValues_SpecDistributionModulesIngressNginxTLSProvider = []interface{}{
+	"certManager",
+	"secret",
+	"none",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SpecDistributionModulesIngressCertManager) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["clusterIssuer"]; !ok || v == nil {
+		return fmt.Errorf("field clusterIssuer in SpecDistributionModulesIngressCertManager: required")
+	}
+	type Plain SpecDistributionModulesIngressCertManager
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = SpecDistributionModulesIngressCertManager(plain)
 	return nil
 }
 
@@ -1477,30 +1492,6 @@ func (j *SpecDistributionModulesIngressCertManagerClusterIssuer) UnmarshalJSON(b
 	}
 	*j = SpecDistributionModulesIngressCertManagerClusterIssuer(plain)
 	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesIngressCertManagerClusterIssuerType) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_SpecDistributionModulesIngressCertManagerClusterIssuerType {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesIngressCertManagerClusterIssuerType, v)
-	}
-	*j = SpecDistributionModulesIngressCertManagerClusterIssuerType(v)
-	return nil
-}
-
-var enumValues_SpecDistributionModulesIngressCertManagerClusterIssuerType = []interface{}{
-	"http01",
 }
 
 var enumValues_SpecDistributionModulesLoggingOpensearchType = []interface{}{
@@ -1529,6 +1520,30 @@ func (j *SpecDistributionModulesLoggingOpensearchType) UnmarshalJSON(b []byte) e
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
+func (j *SpecDistributionModulesIngressCertManagerClusterIssuerType) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_SpecDistributionModulesIngressCertManagerClusterIssuerType {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesIngressCertManagerClusterIssuerType, v)
+	}
+	*j = SpecDistributionModulesIngressCertManagerClusterIssuerType(v)
+	return nil
+}
+
+var enumValues_SpecDistributionModulesIngressCertManagerClusterIssuerType = []interface{}{
+	"http01",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
 func (j *SpecDistributionModulesDr) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(b, &raw); err != nil {
@@ -1543,6 +1558,24 @@ func (j *SpecDistributionModulesDr) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	*j = SpecDistributionModulesDr(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SpecDistributionModulesLoggingOpensearch) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["type"]; !ok || v == nil {
+		return fmt.Errorf("field type in SpecDistributionModulesLoggingOpensearch: required")
+	}
+	type Plain SpecDistributionModulesLoggingOpensearch
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = SpecDistributionModulesLoggingOpensearch(plain)
 	return nil
 }
 
@@ -1569,49 +1602,6 @@ func (j *SpecDistributionModulesDrVeleroBackend) UnmarshalJSON(b []byte) error {
 var enumValues_SpecDistributionModulesDrVeleroBackend = []interface{}{
 	"minio",
 	"externalEndpoint",
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesLoggingOpensearch) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["type"]; !ok || v == nil {
-		return fmt.Errorf("field type in SpecDistributionModulesLoggingOpensearch: required")
-	}
-	type Plain SpecDistributionModulesLoggingOpensearch
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = SpecDistributionModulesLoggingOpensearch(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesDrType) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_SpecDistributionModulesDrType {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesDrType, v)
-	}
-	*j = SpecDistributionModulesDrType(v)
-	return nil
-}
-
-var enumValues_SpecDistributionModulesDrType = []interface{}{
-	"none",
-	"on-premises",
 }
 
 var enumValues_SpecDistributionModulesLoggingType = []interface{}{
@@ -1641,6 +1631,31 @@ func (j *SpecDistributionModulesLoggingType) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SpecDistributionModulesDrType) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_SpecDistributionModulesDrType {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesDrType, v)
+	}
+	*j = SpecDistributionModulesDrType(v)
+	return nil
+}
+
+var enumValues_SpecDistributionModulesDrType = []interface{}{
+	"none",
+	"on-premises",
+}
+
 // Override the common configuration with a particular configuration for the
 // module.
 type TypesFuryModuleOverrides struct {
@@ -1666,6 +1681,24 @@ type TypesFuryModuleOverridesIngress struct {
 
 	// Use this ingress class for the ingress instead of the default one.
 	IngressClass *string `json:"ingressClass,omitempty" yaml:"ingressClass,omitempty" mapstructure:"ingressClass,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SpecDistributionModulesLogging) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["type"]; !ok || v == nil {
+		return fmt.Errorf("field type in SpecDistributionModulesLogging: required")
+	}
+	type Plain SpecDistributionModulesLogging
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = SpecDistributionModulesLogging(plain)
+	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -1701,24 +1734,6 @@ func (j *SpecDistributionModulesAuthProvider) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	*j = SpecDistributionModulesAuthProvider(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesLogging) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["type"]; !ok || v == nil {
-		return fmt.Errorf("field type in SpecDistributionModulesLogging: required")
-	}
-	type Plain SpecDistributionModulesLogging
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = SpecDistributionModulesLogging(plain)
 	return nil
 }
 
@@ -1769,6 +1784,31 @@ func (j *SpecDistributionModulesAuthProviderBasicAuth) UnmarshalJSON(b []byte) e
 	return nil
 }
 
+var enumValues_SpecDistributionModulesMonitoringMimirBackend = []interface{}{
+	"minio",
+	"externalEndpoint",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SpecDistributionModulesMonitoringMimirBackend) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_SpecDistributionModulesMonitoringMimirBackend {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesMonitoringMimirBackend, v)
+	}
+	*j = SpecDistributionModulesMonitoringMimirBackend(v)
+	return nil
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *SpecDistributionModulesAuthOverridesIngress) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
@@ -1805,31 +1845,6 @@ func (j *SpecDistributionModulesAuthOIDCKubernetesAuth) UnmarshalJSON(b []byte) 
 		return err
 	}
 	*j = SpecDistributionModulesAuthOIDCKubernetesAuth(plain)
-	return nil
-}
-
-var enumValues_SpecDistributionModulesMonitoringMimirBackend = []interface{}{
-	"minio",
-	"externalEndpoint",
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesMonitoringMimirBackend) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_SpecDistributionModulesMonitoringMimirBackend {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesMonitoringMimirBackend, v)
-	}
-	*j = SpecDistributionModulesMonitoringMimirBackend(v)
 	return nil
 }
 
@@ -1895,26 +1910,6 @@ func (j *SpecDistributionCustomPatchesSecretGeneratorResourceBehavior) Unmarshal
 	}
 	*j = SpecDistributionCustomPatchesSecretGeneratorResourceBehavior(v)
 	return nil
-}
-
-type SpecDistributionModulesMonitoringMinioRootUser struct {
-	// The password for the default MinIO root user.
-	Password *string `json:"password,omitempty" yaml:"password,omitempty" mapstructure:"password,omitempty"`
-
-	// The username for the default MinIO root user.
-	Username *string `json:"username,omitempty" yaml:"username,omitempty" mapstructure:"username,omitempty"`
-}
-
-// Configuration for Monitoring's MinIO deployment.
-type SpecDistributionModulesMonitoringMinio struct {
-	// Overrides corresponds to the JSON schema field "overrides".
-	Overrides *TypesFuryModuleComponentOverrides `json:"overrides,omitempty" yaml:"overrides,omitempty" mapstructure:"overrides,omitempty"`
-
-	// RootUser corresponds to the JSON schema field "rootUser".
-	RootUser *SpecDistributionModulesMonitoringMinioRootUser `json:"rootUser,omitempty" yaml:"rootUser,omitempty" mapstructure:"rootUser,omitempty"`
-
-	// The PVC size for each MinIO disk, 6 disks total.
-	StorageSize *string `json:"storageSize,omitempty" yaml:"storageSize,omitempty" mapstructure:"storageSize,omitempty"`
 }
 
 type SpecDistributionModulesMonitoringPrometheusRemoteWriteElem map[string]interface{}
@@ -2421,20 +2416,22 @@ var enumValues_SpecDistributionModulesTracingType = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesIngressNginx) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+func (j *SpecDistributionModulesTracingType) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
-	if v, ok := raw["type"]; !ok || v == nil {
-		return fmt.Errorf("field type in SpecDistributionModulesIngressNginx: required")
+	var ok bool
+	for _, expected := range enumValues_SpecDistributionModulesTracingType {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
 	}
-	type Plain SpecDistributionModulesIngressNginx
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SpecDistributionModulesTracingType, v)
 	}
-	*j = SpecDistributionModulesIngressNginx(plain)
+	*j = SpecDistributionModulesTracingType(v)
 	return nil
 }
 
@@ -2462,20 +2459,23 @@ type SpecDistributionModulesTracing struct {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SpecDistributionModulesTracing) UnmarshalJSON(b []byte) error {
+func (j *SpecDistributionModulesIngress) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
-	if v, ok := raw["type"]; !ok || v == nil {
-		return fmt.Errorf("field type in SpecDistributionModulesTracing: required")
+	if v, ok := raw["baseDomain"]; !ok || v == nil {
+		return fmt.Errorf("field baseDomain in SpecDistributionModulesIngress: required")
 	}
-	type Plain SpecDistributionModulesTracing
+	if v, ok := raw["nginx"]; !ok || v == nil {
+		return fmt.Errorf("field nginx in SpecDistributionModulesIngress: required")
+	}
+	type Plain SpecDistributionModulesIngress
 	var plain Plain
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	*j = SpecDistributionModulesTracing(plain)
+	*j = SpecDistributionModulesIngress(plain)
 	return nil
 }
 
@@ -2815,6 +2815,65 @@ type SpecKubernetesAdvancedAnsible struct {
 
 	// The Python interpreter to use for running Ansible. Example: python3
 	PythonInterpreter *string `json:"pythonInterpreter,omitempty" yaml:"pythonInterpreter,omitempty" mapstructure:"pythonInterpreter,omitempty"`
+}
+
+type SpecKubernetesEtcdHost struct {
+	// The IP address of the etcd node.
+	Ip string `json:"ip" yaml:"ip" mapstructure:"ip"`
+
+	// A name to identify the etcd node. This value will be concatenated to
+	// `.spec.kubernetes.dnsZone` to calculate the FQDN for the host as
+	// `<name>.<dnsZone>`.
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SpecKubernetesEtcdHost) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["ip"]; !ok || v == nil {
+		return fmt.Errorf("field ip in SpecKubernetesEtcdHost: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name in SpecKubernetesEtcdHost: required")
+	}
+	type Plain SpecKubernetesEtcdHost
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = SpecKubernetesEtcdHost(plain)
+	return nil
+}
+
+// Optional configuration for an etcd cluster on dedicated nodes. If omitted, etcd
+// will run on control plane nodes.
+type SpecKubernetesEtcd struct {
+	// List of nodes of the dedicated etcd cluster.
+	Hosts []SpecKubernetesEtcdHost `json:"hosts" yaml:"hosts" mapstructure:"hosts"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SpecKubernetesEtcd) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hosts"]; !ok || v == nil {
+		return fmt.Errorf("field hosts in SpecKubernetesEtcd: required")
+	}
+	type Plain SpecKubernetesEtcd
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	if plain.Hosts != nil && len(plain.Hosts) < 1 {
+		return fmt.Errorf("field %s length: must be >= %d", "hosts", 1)
+	}
+	*j = SpecKubernetesEtcd(plain)
+	return nil
 }
 
 type SpecKubernetesLoadBalancersHost struct {
@@ -3241,6 +3300,9 @@ type SpecKubernetes struct {
 	// generate the `kubernetes_hostname` in the Ansible inventory file. It is also
 	// used to calculate etcd's initial cluster value.
 	DnsZone string `json:"dnsZone" yaml:"dnsZone" mapstructure:"dnsZone"`
+
+	// Etcd corresponds to the JSON schema field "etcd".
+	Etcd *SpecKubernetesEtcd `json:"etcd,omitempty" yaml:"etcd,omitempty" mapstructure:"etcd,omitempty"`
 
 	// LoadBalancers corresponds to the JSON schema field "loadBalancers".
 	LoadBalancers SpecKubernetesLoadBalancers `json:"loadBalancers" yaml:"loadBalancers" mapstructure:"loadBalancers"`

--- a/rules/onpremises-kfd-v1alpha2.yaml
+++ b/rules/onpremises-kfd-v1alpha2.yaml
@@ -14,6 +14,10 @@ kubernetes:
     immutable: true
   - path: .spec.kubernetes.etcd
     immutable: true
+  - path: .spec.kubernetes.etcd.hosts.*
+    immutable: true
+  - path: .spec.kubernetes.masters.hosts.*
+    immutable: true
 distribution:
   - path: .spec.distribution.common.networkPoliciesEnabled
     immutable: false

--- a/rules/onpremises-kfd-v1alpha2.yaml
+++ b/rules/onpremises-kfd-v1alpha2.yaml
@@ -12,6 +12,8 @@ kubernetes:
     immutable: true
   - path: .spec.kubernetes.svcCidr
     immutable: true
+  - path: .spec.kubernetes.etcd
+    immutable: true
 distribution:
   - path: .spec.distribution.common.networkPoliciesEnabled
     immutable: false

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -104,6 +104,9 @@
         "masters": {
           "$ref": "#/$defs/Spec.Kubernetes.Masters"
         },
+        "etcd": {
+          "$ref": "#/$defs/Spec.Kubernetes.Etcd"
+        },
         "nodes": {
           "$ref": "#/$defs/Spec.Kubernetes.Nodes"
         },
@@ -324,6 +327,40 @@
         "ip": {
           "type": "string",
           "description": "The IP address of the host"
+        }
+      },
+      "required": [
+        "name",
+        "ip"
+      ]
+    },
+    "Spec.Kubernetes.Etcd": {
+      "type": "object",
+      "description": "Optional configuration for an etcd cluster on dedicated nodes. If omitted, etcd will run on control plane nodes.",
+      "additionalProperties": false,
+      "properties": {
+        "hosts": {
+          "type": "array",
+          "description": "List of nodes of the dedicated etcd cluster.",
+          "items": {
+            "$ref": "#/$defs/Spec.Kubernetes.Etcd.Host"
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["hosts"]
+    },
+    "Spec.Kubernetes.Etcd.Host": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "A name to identify the etcd node. This value will be concatenated to `.spec.kubernetes.dnsZone` to calculate the FQDN for the host as `<name>.<dnsZone>`."
+        },
+        "ip": {
+          "type": "string",
+          "description": "The IP address of the etcd node."
         }
       },
       "required": [

--- a/templates/kubernetes/onpremises/54.upgrade-etcd.yaml.tpl
+++ b/templates/kubernetes/onpremises/54.upgrade-etcd.yaml.tpl
@@ -4,36 +4,24 @@
 
 ---
 - name: Upgrade etcd
-  {{ if index $.spec.kubernetes "etcd" -}}
-  hosts: etcd
-  {{- else -}}
-  hosts: master
-  {{- end }}
+  hosts: master,etcd
   serial: 1
   become: true
   vars:
     etcd_address: "{{ "{{ ansible_host }}" }}"
-    {{- if index $.spec.kubernetes "etcd" }}
-    etcd_client_address: "{{ "{{ ansible_host }}" }}"
-    {{- end }}
   roles:
     - etcd
   tags:
     - kubeadm-upgrade
 
 - name: Etcd certificates renewal
-  {{ if index $.spec.kubernetes "etcd" -}}
-  hosts: etcd
-  {{- else -}}
-  hosts: master
-  {{- end }}
+  hosts: master,etcd
   vars:
     etcd_certs:
       - etcd/ca.crt
       - apiserver-etcd-client.crt
       - apiserver-etcd-client.key
   tasks:
-
     - name: Renewing etcd certificates
       command: "{{ print "{{ item }}" }}"
       loop:
@@ -41,21 +29,14 @@
         - "kubeadm certs renew --cert-dir=/etc/etcd/pki etcd-healthcheck-client --config=/etc/etcd/kubeadm-etcd.yml"
         - "kubeadm certs renew --cert-dir=/etc/etcd/pki etcd-peer --config=/etc/etcd/kubeadm-etcd.yml"
         - "kubeadm certs renew --cert-dir=/etc/etcd/pki etcd-server --config=/etc/etcd/kubeadm-etcd.yml"
-
     - name: Restarting etcd service
       systemd:
         name: etcd
         daemon_reload: yes
         state: restarted
 
-{{ if index $.spec.kubernetes "etcd" -}}
-
 - name: Distribute etcd certificates from etcd to control plane nodes
-  {{ if index $.spec.kubernetes "etcd" -}}
   hosts: etcd
-  {{- else -}}
-  hosts: master
-  {{- end }}
   become: true
   vars:
     etcd_certs:
@@ -71,7 +52,6 @@
       path: /tmp/etcd-certs
       state: directory
       mode: '0755'
-
   - name: Fetching certificates from etcd
     run_once: true
     fetch:
@@ -80,7 +60,6 @@
       flat: yes
     delegate_to: "{{ "{{ groups['etcd'][0] }}" }}"
     with_items: "{{ "{{ etcd_certs }}" }}"
-
   - name: Copy certificates from localhost to control plane nodes
     delegate_to: "{{ "{{ master }}" }}"
     copy:
@@ -95,7 +74,6 @@
     vars:
       master: "{{ "{{ item[0] }}" }}"
       cert: "{{ "{{ item[1] }}" }}"
-
   - name: Clean up temporary certificates on localhost
     run_once: true
     become: false
@@ -104,12 +82,10 @@
       path: /tmp/etcd-certs
       state: absent
 
-- name: Etcd node preparation and kubeadm package upgrade
+- name: Kubeadm package upgrade on etcd nodes
   become: true
   hosts: etcd
   roles:
     - kube-node-common
   tags:
     - kube-node-common
-
-{{ end }}

--- a/templates/kubernetes/onpremises/54.upgrade-etcd.yaml.tpl
+++ b/templates/kubernetes/onpremises/54.upgrade-etcd.yaml.tpl
@@ -1,0 +1,115 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+- name: Upgrade etcd
+  {{ if index $.spec.kubernetes "etcd" -}}
+  hosts: etcd
+  {{- else -}}
+  hosts: master
+  {{- end }}
+  serial: 1
+  become: true
+  vars:
+    etcd_address: "{{ "{{ ansible_host }}" }}"
+    {{- if index $.spec.kubernetes "etcd" }}
+    etcd_client_address: "{{ "{{ ansible_host }}" }}"
+    {{- end }}
+  roles:
+    - etcd
+  tags:
+    - kubeadm-upgrade
+
+- name: Etcd certificates renewal
+  {{ if index $.spec.kubernetes "etcd" -}}
+  hosts: etcd
+  {{- else -}}
+  hosts: master
+  {{- end }}
+  vars:
+    etcd_certs:
+      - etcd/ca.crt
+      - apiserver-etcd-client.crt
+      - apiserver-etcd-client.key
+  tasks:
+
+    - name: Renewing etcd certificates
+      command: "{{ print "{{ item }}" }}"
+      loop:
+        - "kubeadm certs renew --cert-dir=/etc/etcd/pki apiserver-etcd-client --config=/etc/etcd/kubeadm-etcd.yml"
+        - "kubeadm certs renew --cert-dir=/etc/etcd/pki etcd-healthcheck-client --config=/etc/etcd/kubeadm-etcd.yml"
+        - "kubeadm certs renew --cert-dir=/etc/etcd/pki etcd-peer --config=/etc/etcd/kubeadm-etcd.yml"
+        - "kubeadm certs renew --cert-dir=/etc/etcd/pki etcd-server --config=/etc/etcd/kubeadm-etcd.yml"
+
+    - name: Restarting etcd service
+      systemd:
+        name: etcd
+        daemon_reload: yes
+        state: restarted
+
+{{ if index $.spec.kubernetes "etcd" -}}
+
+- name: Distribute etcd certificates from etcd to control plane nodes
+  {{ if index $.spec.kubernetes "etcd" -}}
+  hosts: etcd
+  {{- else -}}
+  hosts: master
+  {{- end }}
+  become: true
+  vars:
+    etcd_certs:
+      - etcd/ca.crt
+      - apiserver-etcd-client.crt
+      - apiserver-etcd-client.key
+  tasks:
+  - name: Ensuring temporary directory exists on localhost
+    run_once: true
+    delegate_to: localhost
+    become: false
+    file:
+      path: /tmp/etcd-certs
+      state: directory
+      mode: '0755'
+
+  - name: Fetching certificates from etcd
+    run_once: true
+    fetch:
+      src: "/etc/etcd/pki/{{ "{{ item }}" }}"
+      dest: "/tmp/etcd-certs/"
+      flat: yes
+    delegate_to: "{{ "{{ groups['etcd'][0] }}" }}"
+    with_items: "{{ "{{ etcd_certs }}" }}"
+
+  - name: Copy certificates from localhost to control plane nodes
+    delegate_to: "{{ "{{ master }}" }}"
+    copy:
+      src: "/tmp/etcd-certs/{{ "{{ cert | basename }}" }}"
+      dest: "/etc/etcd/pki/{{ "{{ cert }}" }}"
+      owner: root
+      group: root
+      mode: '0640'
+    loop: "{{ "{{ groups['master'] | product(etcd_certs) | list }}" }}"
+    loop_control:
+      loop_var: item
+    vars:
+      master: "{{ "{{ item[0] }}" }}"
+      cert: "{{ "{{ item[1] }}" }}"
+
+  - name: Clean up temporary certificates on localhost
+    run_once: true
+    become: false
+    delegate_to: localhost
+    file:
+      path: /tmp/etcd-certs
+      state: absent
+
+- name: Etcd node preparation and kubeadm package upgrade
+  become: true
+  hosts: etcd
+  roles:
+    - kube-node-common
+  tags:
+    - kube-node-common
+
+{{ end }}

--- a/templates/kubernetes/onpremises/54.upgrade-etcd.yaml.tpl
+++ b/templates/kubernetes/onpremises/54.upgrade-etcd.yaml.tpl
@@ -9,97 +9,19 @@
   become: true
   vars:
     etcd_address: "{{ "{{ ansible_host }}" }}"
+    etcd_upgrade: true
   roles:
     - etcd
   tags:
     - etcd
-
-- name: Etcd certificates renewal
-  hosts: master,etcd
-  vars:
-    etcd_certs:
-      - etcd/ca.crt
-      - apiserver-etcd-client.crt
-      - apiserver-etcd-client.key
-  tasks:
-    - name: Ensure rsync is installed
-      package:
-        name:
-          - rsync
-        state: latest
-
-    - name: Backup etcd certs
-      shell: |
-        BCK_FOLDER=$HOME/certs-backup/$(date +%Y-%m-%d_%H-%M-%S)
-        mkdir -p $BCK_FOLDER/etc-etcd-pki
-        rsync -av /etc/etcd/pki/ $BCK_FOLDER/etc-etcd-pki
-
-    - name: Renewing etcd certificates
-      command: "{{ print "{{ item }}" }}"
-      loop:
-        - "kubeadm certs renew --cert-dir=/etc/etcd/pki apiserver-etcd-client --config=/etc/etcd/kubeadm-etcd.yml"
-        - "kubeadm certs renew --cert-dir=/etc/etcd/pki etcd-healthcheck-client --config=/etc/etcd/kubeadm-etcd.yml"
-        - "kubeadm certs renew --cert-dir=/etc/etcd/pki etcd-peer --config=/etc/etcd/kubeadm-etcd.yml"
-        - "kubeadm certs renew --cert-dir=/etc/etcd/pki etcd-server --config=/etc/etcd/kubeadm-etcd.yml"
-
-    - name: Restarting etcd service
-      systemd:
-        name: etcd
-        daemon_reload: yes
-        state: restarted
-
-- name: Distribute etcd certificates from etcd to control plane nodes
-  hosts: etcd
-  become: true
-  vars:
-    etcd_certs:
-      - etcd/ca.crt
-      - apiserver-etcd-client.crt
-      - apiserver-etcd-client.key
-  tasks:
-    - name: Fetching certificates from etcd
-      run_once: true
-      delegate_to: "{{ print "{{ groups.etcd[0] }}" }}"
-      fetch:
-        src: "/etc/etcd/pki/{{ print "{{ item }}" }}"
-        dest: "/tmp/etcd-certs/"
-        flat: yes
-      with_items: "{{ print "{{ etcd_certs }}" }}"
-      when: not etcd_on_control_plane | bool
-
-    - name: Copying certificates to control plane nodes
-      run_once: true
-      copy:
-        src: "/tmp/etcd-certs/{{ print "{{ item[1] | basename }}" }}"
-        dest: "/etc/etcd/pki/{{ print "{{ item[1] }}" }}"
-        owner: root
-        group: root
-        mode: '0640'
-      loop: "{{ print "{{ groups['master'] | product(etcd_certs) | list }}" }}"
-      loop_control:
-        loop_var: item
-      vars:
-        master: "{{ print "{{ item[0] }}" }}"
-        cert: "{{ print "{{ item[1] }}" }}"
-      delegate_to: "{{ print "{{ item[0] }}" }}"
-      when: not etcd_on_control_plane | bool
-
-    - name: Cleaning up temporary certificates
-      run_once: true
-      become: false
-      delegate_to: localhost
-      file:
-        path: /tmp/etcd-certs
-        state: absent
-      when: not etcd_on_control_plane | bool
 
 - name: Kubeadm package upgrade on etcd nodes
   become: true
   hosts: etcd
   tasks:
     - name: Include kube-node-common role
-      include_role:
+      ansible.builtin.include_role:
         name: kube-node-common
-      when: not etcd_on_control_plane | bool
+      when: not etcd_on_control_plane
   tags:
     - kube-node-common

--- a/templates/kubernetes/onpremises/55.upgrade-control-plane.yml.tpl
+++ b/templates/kubernetes/onpremises/55.upgrade-control-plane.yml.tpl
@@ -3,15 +3,6 @@
 # license that can be found in the LICENSE file.
 
 ---
-- name: Upgrade etcd
-  hosts: master
-  serial: 1
-  become: true
-  roles:
-    - etcd
-  tags:
-    - kubeadm-upgrade
-
 - name: Control plane upgrade
   hosts: master
   serial: 1

--- a/templates/kubernetes/onpremises/create-playbook.yaml.tpl
+++ b/templates/kubernetes/onpremises/create-playbook.yaml.tpl
@@ -102,42 +102,6 @@
   tags:
     - etcd
 
-- name: Distribute etcd certificates on control plane nodes
-  hosts: master
-  become: true
-  vars:
-    etcd_certs:
-      - etcd/ca.crt
-      - apiserver-etcd-client.crt
-      - apiserver-etcd-client.key
-  tasks:
-    - name: Retrieving certificates from etcd nodes
-      run_once: true
-      delegate_to: "{{ print "{{ groups.etcd[0] }}" }}"
-      fetch:
-        src: "/etc/etcd/pki/{{ print "{{ item }}" }}"
-        dest: "/tmp/etcd-certs/"
-        flat: yes
-      with_items: "{{ print "{{ etcd_certs }}" }}"
-      when: not etcd_on_control_plane | bool
-    - name: Copying certificates to control plane nodes
-      copy:
-        src: "/tmp/etcd-certs/{{ print "{{ item | basename }}" }}"
-        dest: "/etc/etcd/pki/{{ print "{{ item }}" }}"
-        owner: root
-        group: root
-        mode: 0640
-      with_items: "{{ print "{{ etcd_certs }}" }}"
-      when: not etcd_on_control_plane | bool
-    - name: Cleaning up temporary certificates
-      run_once: true
-      become: false
-      delegate_to: localhost
-      file:
-        path: /tmp/etcd-certs
-        state: absent
-      when: not etcd_on_control_plane | bool
-
 - name: Control plane configuration
   hosts: master
   become: true

--- a/templates/kubernetes/onpremises/create-playbook.yaml.tpl
+++ b/templates/kubernetes/onpremises/create-playbook.yaml.tpl
@@ -119,7 +119,7 @@
         dest: "/tmp/etcd-certs/"
         flat: yes
       with_items: "{{ print "{{ etcd_certs }}" }}"
-      when: not etcd_on_control_plane
+      when: not etcd_on_control_plane | bool
     - name: Copying certificates to control plane nodes
       copy:
         src: "/tmp/etcd-certs/{{ print "{{ item | basename }}" }}"
@@ -128,7 +128,7 @@
         group: root
         mode: 0640
       with_items: "{{ print "{{ etcd_certs }}" }}"
-      when: not etcd_on_control_plane
+      when: not etcd_on_control_plane | bool
     - name: Cleaning up temporary certificates
       run_once: true
       become: false
@@ -136,7 +136,7 @@
       file:
         path: /tmp/etcd-certs
         state: absent
-      when: not etcd_on_control_plane
+      when: not etcd_on_control_plane | bool
 
 - name: Control plane configuration
   hosts: master

--- a/templates/kubernetes/onpremises/delete-playbook.yaml.tpl
+++ b/templates/kubernetes/onpremises/delete-playbook.yaml.tpl
@@ -40,7 +40,7 @@
         path: /etc/kubernetes/pki
         state: absent
   tags:
-    - reset-etcd-master
+    - reset-etcd-nodes
 
 - name: Reboot
   hosts: master,nodes,etcd

--- a/templates/kubernetes/onpremises/delete-playbook.yaml.tpl
+++ b/templates/kubernetes/onpremises/delete-playbook.yaml.tpl
@@ -19,8 +19,12 @@
   tags:
     - reset-k8s
 
-- name: Reset etcd master nodes
+- name: Reset etcd nodes
+  {{ if index $.spec.kubernetes "etcd" -}}
+  hosts: etcd
+  {{- else -}}
   hosts: master
+  {{- end }}
   become: true
   tasks:
     - name: Stop etcd
@@ -43,7 +47,11 @@
     - reset-etcd-master
 
 - name: Reboot
+  {{ if index $.spec.kubernetes "etcd" -}}
+  hosts: master,nodes,etcd
+  {{- else -}}
   hosts: master,nodes
+  {{- end }}
   become: true
   tasks:   
     - name: Reboot

--- a/templates/kubernetes/onpremises/delete-playbook.yaml.tpl
+++ b/templates/kubernetes/onpremises/delete-playbook.yaml.tpl
@@ -20,11 +20,7 @@
     - reset-k8s
 
 - name: Reset etcd nodes
-  {{ if index $.spec.kubernetes "etcd" -}}
   hosts: etcd
-  {{- else -}}
-  hosts: master
-  {{- end }}
   become: true
   tasks:
     - name: Stop etcd
@@ -47,11 +43,7 @@
     - reset-etcd-master
 
 - name: Reboot
-  {{ if index $.spec.kubernetes "etcd" -}}
   hosts: master,nodes,etcd
-  {{- else -}}
-  hosts: master,nodes
-  {{- end }}
   become: true
   tasks:   
     - name: Reboot

--- a/templates/kubernetes/onpremises/delete-playbook.yaml.tpl
+++ b/templates/kubernetes/onpremises/delete-playbook.yaml.tpl
@@ -20,13 +20,14 @@
     - reset-k8s
 
 - name: Reset etcd nodes
-  hosts: etcd
+  hosts: master,etcd
   become: true
   tasks:
     - name: Stop etcd
       systemd:
         name: etcd
         state: stopped
+      when: inventory_hostname in groups['etcd']
     - name: Clean etcd datadir
       file:
         path: /var/lib/etcd

--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -22,8 +22,10 @@ all:
       hosts:
         {{- $etcdInitialCluster := list }}
         {{- range $h := .spec.kubernetes.masters.hosts }}
+        {{- if not (index $.spec.kubernetes "etcd") }}
         {{- $etcdUri := print $h.name "=https://" $h.name "." $dnsZone ":2380" }}
         {{- $etcdInitialCluster = append $etcdInitialCluster $etcdUri }}
+        {{- end }}
         {{ $h.name }}:
           ansible_host: "{{ $h.ip }}"
           kubernetes_apiserver_advertise_address: "{{ $h.ip }}"
@@ -39,11 +41,38 @@ all:
         {{- end }}
       vars:
         dns_zone: "{{ $dnsZone }}"
+        {{- if not (index $.spec.kubernetes "etcd") }}
         etcd_initial_cluster: "{{ $etcdInitialCluster | join "," }}"
+        {{- end }}
         kubernetes_cluster_name: "{{ .metadata.name }}"
         kubernetes_control_plane_address: "{{ $controlPlaneAddress }}"
         kubernetes_pod_cidr: "{{ .spec.kubernetes.podCidr }}"
         kubernetes_svc_cidr: "{{ .spec.kubernetes.svcCidr }}"
+        {{- if index $.spec.kubernetes "etcd" }}
+        etcd_on_control_plane: False
+        etcd:
+          endpoints:
+            {{- range $h := .spec.kubernetes.etcd.hosts }}
+            - "https://{{ $h.name }}.{{ $dnsZone }}:2379"
+            {{- end }}
+          caFile: "/etc/etcd/pki/etcd/ca.crt"
+          keyFile: "/etc/etcd/pki/apiserver-etcd-client.key"
+          certFile: "/etc/etcd/pki/apiserver-etcd-client.crt"
+        {{- end }}
+    {{- if index $.spec.kubernetes "etcd" }}
+    etcd:
+      hosts:
+        {{- range $h := .spec.kubernetes.etcd.hosts }}
+        {{- $etcdUri := print $h.name "=https://" $h.name "." $dnsZone ":2380" }}
+        {{- $etcdInitialCluster = append $etcdInitialCluster $etcdUri }}
+        {{ $h.name }}:
+          ansible_host: "{{ $h.ip }}"
+          kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
+        {{- end }}
+      vars:
+        dns_zone: "{{ $dnsZone }}"
+        etcd_initial_cluster: "{{ $etcdInitialCluster | join "," }}"
+    {{- end }}
         {{- if and (index .spec.kubernetes "advanced") (index .spec.kubernetes.advanced "cloud") }}
         {{- if index .spec.kubernetes.advanced.cloud "provider" }}
         kubernetes_cloud_provider: "{{ .spec.kubernetes.advanced.cloud.provider }}"

--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -41,15 +41,14 @@ all:
         {{- end }}
       vars:
         dns_zone: "{{ $dnsZone }}"
-        {{- if not (index $.spec.kubernetes "etcd") }}
-        etcd_initial_cluster: "{{ $etcdInitialCluster | join "," }}"
-        {{- end }}
         kubernetes_cluster_name: "{{ .metadata.name }}"
         kubernetes_control_plane_address: "{{ $controlPlaneAddress }}"
         kubernetes_pod_cidr: "{{ .spec.kubernetes.podCidr }}"
         kubernetes_svc_cidr: "{{ .spec.kubernetes.svcCidr }}"
-        {{- if index $.spec.kubernetes "etcd" }}
-        etcd_on_control_plane: False
+        {{- if not (index $.spec.kubernetes "etcd") }}
+        etcd_initial_cluster: "{{ $etcdInitialCluster | join "," }}"
+        etcd_on_control_plane: True
+        {{- else }}
         etcd:
           endpoints:
             {{- range $h := .spec.kubernetes.etcd.hosts }}
@@ -58,21 +57,9 @@ all:
           caFile: "/etc/etcd/pki/etcd/ca.crt"
           keyFile: "/etc/etcd/pki/apiserver-etcd-client.key"
           certFile: "/etc/etcd/pki/apiserver-etcd-client.crt"
+        etcd_on_control_plane: False
         {{- end }}
-    {{- if index $.spec.kubernetes "etcd" }}
-    etcd:
-      hosts:
-        {{- range $h := .spec.kubernetes.etcd.hosts }}
-        {{- $etcdUri := print $h.name "=https://" $h.name "." $dnsZone ":2380" }}
-        {{- $etcdInitialCluster = append $etcdInitialCluster $etcdUri }}
-        {{ $h.name }}:
-          ansible_host: "{{ $h.ip }}"
-          kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
-        {{- end }}
-      vars:
-        dns_zone: "{{ $dnsZone }}"
-        etcd_initial_cluster: "{{ $etcdInitialCluster | join "," }}"
-    {{- end }}
+
         {{- if and (index .spec.kubernetes "advanced") (index .spec.kubernetes.advanced "cloud") }}
         {{- if index .spec.kubernetes.advanced.cloud "provider" }}
         kubernetes_cloud_provider: "{{ .spec.kubernetes.advanced.cloud.provider }}"
@@ -121,6 +108,29 @@ all:
         {{- if and (index .spec.kubernetes.advanced "registry") (ne .spec.kubernetes.advanced.registry "") }}
         kubernetes_image_registry: "{{ .spec.kubernetes.advanced.registry }}"
         {{- end }}
+        {{- end }}
+    etcd:
+      hosts:
+        {{- if index $.spec.kubernetes "etcd" }}
+        {{- range $h := .spec.kubernetes.etcd.hosts }}
+        {{- $etcdUri := print $h.name "=https://" $h.name "." $dnsZone ":2380" }}
+        {{- $etcdInitialCluster = append $etcdInitialCluster $etcdUri }}
+        {{ $h.name }}:
+          ansible_host: "{{ $h.ip }}"
+          kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
+          etcd_client_address: "{{ $h.ip }}"
+        {{- end }}
+      vars:
+        dns_zone: "{{ $dnsZone }}"
+        etcd_initial_cluster: "{{ $etcdInitialCluster | join "," }}"
+        {{- else }}
+        {{- range $h := .spec.kubernetes.masters.hosts }}
+        {{ $h.name }}:
+          ansible_host: "{{ $h.ip }}"
+          kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
+        {{- end }}
+      vars:
+        dns_zone: "{{ $dnsZone }}"
         {{- end }}
     nodes:
       children:

--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -47,7 +47,6 @@ all:
         kubernetes_svc_cidr: "{{ .spec.kubernetes.svcCidr }}"
         {{- if not (index $.spec.kubernetes "etcd") }}
         etcd_initial_cluster: "{{ $etcdInitialCluster | join "," }}"
-        etcd_on_control_plane: True
         {{- else }}
         etcd:
           endpoints:
@@ -57,7 +56,6 @@ all:
           caFile: "/etc/etcd/pki/etcd/ca.crt"
           keyFile: "/etc/etcd/pki/apiserver-etcd-client.key"
           certFile: "/etc/etcd/pki/apiserver-etcd-client.crt"
-        etcd_on_control_plane: False
         {{- end }}
 
         {{- if and (index .spec.kubernetes "advanced") (index .spec.kubernetes.advanced "cloud") }}
@@ -169,6 +167,11 @@ all:
     ansible_user: "{{ .spec.kubernetes.ssh.username }}"
     kubernetes_kubeconfig_path: ./
     kubernetes_version: "{{ .kubernetes.version }}"
+    {{- if not (index $.spec.kubernetes "etcd") }}
+    etcd_on_control_plane: True
+    {{- else }}
+    etcd_on_control_plane: False
+    {{- end }}
     {{- if (index .spec.kubernetes "proxy") }}
     http_proxy: "{{ .spec.kubernetes.proxy.http }}"
     https_proxy: "{{ .spec.kubernetes.proxy.https }}"

--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -168,9 +168,9 @@ all:
     kubernetes_kubeconfig_path: ./
     kubernetes_version: "{{ .kubernetes.version }}"
     {{- if not (index $.spec.kubernetes "etcd") }}
-    etcd_on_control_plane: True
+    etcd_on_control_plane: true
     {{- else }}
-    etcd_on_control_plane: False
+    etcd_on_control_plane: false
     {{- end }}
     {{- if (index .spec.kubernetes "proxy") }}
     http_proxy: "{{ .spec.kubernetes.proxy.http }}"

--- a/templates/preflight/onpremises/hosts.yaml.tpl
+++ b/templates/preflight/onpremises/hosts.yaml.tpl
@@ -47,7 +47,6 @@ all:
         kubernetes_svc_cidr: "{{ .spec.kubernetes.svcCidr }}"
         {{- if not (index $.spec.kubernetes "etcd") }}
         etcd_initial_cluster: "{{ $etcdInitialCluster | join "," }}"
-        etcd_on_control_plane: True
         {{- else }}
         etcd:
           endpoints:
@@ -57,7 +56,6 @@ all:
           caFile: "/etc/etcd/pki/etcd/ca.crt"
           keyFile: "/etc/etcd/pki/apiserver-etcd-client.key"
           certFile: "/etc/etcd/pki/apiserver-etcd-client.crt"
-        etcd_on_control_plane: False
         {{- end }}
 
         {{- if and (index .spec.kubernetes "advanced") (index .spec.kubernetes.advanced "cloud") }}
@@ -139,6 +137,11 @@ all:
     ansible_user: "{{ .spec.kubernetes.ssh.username }}"
     kubernetes_kubeconfig_path: ./
     kubernetes_version: "{{ .kubernetes.version }}"
+    {{- if not (index $.spec.kubernetes "etcd") }}
+    etcd_on_control_plane: True
+    {{- else }}
+    etcd_on_control_plane: False
+    {{- end }}
     {{- if index .spec.kubernetes "proxy" }}
     http_proxy: "{{ .spec.kubernetes.proxy.http }}"
     https_proxy: "{{ .spec.kubernetes.proxy.https }}"

--- a/templates/preflight/onpremises/hosts.yaml.tpl
+++ b/templates/preflight/onpremises/hosts.yaml.tpl
@@ -138,9 +138,9 @@ all:
     kubernetes_kubeconfig_path: ./
     kubernetes_version: "{{ .kubernetes.version }}"
     {{- if not (index $.spec.kubernetes "etcd") }}
-    etcd_on_control_plane: True
+    etcd_on_control_plane: true
     {{- else }}
-    etcd_on_control_plane: False
+    etcd_on_control_plane: false
     {{- end }}
     {{- if index .spec.kubernetes "proxy" }}
     http_proxy: "{{ .spec.kubernetes.proxy.http }}"


### PR DESCRIPTION
### Summary 💡  

This PR introduces support for a dedicated etcd cluster deployment on the OnPremises provider.  
The changes allow defining separate etcd nodes from the control plane (`master`) nodes. 

Closes: [#548](https://github.com/sighupio/product-management/issues/548)

Relates: [#116](https://github.com/sighupio/fury-kubernetes-on-premises/pull/116) [#146](https://github.com/sighupio/kfd-docs/pull/146) [#568](https://github.com/sighupio/furyctl/pull/568)

### Description 📝  

The main changes introduced in this PR:  

- Schema update (`onpremises-kfd-v1alpha2.md`, `schema.go`, `onpremises-kfd-v1alpha2.json`) to include the new `.spec.kubernetes.etcd` key.  This is optional.
- New Ansible playbook (`54.upgrade-etcd.yaml.tpl`) to centralize etcd nodes upgrade and certificates renewal.
- Updating the existing playbooks (`create-playbook.yaml.tpl`, `delete-playbook.yaml.tpl`, `upgrade-control-plane.yml.tpl`, `98.cluster-certificates-renewal.yaml.tpl`) to support etcd node deployment and reset.
- Update of inventory file (`hosts.yaml.tpl` for cluster and preflight) to include a separate etcd block when configured.  
- Remove etcd management from control plane nodes previously on `55.upgrade-control-plane.yml.tpl` to `54.upgrade-etcd.yaml.tpl`.  

### Example

- If the `.spec.kubernetes.etcd` key is present in the `furyctl.yaml`:

```yaml
spec:
  kubernetes:
    etcd:
      hosts:
        - name: etcd1
          ip: 192.168.56.50
        - name: etcd2
          ip: 192.168.56.51
        - name: etcd3
          ip: 192.168.56.52
```
user must specify at least 1 etcd host, and etcd will be deployed on dedicated nodes.

- If the `.spec.kubernetes.etcd` key is absent, `etcd` deployment will be provisioned on the control plane nodes and the behavior is unchanged.
- no migration path is supported, neither from control plane to dedicated etcd nodes, nor viceversa.

### Breaking Changes 💔 
 
This PR introduces a structural change in etcd management but maintains backward compatibility with existing configurations and has no breaking changes. 

### Tests performed 🧪  

Feature testing

- [x] Deploy a clean KFD 1.31.0 cluster running etcd on separate nodes.
- [x] Upgrade an existing KFD 1.30.1 cluster running etcd on separate nodes.
- [x] Check that certificates are correctly propagated to control plane nodes.
- [x] Check the certificates renewal command.

Regression testing

- [x] Deploy a new KFD 1.31.0 cluster with internal etcd on control plane nodes.
- [x] Upgrade an existing KFD 1.30.1 cluster to 1.31.0 running internal etcd on control plane nodes.
- [x] Deleting a KFD 1.31.0 cluster.

### Future work 🔧  

In this iteration making the etcd ports customizable as well is not a requirement, but this can be added in the future. 
