### PR TITLE
feat: add e2e tests for eks installer

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -375,7 +375,7 @@ steps:
     - mv furyctl /usr/local/bin
     - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
-    - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME-velero --recursive
+    - aws s3 rm s3://$CLUSTER_NAME-velero --recursive
     - aws s3api delete-bucket --bucket $CLUSTER_NAME-velero
 ---
 name: e2e-ekscluster-upgrades

--- a/.drone.yml
+++ b/.drone.yml
@@ -376,7 +376,7 @@ steps:
     - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
     - mv furyctl /usr/local/bin
     - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
-    - aws s3 rm s3://e2e-drone-eks/$env(CLUSTER_NAME) --recursive
+    - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
 
 ---
 name: e2e-ekscluster-upgrades
@@ -384,7 +384,7 @@ kind: pipeline
 type: docker
 
 depends_on:
-  - e2e-ekscluster
+  - qa
 
 clone:
   depth: 1

--- a/.drone.yml
+++ b/.drone.yml
@@ -344,6 +344,11 @@ steps:
       from_secret: aws_region
   commands:
     - apt-get install -y expect
+    - echo "Installing the correct furyctl version..."
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
+    # to use furyctl latest, use the following instead:
+    # - curl -L "https://github.com/sighupio/furyctl/releases/latest/download/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
+    - chmod +x /tmp/furyctl
     - ./tests/e2e/ekscluster/e2e-ekscluster.sh
 
 - name: cleanup
@@ -361,6 +366,12 @@ steps:
       from_secret: aws_region
   commands:
     - apt-get install -y expect
+    - apt-get install -y expect
+    - echo "Installing the correct furyctl version..."
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
+    # to use furyctl latest, use the following instead:
+    # - curl -L "https://github.com/sighupio/furyctl/releases/latest/download/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
+    - chmod +x /tmp/furyctl
     - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
 ---
@@ -395,6 +406,12 @@ steps:
       from_secret: aws_region
   commands:
     - apt-get install -y expect
+    - apt-get install -y expect
+    - echo "Installing the correct furyctl version..."
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
+    # to use furyctl latest, use the following instead:
+    # - curl -L "https://github.com/sighupio/furyctl/releases/latest/download/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
+    - chmod +x /tmp/furyctl
     - ./tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
 
 - name: cleanup
@@ -412,6 +429,12 @@ steps:
       from_secret: aws_region
   commands:
     - apt-get install -y expect
+    - apt-get install -y expect
+    - echo "Installing the correct furyctl version..."
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
+    # to use furyctl latest, use the following instead:
+    # - curl -L "https://github.com/sighupio/furyctl/releases/latest/download/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
+    - chmod +x /tmp/furyctl
     - tests/e2e/ekscluster/furyctl_delete.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -126,7 +126,6 @@ trigger:
       - refs/tags/**
     exclude:
       - refs/tags/**-docs*
-      - refs/tags/e2e-full-**
 
 steps:
   - name: create Kind cluster
@@ -231,7 +230,6 @@ trigger:
       - refs/tags/**
     exclude:
       - refs/tags/**-docs*
-      - refs/tags/e2e-full-**
 
 steps:
   - name: create Kind cluster

--- a/.drone.yml
+++ b/.drone.yml
@@ -375,8 +375,6 @@ steps:
     - mv furyctl /usr/local/bin
     - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
-    - aws s3 rm s3://$CLUSTER_NAME-velero --recursive
-    - aws s3api delete-bucket --bucket $CLUSTER_NAME-velero
 ---
 name: e2e-ekscluster-upgrades
 kind: pipeline
@@ -440,8 +438,6 @@ steps:
     - mv furyctl /usr/local/bin
     - tests/e2e/ekscluster/furyctl_delete.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
-    - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME-velero --recursive
-    - aws s3api delete-bucket --bucket $CLUSTER_NAME-velero
 
 ---
 kind: pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -377,7 +377,8 @@ steps:
     - mv furyctl /usr/local/bin
     - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
-
+    - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME-velero --recursive
+    - aws s3api delete-bucket --bucket $CLUSTER_NAME-velero
 ---
 name: e2e-ekscluster-upgrades
 kind: pipeline
@@ -441,6 +442,8 @@ steps:
     - mv furyctl /usr/local/bin
     - tests/e2e/ekscluster/furyctl_delete.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
     - aws s3 rm s3://e2e-drone-eks/e2e-eks-upgrades --recursive
+    - aws s3 rm s3://e2e-drone-eks/e2e-eks-upgrades-velero --recursive
+    - aws s3api delete-bucket --bucket e2e-eks-upgrades-velero
 
 ---
 name: release

--- a/.drone.yml
+++ b/.drone.yml
@@ -423,7 +423,7 @@ steps:
   image: ubuntu:latest
   environment:
     FURYCTL_VERSION: "v0.31.1"
-    CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}
+    CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}-upgrades
     DISTRIBUTION_VERSION: "v1.31.0"
     AWS_ACCESS_KEY_ID:
       from_secret: aws_access_key_id
@@ -441,9 +441,9 @@ steps:
     - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
     - mv furyctl /usr/local/bin
     - tests/e2e/ekscluster/furyctl_delete.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
-    - aws s3 rm s3://e2e-drone-eks/e2e-eks-upgrades --recursive
-    - aws s3 rm s3://e2e-drone-eks/e2e-eks-upgrades-velero --recursive
-    - aws s3api delete-bucket --bucket e2e-eks-upgrades-velero
+    - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
+    - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME-velero --recursive
+    - aws s3api delete-bucket --bucket $CLUSTER_NAME-velero
 
 ---
 name: release

--- a/.drone.yml
+++ b/.drone.yml
@@ -334,6 +334,7 @@ steps:
   environment:
     FURYCTL_VERSION: "v0.31.1"
     DISTRIBUTION_VERSION: "v1.31.0"
+    DEBIAN_FRONTEND: noninteractive
     CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}
     AWS_ACCESS_KEY_ID:
       from_secret: aws_access_key_id
@@ -350,6 +351,7 @@ steps:
   environment:
     FURYCTL_VERSION: "v0.31.1"
     CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}
+    DEBIAN_FRONTEND: noninteractive
     DISTRIBUTION_VERSION: "v1.31.0"
     AWS_ACCESS_KEY_ID:
       from_secret: aws_access_key_id
@@ -384,6 +386,7 @@ steps:
     FURYCTL_VERSION: "v0.31.1"
     DISTRIBUTION_VERSION: "v1.31.0"
     CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}-upgrades
+    DEBIAN_FRONTEND: noninteractive
     AWS_ACCESS_KEY_ID:
       from_secret: aws_access_key_id
     AWS_SECRET_ACCESS_KEY:
@@ -399,6 +402,7 @@ steps:
   environment:
     FURYCTL_VERSION: "v0.31.1"
     CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}-upgrades
+    DEBIAN_FRONTEND: noninteractive
     DISTRIBUTION_VERSION: "v1.31.0"
     AWS_ACCESS_KEY_ID:
       from_secret: aws_access_key_id

--- a/.drone.yml
+++ b/.drone.yml
@@ -333,7 +333,6 @@ trigger:
 steps:
 - name: run-tests
   image: ubuntu:latest
-  privileged: true
   environment:
     FURYCTL_VERSION: "v0.31.1"
     DISTRIBUTION_VERSION: "v1.31.0"
@@ -378,6 +377,70 @@ steps:
     - mv furyctl /usr/local/bin
     - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
     - aws s3 rm s3://e2e-drone-eks/$env(CLUSTER_NAME) --recursive
+
+---
+name: e2e-ekscluster-upgrades
+kind: pipeline
+type: docker
+
+depends_on:
+  - e2e-ekscluster
+
+clone:
+  depth: 1
+
+trigger:
+  ref:
+    - refs/tags/e2e-full-**
+    - refs/tags/v**
+
+steps:
+- name: run-tests
+  image: ubuntu:latest
+  environment:
+    FURYCTL_VERSION: "v0.31.1"
+    DISTRIBUTION_VERSION: "v1.31.0"
+    CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}-upgrades
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    AWS_REGION:
+      from_secret: aws_region
+  commands:
+    - apt-get update && apt-get install -y curl unzip expect bats git psmisc jq yq
+    - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    - unzip awscliv2.zip
+    - ./aws/install
+    - curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+    - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
+    - mv furyctl /usr/local/bin
+    - ./tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
+
+- name: cleanup
+  image: ubuntu:latest
+  environment:
+    FURYCTL_VERSION: "v0.31.1"
+    CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}
+    DISTRIBUTION_VERSION: "v1.31.0"
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    AWS_REGION:
+      from_secret: aws_region
+  commands:
+    - apt-get update && apt-get install -y curl unzip expect bats git psmisc jq yq
+    - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    - unzip awscliv2.zip
+    - ./aws/install
+    - curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+    - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
+    - mv furyctl /usr/local/bin
+    - tests/e2e/ekscluster/furyctl_delete.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
+    - aws s3 rm s3://e2e-drone-eks/e2e-eks-upgrades --recursive
 
 ---
 name: release

--- a/.drone.yml
+++ b/.drone.yml
@@ -330,7 +330,7 @@ trigger:
 
 steps:
 - name: run-tests
-  image: ubuntu:latest
+  image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.31.1_5.6.0_4.33.3
   environment:
     FURYCTL_VERSION: "v0.31.1"
     DISTRIBUTION_VERSION: "v1.31.0"
@@ -342,18 +342,10 @@ steps:
     AWS_REGION:
       from_secret: aws_region
   commands:
-    - apt-get update && apt-get install -y curl unzip expect bats git psmisc jq yq
-    - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    - unzip awscliv2.zip
-    - ./aws/install
-    - curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-    - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
-    - mv furyctl /usr/local/bin
     - ./tests/e2e/ekscluster/e2e-ekscluster.sh
 
 - name: cleanup
-  image: ubuntu:latest
+  image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.31.1_5.6.0_4.33.3
   environment:
     FURYCTL_VERSION: "v0.31.1"
     CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}
@@ -365,14 +357,6 @@ steps:
     AWS_REGION:
       from_secret: aws_region
   commands:
-    - apt-get update && apt-get install -y curl unzip expect bats git psmisc jq yq
-    - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    - rm -rf ./aws && unzip awscliv2.zip
-    - ./aws/install
-    - curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-    - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
-    - mv furyctl /usr/local/bin
     - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
 ---
@@ -393,7 +377,7 @@ trigger:
 
 steps:
 - name: run-tests
-  image: ubuntu:latest
+  image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.31.1_5.6.0_4.33.3
   environment:
     FURYCTL_VERSION: "v0.31.1"
     DISTRIBUTION_VERSION: "v1.31.0"
@@ -405,18 +389,10 @@ steps:
     AWS_REGION:
       from_secret: aws_region
   commands:
-    - apt-get update && apt-get install -y curl unzip expect bats git psmisc jq yq
-    - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    - unzip awscliv2.zip
-    - ./aws/install
-    - curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-    - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
-    - mv furyctl /usr/local/bin
     - ./tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
 
 - name: cleanup
-  image: ubuntu:latest
+  image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.31.1_5.6.0_4.33.3
   environment:
     FURYCTL_VERSION: "v0.31.1"
     CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}-upgrades
@@ -428,14 +404,6 @@ steps:
     AWS_REGION:
       from_secret: aws_region
   commands:
-    - apt-get update && apt-get install -y curl unzip expect bats git psmisc jq yq
-    - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    - rm -rf ./aws && unzip awscliv2.zip
-    - ./aws/install
-    - curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-    - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
-    - mv furyctl /usr/local/bin
     - tests/e2e/ekscluster/furyctl_delete.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -478,7 +478,7 @@ steps:
       - tar -xvf aws-nuke-v2.25.0-linux-amd64.tar.gz
       - mv aws-nuke-v2.25.0-linux-amd64 /usr/local/bin/aws-nuke
       - chmod +x /usr/local/bin/aws-nuke
-      - export ACCOUNT_ID=$(aws sts get-caller-identity | jq -r ".UserId")
+      - export ACCOUNT_ID=$(aws sts get-caller-identity | jq -r ".Account")
       - sed "s/ACCOUNT_ID_PLACEHOLDER/$ACCOUNT_ID/" tests/e2e/ekscluster/awsnuke/config.yml > ./aws-nuke-config.yml
       - sed -i "s/ACCOUNT_ID_PROD_PLACEHOLDER/$ACCOUNT_ID_PROD/" ./aws-nuke-config.yml
       # Run AWS Nuke

--- a/.drone.yml
+++ b/.drone.yml
@@ -445,8 +445,14 @@ type: docker
 name: scheduled-aws-nuke
 
 trigger:
-  cron: 
-    - "0 23 * * *"  # Run at 11 PM every day
+  event:
+    - cron
+    - tag
+  cron:
+    - "0 23 * * *" # Run at 11 PM every day
+  ref:
+    include:
+      - refs/tags/aws-nuke-ci-**
 
 clone:
   depth: 1
@@ -460,20 +466,23 @@ steps:
       AWS_SECRET_ACCESS_KEY:
         from_secret: aws_secret_access_key
       AWS_DEFAULT_REGION: eu-west-1
+      ACCOUNT_ID_PROD:
+        from_secret: aws_account_id_prod
     commands:
       # Install required tools
       - yum update -y
-      - yum install -y wget tar gzip
+      - yum install -y wget tar gzip jq
       
       # Install AWS Nuke
       - wget https://github.com/rebuy-de/aws-nuke/releases/download/v2.25.0/aws-nuke-v2.25.0-linux-amd64.tar.gz
       - tar -xvf aws-nuke-v2.25.0-linux-amd64.tar.gz
       - mv aws-nuke-v2.25.0-linux-amd64 /usr/local/bin/aws-nuke
       - chmod +x /usr/local/bin/aws-nuke
-      
-      
+      - export ACCOUNT_ID=$(aws sts get-caller-identity | jq -r ".UserId")
+      - sed "s/ACCOUNT_ID_PLACEHOLDER/$ACCOUNT_ID/" tests/e2e/ekscluster/awsnuke/config.yml > ./aws-nuke-config.yml
+      - sed -i "s/ACCOUNT_ID_PROD_PLACEHOLDER/$ACCOUNT_ID_PROD/" ./aws-nuke-config.yml
       # Run AWS Nuke
-      - aws-nuke -c tests/e2e/ekscluster/awsnuke/config.yml --force --no-dry-run
+      - aws-nuke -c ./aws-nuke-config.yml --force --no-dry-run
       - aws s3 rm s3://e2e-drone-eks --recursive
 
 ---

--- a/.drone.yml
+++ b/.drone.yml
@@ -342,6 +342,7 @@ steps:
     AWS_REGION:
       from_secret: aws_region
   commands:
+    - apt-get install -y expect
     - ./tests/e2e/ekscluster/e2e-ekscluster.sh
 
 - name: cleanup
@@ -357,6 +358,7 @@ steps:
     AWS_REGION:
       from_secret: aws_region
   commands:
+    - apt-get install -y expect
     - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
 ---
@@ -389,6 +391,7 @@ steps:
     AWS_REGION:
       from_secret: aws_region
   commands:
+    - apt-get install -y expect
     - ./tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
 
 - name: cleanup
@@ -404,6 +407,7 @@ steps:
     AWS_REGION:
       from_secret: aws_region
   commands:
+    - apt-get install -y expect
     - tests/e2e/ekscluster/furyctl_delete.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -357,7 +357,6 @@ steps:
 
 - name: cleanup
   image: ubuntu:latest
-  privileged: true
   environment:
     FURYCTL_VERSION: "v0.31.1"
     CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}
@@ -378,6 +377,7 @@ steps:
     - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
     - mv furyctl /usr/local/bin
     - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
+    - aws s3 rm s3://e2e-drone-eks/$env(CLUSTER_NAME) --recursive
 
 ---
 name: release

--- a/.drone.yml
+++ b/.drone.yml
@@ -407,7 +407,7 @@ steps:
     - echo "Installing the correct furyctl version..."
     - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
     - mv furyctl /usr/local/bin
-    - chmod +x /tmp/furyctl
+    - chmod +x /usr/local/bin/furyctl
     - ./tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
 
 - name: cleanup

--- a/.drone.yml
+++ b/.drone.yml
@@ -347,7 +347,7 @@ steps:
     - echo "Installing the correct furyctl version..."
     - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
     - mv furyctl /usr/local/bin
-    - chmod +x /usr/local/furyctl
+    - chmod +x /usr/local/bin/furyctl
     - ./tests/e2e/ekscluster/e2e-ekscluster.sh
 
 - name: cleanup
@@ -369,7 +369,7 @@ steps:
     - echo "Installing the correct furyctl version..."
     - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
     - mv furyctl /usr/local/bin
-    - chmod +x /usr/local/furyctl
+    - chmod +x /usr/local/bin/furyctl
     - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
 ---
@@ -428,7 +428,7 @@ steps:
     - echo "Installing the correct furyctl version..."
     - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
     - mv furyctl /usr/local/bin
-    - chmod +x /usr/local/furyctl
+    - chmod +x /usr/local/bin/furyctl
     - tests/e2e/ekscluster/furyctl_delete.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -474,6 +474,7 @@ steps:
       
       # Run AWS Nuke
       - aws-nuke -c tests/e2e/ekscluster/awsnuke/config.yml --force --no-dry-run
+      - aws s3 rm s3://e2e-drone-eks --recursive
 
 ---
 name: release

--- a/.drone.yml
+++ b/.drone.yml
@@ -126,6 +126,7 @@ trigger:
       - refs/tags/**
     exclude:
       - refs/tags/**-docs*
+      - refs/tags/e2e-full-**
 
 steps:
   - name: create Kind cluster
@@ -230,6 +231,7 @@ trigger:
       - refs/tags/**
     exclude:
       - refs/tags/**-docs*
+      - refs/tags/e2e-full-**
 
 steps:
   - name: create Kind cluster
@@ -312,6 +314,71 @@ volumes:
   - name: dockersock
     host:
       path: /var/run/docker.sock
+---
+name: e2e-ekscluster
+kind: pipeline
+type: docker
+
+depends_on:
+  - qa
+
+clone:
+  depth: 1
+
+trigger:
+  ref:
+    - refs/tags/e2e-full-**
+    - refs/tags/v**
+
+steps:
+- name: run-tests
+  image: ubuntu:latest
+  privileged: true
+  environment:
+    FURYCTL_VERSION: "v0.31.1"
+    DISTRIBUTION_VERSION: "v1.31.0"
+    CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    AWS_REGION:
+      from_secret: aws_region
+  commands:
+    - apt-get update && apt-get install -y curl unzip expect bats git psmisc jq yq
+    - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    - unzip awscliv2.zip
+    - ./aws/install
+    - curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+    - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
+    - mv furyctl /usr/local/bin
+    - ./tests/e2e/ekscluster/e2e-ekscluster.sh
+
+- name: cleanup
+  image: ubuntu:latest
+  privileged: true
+  environment:
+    FURYCTL_VERSION: "v0.31.1"
+    CLUSTER_NAME: e2e-eks-${DRONE_BUILD_NUMBER}
+    DISTRIBUTION_VERSION: "v1.31.0"
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    AWS_REGION:
+      from_secret: aws_region
+  commands:
+    - apt-get update && apt-get install -y curl unzip expect bats git psmisc jq yq
+    - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    - unzip awscliv2.zip
+    - ./aws/install
+    - curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+    - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
+    - mv furyctl /usr/local/bin
+    - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
+
 ---
 name: release
 kind: pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -369,7 +369,7 @@ steps:
   commands:
     - apt-get update && apt-get install -y curl unzip expect bats git psmisc jq yq
     - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    - unzip awscliv2.zip
+    - rm -rf ./aws && unzip awscliv2.zip
     - ./aws/install
     - curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
     - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
@@ -433,7 +433,7 @@ steps:
   commands:
     - apt-get update && apt-get install -y curl unzip expect bats git psmisc jq yq
     - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    - unzip awscliv2.zip
+    - rm -rf ./aws && unzip awscliv2.zip
     - ./aws/install
     - curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
     - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl

--- a/.drone.yml
+++ b/.drone.yml
@@ -347,7 +347,7 @@ steps:
     - echo "Installing the correct furyctl version..."
     - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
     - mv furyctl /usr/local/bin
-    - chmod +x /tmp/furyctl
+    - chmod +x /usr/local/furyctl
     - ./tests/e2e/ekscluster/e2e-ekscluster.sh
 
 - name: cleanup
@@ -369,6 +369,7 @@ steps:
     - echo "Installing the correct furyctl version..."
     - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
     - mv furyctl /usr/local/bin
+    - chmod +x /usr/local/furyctl
     - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
 ---
@@ -427,6 +428,7 @@ steps:
     - echo "Installing the correct furyctl version..."
     - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
     - mv furyctl /usr/local/bin
+    - chmod +x /usr/local/furyctl
     - tests/e2e/ekscluster/furyctl_delete.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -345,9 +345,8 @@ steps:
   commands:
     - apt-get install -y expect
     - echo "Installing the correct furyctl version..."
-    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
-    # to use furyctl latest, use the following instead:
-    # - curl -L "https://github.com/sighupio/furyctl/releases/latest/download/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
+    - mv furyctl /usr/local/bin
     - chmod +x /tmp/furyctl
     - ./tests/e2e/ekscluster/e2e-ekscluster.sh
 
@@ -368,10 +367,8 @@ steps:
     - apt-get install -y expect
     - apt-get install -y expect
     - echo "Installing the correct furyctl version..."
-    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
-    # to use furyctl latest, use the following instead:
-    # - curl -L "https://github.com/sighupio/furyctl/releases/latest/download/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
-    - chmod +x /tmp/furyctl
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
+    - mv furyctl /usr/local/bin
     - tests/e2e/ekscluster/furyctl_delete.expect $(cat ./last_furyctl_yaml.txt)
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
 ---
@@ -406,11 +403,9 @@ steps:
       from_secret: aws_region
   commands:
     - apt-get install -y expect
-    - apt-get install -y expect
     - echo "Installing the correct furyctl version..."
-    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
-    # to use furyctl latest, use the following instead:
-    # - curl -L "https://github.com/sighupio/furyctl/releases/latest/download/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
+    - mv furyctl /usr/local/bin
     - chmod +x /tmp/furyctl
     - ./tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
 
@@ -429,12 +424,9 @@ steps:
       from_secret: aws_region
   commands:
     - apt-get install -y expect
-    - apt-get install -y expect
     - echo "Installing the correct furyctl version..."
-    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
-    # to use furyctl latest, use the following instead:
-    # - curl -L "https://github.com/sighupio/furyctl/releases/latest/download/furyctl-$(uname -s)-amd64.tar.gz" -o /tmp/furyctl.tar.gz && tar xfz /tmp/furyctl.tar.gz -C /tmp
-    - chmod +x /tmp/furyctl
+    - curl -L "https://github.com/sighupio/furyctl/releases/download/$${FURYCTL_VERSION}/furyctl-linux-amd64.tar.gz" | tar -xz
+    - mv furyctl /usr/local/bin
     - tests/e2e/ekscluster/furyctl_delete.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
     - aws s3 rm s3://e2e-drone-eks/$CLUSTER_NAME --recursive
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -446,6 +446,42 @@ steps:
     - aws s3api delete-bucket --bucket $CLUSTER_NAME-velero
 
 ---
+kind: pipeline
+type: docker
+name: scheduled-aws-nuke
+
+trigger:
+  cron: 
+    - "0 23 * * *"  # Run at 11 PM every day
+
+clone:
+  depth: 1
+
+steps:
+  - name: run-aws-nuke
+    image: amazon/aws-cli:latest
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
+      AWS_DEFAULT_REGION: eu-west-1
+    commands:
+      # Install required tools
+      - yum update -y
+      - yum install -y wget tar gzip
+      
+      # Install AWS Nuke
+      - wget https://github.com/rebuy-de/aws-nuke/releases/download/v2.25.0/aws-nuke-v2.25.0-linux-amd64.tar.gz
+      - tar -xvf aws-nuke-v2.25.0-linux-amd64.tar.gz
+      - mv aws-nuke-v2.25.0-linux-amd64 /usr/local/bin/aws-nuke
+      - chmod +x /usr/local/bin/aws-nuke
+      
+      
+      # Run AWS Nuke
+      - aws-nuke -c tests/e2e/ekscluster/awsnuke/config.yml --force --no-dry-run
+
+---
 name: release
 kind: pipeline
 type: docker

--- a/tests/e2e-kfddistribution-upgrades.sh
+++ b/tests/e2e-kfddistribution-upgrades.sh
@@ -7,8 +7,8 @@ set -e
 
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl for the initial setup 1.30.0"
-/tmp/furyctl apply --config tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml --outdir "$PWD" --disable-analytics
+/tmp/furyctl apply --config tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.30.0.yaml --outdir "$PWD" --disable-analytics
 
 echo "----------------------------------------------------------------------------"
 echo "Executing upgrade to 1.31.0"
-/tmp/furyctl apply --upgrade --config tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml --outdir "$PWD" --distro-location ./ --force upgrades --disable-analytics
+/tmp/furyctl apply --upgrade --config tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.31.0.yaml --outdir "$PWD" --distro-location ./ --force upgrades --disable-analytics

--- a/tests/e2e-kfddistribution-upgrades.sh
+++ b/tests/e2e-kfddistribution-upgrades.sh
@@ -7,8 +7,8 @@ set -e
 
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl for the initial setup 1.30.0"
-/tmp/furyctl apply --config tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.30.0.yaml --outdir "$PWD" --disable-analytics
+/tmp/furyctl apply --config tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml --outdir "$PWD" --disable-analytics
 
 echo "----------------------------------------------------------------------------"
 echo "Executing upgrade to 1.31.0"
-/tmp/furyctl apply --upgrade --config tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.31.0.yaml --outdir "$PWD" --distro-location ./ --force upgrades --disable-analytics
+/tmp/furyctl apply --upgrade --config tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml --outdir "$PWD" --distro-location ./ --force upgrades --disable-analytics

--- a/tests/e2e-kfddistribution.sh
+++ b/tests/e2e-kfddistribution.sh
@@ -52,10 +52,10 @@ echo "Executing furyctl with the auth basic to sso migration"
 /tmp/furyctl create cluster --config tests/e2e/kfddistribution/furyctl-7-migrate-from-basicAuth-to-sso.yaml --outdir "$PWD" --distro-location ./ --force all --skip-deps-download --disable-analytics
 bats -t tests/e2e-kfddistribution-7-migrate-from-basicAuth-to-sso.sh
 
-echo "----------------------------------------------------------------------------"
-echo "Executing furyctl with the auth basic to sso migration"
-/tmp/furyctl create cluster --config tests/e2e/kfddistribution/furyctl-8-migrate-from-sso-to-none.yaml --outdir "$PWD" --distro-location ./ --force all --skip-deps-download --disable-analytics
-bats -t tests/e2e-kfddistribution-8-migrate-from-sso-to-none.sh
+# echo "----------------------------------------------------------------------------"
+# echo "Executing furyctl with the auth basic to sso migration"
+# /tmp/furyctl create cluster --config tests/e2e/kfddistribution/furyctl-8-migrate-from-sso-to-none.yaml --outdir "$PWD" --distro-location ./ --force all --skip-deps-download --disable-analytics
+# bats -t tests/e2e-kfddistribution-8-migrate-from-sso-to-none.sh
 
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl with the nginx migration to none"

--- a/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
+++ b/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
@@ -5,12 +5,14 @@
 
 set -e
 
+cd /tmp
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl for the initial setup 1.30.0"
-FURYCTL_YAML=tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml
-tests/e2e/ekscluster/replace_variables.sh --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$FURYCTL_YAML"
-tests/e2e/ekscluster/furyctl_apply.expect $FURYCTL_YAML
+FURYCTL_YAML=/drone/src/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml
+/drone/src/tests/e2e/ekscluster/replace_variables.sh --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$FURYCTL_YAML"
+/drone/src/tests/e2e/ekscluster/furyctl_apply.expect $FURYCTL_YAML
 
+cd /drone/src
 echo "----------------------------------------------------------------------------"
 echo "Executing upgrade to 1.31.0"
 FURYCTL_YAML=tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml

--- a/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
+++ b/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
@@ -11,4 +11,4 @@ tests/e2e/ekscluster/furyctl_apply.expect tests/e2e/ekscluster-upgrades/manifest
 
 echo "----------------------------------------------------------------------------"
 echo "Executing upgrade to 1.31.0"
-tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml --outdir "$PWD" --distro-location ./ --force upgrades --disable-analytics
+tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml --outdir "$PWD" --force upgrades --disable-analytics

--- a/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
+++ b/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
@@ -7,8 +7,12 @@ set -e
 
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl for the initial setup 1.30.0"
-tests/e2e/ekscluster/furyctl_apply.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml
+FURYCTL_YAML=tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml
+tests/e2e/ekscluster/replace_variables.sh --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$FURYCTL_YAML"
+tests/e2e/ekscluster/furyctl_apply.expect $FURYCTL_YAML
 
 echo "----------------------------------------------------------------------------"
 echo "Executing upgrade to 1.31.0"
-tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml --outdir "$PWD" --force upgrades --disable-analytics
+FURYCTL_YAML=tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
+tests/e2e/ekscluster/replace_variables.sh --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$FURYCTL_YAML"
+tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect $FURYCTL_YAML

--- a/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
+++ b/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
@@ -5,14 +5,12 @@
 
 set -e
 
-cd /tmp
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl for the initial setup 1.30.0"
 FURYCTL_YAML=/drone/src/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml
 /drone/src/tests/e2e/ekscluster/replace_variables.sh --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$FURYCTL_YAML"
-/drone/src/tests/e2e/ekscluster/furyctl_apply.expect $FURYCTL_YAML
+/drone/src/tests/e2e/ekscluster/furyctl_apply.expect $FURYCTL_YAML /tmp
 
-cd /drone/src
 echo "----------------------------------------------------------------------------"
 echo "Executing upgrade to 1.31.0"
 FURYCTL_YAML=tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml

--- a/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
+++ b/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
@@ -15,4 +15,4 @@ echo "--------------------------------------------------------------------------
 echo "Executing upgrade to 1.31.0"
 FURYCTL_YAML=tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
 tests/e2e/ekscluster/replace_variables.sh --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$FURYCTL_YAML"
-tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect $FURYCTL_YAML
+tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect $FURYCTL_YAML /tmp

--- a/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
+++ b/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
@@ -7,8 +7,8 @@ set -e
 
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl for the initial setup 1.30.0"
-tests/e2e/ekscluster/furyctl_apply.expect tests/e2e/ekscluster-upgrades/furyctl-init-cluster-1.30.0.yaml
+tests/e2e/ekscluster/furyctl_apply.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml
 
 echo "----------------------------------------------------------------------------"
 echo "Executing upgrade to 1.31.0"
-tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.31.0.yaml --outdir "$PWD" --distro-location ./ --force upgrades --disable-analytics
+tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml --outdir "$PWD" --distro-location ./ --force upgrades --disable-analytics

--- a/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
+++ b/tests/e2e/ekscluster-upgrades/e2e-ekscluster-upgrades.sh
@@ -7,8 +7,8 @@ set -e
 
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl for the initial setup 1.30.0"
-/tmp/furyctl apply --config tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.30.0.yaml --outdir "$PWD" --disable-analytics
+tests/e2e/ekscluster/furyctl_apply.expect tests/e2e/ekscluster-upgrades/furyctl-init-cluster-1.30.0.yaml
 
 echo "----------------------------------------------------------------------------"
 echo "Executing upgrade to 1.31.0"
-/tmp/furyctl apply --upgrade --config tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.31.0.yaml --outdir "$PWD" --distro-location ./ --force upgrades --disable-analytics
+tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.31.0.yaml --outdir "$PWD" --distro-location ./ --force upgrades --disable-analytics

--- a/tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect
+++ b/tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect
@@ -11,6 +11,16 @@ if {[llength $argv] == 0} {
     puts "Usage: furyctl_apply.expect /path/to/furyctl.yaml"
     exit 1
 }
+
+
+if {[llength $argv] >= 2} { 
+    set outdir [lindex $argv 1] 
+    puts "Using specified output directory: $outdir" 
+} else { 
+    set outdir $env(PWD) 
+    puts "Using current directory as output directory: $outdir" 
+}
+
 set configFilePath [lindex $argv 0]
 # Verify that necessary AWS environment variables exist.
 if { ![info exists env(AWS_ACCESS_KEY_ID)] || \
@@ -22,7 +32,7 @@ if { ![info exists env(AWS_ACCESS_KEY_ID)] || \
 
 
 # Start furyctl apply.
-spawn furyctl apply --upgrade --outdir /tmp -D --config $configFilePath --force upgrades --distro-location $env(PWD) --disable-analytics
+spawn furyctl apply --upgrade --outdir $outdir -D --config $configFilePath --force upgrades --distro-location $env(PWD) --disable-analytics
 set furyctl_id $spawn_id
 
 expect {

--- a/tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect
+++ b/tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect
@@ -22,7 +22,7 @@ if { ![info exists env(AWS_ACCESS_KEY_ID)] || \
 
 
 # Start furyctl apply.
-spawn furyctl apply --upgrade --outdir $env(PWD) -D --config $configFilePath --force upgrades --distro-location ./
+spawn furyctl apply --upgrade --outdir /tmp -D --config $configFilePath --force upgrades --distro-location $env(PWD) --disable-analytics
 set furyctl_id $spawn_id
 
 expect {

--- a/tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect
+++ b/tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect
@@ -22,7 +22,7 @@ if { ![info exists env(AWS_ACCESS_KEY_ID)] || \
 
 
 # Start furyctl apply.
-spawn furyctl apply --upgrade --outdir $env(PWD) -D --config $configFilePath --force upgrades
+spawn furyctl apply --upgrade --outdir $env(PWD) -D --config $configFilePath --force upgrades --distro-location ./
 set furyctl_id $spawn_id
 
 expect {

--- a/tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect
+++ b/tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect
@@ -22,10 +22,11 @@ if { ![info exists env(AWS_ACCESS_KEY_ID)] || \
 
 
 # Start furyctl apply.
-spawn furyctl delete cluster --outdir $env(PWD) -D --config $configFilePath
+spawn furyctl apply --upgrade --outdir $env(PWD) -D --config $configFilePath --distro-location ./ --force upgrades --disable-analytics
 set furyctl_id $spawn_id
 
 expect {
+
      -re {.*Are you sure you want to continue\? Only 'yes' will be accepted to confirm.*} {
         puts "Confirmation prompt detected, sending 'yes'"
         send -i $furyctl_id "yes\r"
@@ -59,4 +60,3 @@ if {[catch {wait -i $furyctl_id} result]} {
 
 puts "Script completed with exit code $exit_code."
 exit $exit_code
-

--- a/tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect
+++ b/tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect
@@ -22,7 +22,7 @@ if { ![info exists env(AWS_ACCESS_KEY_ID)] || \
 
 
 # Start furyctl apply.
-spawn furyctl apply --upgrade --outdir $env(PWD) -D --config $configFilePath --distro-location ./ --force upgrades --disable-analytics
+spawn furyctl apply --upgrade --outdir $env(PWD) -D --config $configFilePath --force upgrades
 set furyctl_id $spawn_id
 
 expect {

--- a/tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect
+++ b/tests/e2e/ekscluster-upgrades/furyctl_upgrade.expect
@@ -49,7 +49,7 @@ expect {
         exit 1
     }
     eof {
-        puts "Furyctl process ended."
+        puts "furyctl process ended."
     }
 }
 

--- a/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml
+++ b/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml
@@ -53,8 +53,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml
+++ b/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml
@@ -1,0 +1,157 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: e2e-eks-upgrades
+spec:
+  distributionVersion: v1.30.0
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: e2e-drone-eks
+          keyPrefix: e2e-eks-upgrades
+          region: eu-west-1
+  region: eu-west-1
+  tags:
+    env: e2e-eks-upgrades
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  kubernetes:
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
+    nodePoolGlobalAmiType: alinux2
+    nodePoolsLaunchKind: launch_templates
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
+    nodePools:
+      - name: infra
+        type: eks-managed
+        size:
+          min: 5
+          max: 7
+        instance:
+          type: t3.xlarge
+          spot: true
+          volumeSize: 50
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
+  distribution:
+    modules:
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          public:
+            name: e2e.ci.sighup.io
+            create: true
+          private:
+            name: internal.e2e.ci.sighup.io
+            create: true
+      logging:
+        type: loki
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+        loki:
+          backend: minio
+          tsdbStartDate: '2024-11-21'
+      monitoring:
+        type: mimir
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: tempo
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: kyverno
+        kyverno:
+          additionalExcludedNamespaces:
+            - local-path-storage
+          validationFailureAction: Enforce
+          installDefaultPolicies: true
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: e2e-eks-upgrades-velero
+            region: eu-west-1
+      auth:
+        provider:
+          type: basicAuth
+          basicAuth:
+            username: test
+            password: testpassword

--- a/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml
+++ b/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.30.0.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: loki

--- a/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
+++ b/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
@@ -53,8 +53,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
+++ b/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
@@ -1,0 +1,157 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: e2e-eks-upgrades
+spec:
+  distributionVersion: v1.31.0
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: e2e-drone-eks
+          keyPrefix: e2e-eks-upgrades
+          region: eu-west-1
+  region: eu-west-1
+  tags:
+    env: e2e-eks-upgrades
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  kubernetes:
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
+    nodePoolGlobalAmiType: alinux2
+    nodePoolsLaunchKind: launch_templates
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
+    nodePools:
+      - name: infra
+        type: eks-managed
+        size:
+          min: 5
+          max: 7
+        instance:
+          type: t3.xlarge
+          spot: true
+          volumeSize: 50
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
+  distribution:
+    modules:
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          public:
+            name: e2e.ci.sighup.io
+            create: true
+          private:
+            name: internal.e2e.ci.sighup.io
+            create: true
+      logging:
+        type: loki
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+        loki:
+          backend: minio
+          tsdbStartDate: '2024-11-21'
+      monitoring:
+        type: mimir
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: tempo
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: kyverno
+        kyverno:
+          additionalExcludedNamespaces:
+            - local-path-storage
+          validationFailureAction: Enforce
+          installDefaultPolicies: true
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: e2e-eks-upgrades-velero
+            region: eu-west-1
+      auth:
+        provider:
+          type: basicAuth
+          basicAuth:
+            username: test
+            password: testpassword

--- a/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
+++ b/tests/e2e/ekscluster-upgrades/manifests/furyctl-init-cluster-1.31.0.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: loki

--- a/tests/e2e/ekscluster/awsnuke/config.yml
+++ b/tests/e2e/ekscluster/awsnuke/config.yml
@@ -29,6 +29,12 @@ resource-types:
     - AutoScalingGroup
     - ELBv2
     - EC2RouteTable
+    - Route53HostedZone
+    - Route53RecordSet
+    - Route53HealthCheck
+    - Route53ResolverEndpoint
+    - Route53ResolverRule
+    - Route53ResolverRuleAssociation
 
 accounts:
   996502747800: {} # engineering-aws-ci

--- a/tests/e2e/ekscluster/awsnuke/config.yml
+++ b/tests/e2e/ekscluster/awsnuke/config.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 ---
 regions:
   - "eu-west-1"

--- a/tests/e2e/ekscluster/awsnuke/config.yml
+++ b/tests/e2e/ekscluster/awsnuke/config.yml
@@ -7,7 +7,7 @@ regions:
   - "eu-west-1"
 
 account-blocklist:
-- 363601582189 # production
+- ACCOUNT_ID_PROD_PLACEHOLDER # production
 
 resource-types:
   targets:
@@ -37,4 +37,4 @@ resource-types:
     - Route53ResolverRuleAssociation
 
 accounts:
-  996502747800: {} # engineering-aws-ci
+  ACCOUNT_ID_PLACEHOLDER: {}

--- a/tests/e2e/ekscluster/awsnuke/config.yml
+++ b/tests/e2e/ekscluster/awsnuke/config.yml
@@ -1,0 +1,30 @@
+---
+regions:
+  - "eu-west-1"
+
+account-blocklist:
+- 363601582189 # production
+
+resource-types:
+  targets:
+    - EC2Subnet
+    - EC2SecurityGroup
+    - EC2InternetGateway
+    - EC2InternetGatewayAttachment
+    - EC2NetworkInterface
+    - EKSCluster
+    - EKSNodegroup
+    - EC2Address
+    - EC2NATGateway
+    - CloudWatchLogsLogGroup
+    - EC2Volume
+    - EC2Snapshot
+    - EC2VPC
+    - EC2Instance
+    - EC2LaunchTemplate
+    - AutoScalingGroup
+    - ELBv2
+    - EC2RouteTable
+
+accounts:
+  996502747800: {} # engineering-aws-ci

--- a/tests/e2e/ekscluster/e2e-ekscluster-10-migrate-from-kyverno-default-policies-to-disabled.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster-10-migrate-from-kyverno-default-policies-to-disabled.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+@test "Verify that kyverno policies have been deleted" {
+    info
+    test() {
+        kubectl get clusterpolicy > check.txt
+        if ! grep -q "disallow" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}

--- a/tests/e2e/ekscluster/e2e-ekscluster-11-migrate-from-alertmanagerconfigs-to-disabled.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster-11-migrate-from-alertmanagerconfigs-to-disabled.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+@test "Verify that alertmanagerconfigs deadmanswitch have been deleted" {
+    info
+    test() {
+        kubectl get alertmanagerconfigs -n monitoring > check.txt
+        if ! grep -q "deadmanswitch" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Verify that alertmanagerconfigs infra have been deleted" {
+    info
+    test() {
+        kubectl get alertmanagerconfigs -n monitoring > check.txt
+        if ! grep -q "infra" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Verify that alertmanagerconfigs k8s have been deleted" {
+    info
+    test() {
+        kubectl get alertmanagerconfigs -n monitoring > check.txt
+        if ! grep -q "k8s" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}

--- a/tests/e2e/ekscluster/e2e-ekscluster-2-migrate-from-tempo-to-none.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster-2-migrate-from-tempo-to-none.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+@test "Tracing NS has been deleted" {
+    info
+    test() {
+        kubectl get namespace > check.txt
+        if ! grep -q "tracing" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}

--- a/tests/e2e/ekscluster/e2e-ekscluster-3-migrate-from-kyverno-to-none.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster-3-migrate-from-kyverno-to-none.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+@test "Kyverno NS has been deleted" {
+    info
+    test() {
+        kubectl get namespace > check.txt
+        if ! grep -q "kyverno" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}

--- a/tests/e2e/ekscluster/e2e-ekscluster-4-migrate-from-velero-to-none.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster-4-migrate-from-velero-to-none.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+@test "Velero has been deleted" {
+    info
+    test() {
+        kubectl get pods -n kube-system --show-labels > check.txt
+        if ! grep -q "velero" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}

--- a/tests/e2e/ekscluster/e2e-ekscluster-5-migrate-from-loki-to-none.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster-5-migrate-from-loki-to-none.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+@test "Logging NS has been deleted" {
+    info
+    test() {
+        kubectl get namespace > check.txt
+        if ! grep -q "logging" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}

--- a/tests/e2e/ekscluster/e2e-ekscluster-6-migrate-from-mimir-to-none.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster-6-migrate-from-mimir-to-none.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+@test "Monitoring NS has been deleted" {
+    info
+    test() {
+        kubectl get namespace > check.txt
+        if ! grep -q "monitoring" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}

--- a/tests/e2e/ekscluster/e2e-ekscluster-7-migrate-from-basicAuth-to-sso.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster-7-migrate-from-basicAuth-to-sso.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+@test "Pomerium NS is present" {
+    info
+    test() {
+        kubectl get namespace > check.txt
+        if grep -q "pomerium" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}

--- a/tests/e2e/ekscluster/e2e-ekscluster-8-migrate-from-sso-to-none.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster-8-migrate-from-sso-to-none.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+@test "Pomerium NS is NOT present" {
+    info
+    test() {
+        kubectl get namespace > check.txt
+        if ! grep -q "pomerium" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}

--- a/tests/e2e/ekscluster/e2e-ekscluster-cleanup-all.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster-cleanup-all.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+@test "Ingress Nginx NS has been deleted" {
+    info
+    test() {
+        kubectl get namespace > check.txt
+        if ! grep -q "ingress-nginx" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Pomerium NS is NOT present" {
+    info
+    test() {
+        kubectl get namespace > check.txt
+        if ! grep -q "pomerium" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Monitoring NS has been deleted" {
+    info
+    test() {
+        kubectl get namespace > check.txt
+        if ! grep -q "monitoring" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Logging NS has been deleted" {
+    info
+    test() {
+        kubectl get namespace > check.txt
+        if ! grep -q "logging" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Velero has been deleted" {
+    info
+    test() {
+        kubectl get pods -n kube-system --show-labels > check.txt
+        if ! grep -q "velero" check.txt; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}

--- a/tests/e2e/ekscluster/e2e-ekscluster-init-cluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster-init-cluster.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# shellcheck disable=SC2154
+
+load ./helper
+
+export KUBECONFIG=./kubeconfig
+
+@test "Calico Kube Controller is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=calico-kube-controllers -o json -n calico-system |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Calico Node is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=calico-node -o json -n calico-system |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Velero is Running" {
+    info
+    test() {
+        kubectl get pods -l k8s-app=velero -o json -n kube-system |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+# @test "Velero Node Agent is Running" {
+#     info
+#     test() {
+#         kubectl get pods -l k8s-app=velero-node-agent -o json -n kube-system |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+#     }
+#     loop_it test 60 10
+#     status=${loop_it_result}
+#     [ "$status" -eq 0 ]
+# }
+
+@test "Cert-manager Controller is Running" {
+    info
+    test() {
+        kubectl get pods -l app=cert-manager -o json -n cert-manager |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Nginx Ingress Controller is Running" {
+    info
+    test() {
+        kubectl get pods -l app=ingress -o json -n ingress-nginx |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Forecastle is Running" {
+    info
+    test() {
+        kubectl get pods -l app=forecastle -o json -n ingress-nginx |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Fluentd is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=fluentd -o json -n logging |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+
+@test "Grafana is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=grafana -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Prometheus Operator is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=prometheus-operator -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Kube State Metrics is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=kube-state-metrics -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Node Exporter is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=node-exporter -o json -n monitoring |jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "Prometheus is Running" {
+    info
+    test() {
+        kubectl get pods -l app.kubernetes.io/name=prometheus -o json -n monitoring | jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+
+    }
+    loop_it test 160 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "kube-proxy-metrics is Running" {
+    info
+    test() {
+        kubectl get pods -l k8s-app=kube-proxy-metrics -o json -n monitoring | jq '.items[].status.containerStatuses[].ready' | uniq | grep -q true
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [ "$status" -eq 0 ]
+}
+
+@test "tempo is Running" {
+    info
+    test(){
+        data=$(kubectl get sts -n tracing -l app.kubernetes.io/component=ingester -o json | jq '.items[] | select(.metadata.name == "tempo-distributed-ingester" and .status.replicas == .status.readyReplicas)')
+        if [ "${data}" == "" ]; then return 1; fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [[ "$status" -eq 0 ]]
+}
+
+@test "Kyverno Admission controller is Running" {
+    info
+    test(){
+        readyReplicas=$(kubectl get deploy kyverno-admission-controller -n kyverno -o jsonpath="{.status.readyReplicas}")
+        if [ "${readyReplicas}" != "3" ]; then return 1; fi
+    }
+    loop_it test 60 10
+    status=${loop_it_result}
+    [[ "$status" -eq 0 ]]
+}

--- a/tests/e2e/ekscluster/e2e-ekscluster-upgrades.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster-upgrades.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set -e
+
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl for the initial setup 1.30.0"
+/tmp/furyctl apply --config tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.30.0.yaml --outdir "$PWD" --disable-analytics
+
+echo "----------------------------------------------------------------------------"
+echo "Executing upgrade to 1.31.0"
+/tmp/furyctl apply --upgrade --config tests/e2e/kfddistribution-upgrades/furyctl-init-cluster-1.31.0.yaml --outdir "$PWD" --distro-location ./ --force upgrades --disable-analytics

--- a/tests/e2e/ekscluster/e2e-ekscluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster.sh
@@ -82,20 +82,22 @@ bats -t tests/e2e/ekscluster/e2e-ekscluster-7-migrate-from-basicAuth-to-sso.sh
 
 #Temporary fix to delete pomerium dns 
 hosted_zone_id=$(aws route53 list-hosted-zones \
-  --output text \
-  --query "HostedZones[?Name==$CLUSTER_NAME.e2e.ci.sighup.cc.)].Id")
+--output text \
+--query "HostedZones[?Name==$CLUSTER_NAME.e2e.ci.sighup.cc.)].Id")
+
 aws route53 list-resource-record-sets \
-  --hosted-zone-id "$hosted_zone_id" | \
+--hosted-zone-id "$hosted_zone_id" | \
 jq -c '.ResourceRecordSets[]' | \
 while read -r resourcerecordset; do
-    read -r name type <<<$(echo $(jq -r '.Name,.Type' <<<"$resourcerecordset"))
-  if [ "$type" != "NS" -a "$type" != "SOA" ]; then
+  type=$(echo "$resourcerecordset" | jq -r '.Type')
+  
+  if [ "$type" != "NS" ] && [ "$type" != "SOA" ]; then
     aws route53 change-resource-record-sets \
-      --hosted-zone-id "$hosted_zone_id" \
-      --change-batch '{"Changes":[{"Action":"DELETE","ResourceRecordSet":
-          '"$resourcerecordset"'
-        }]}' \
-      --output text --query 'ChangeInfo.Id'
+    --hosted-zone-id "$hosted_zone_id" \
+    --change-batch '{"Changes":[{"Action":"DELETE","ResourceRecordSet":
+'"$resourcerecordset"'
+}]}' \
+    --output text --query 'ChangeInfo.Id'
   fi
 done
 

--- a/tests/e2e/ekscluster/e2e-ekscluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-echo $PWD
+echo "$PWD"
 echo ls
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml

--- a/tests/e2e/ekscluster/e2e-ekscluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster.sh
@@ -83,7 +83,7 @@ bats -t tests/e2e/ekscluster/e2e-ekscluster-7-migrate-from-basicAuth-to-sso.sh
 #Temporary fix to delete pomerium dns 
 hosted_zone_id=$(aws route53 list-hosted-zones \
   --output text \
-  --query "HostedZones[?Name==$("$CLUSTER_NAME".e2e.ci.sighup.cc.)].Id")
+  --query "HostedZones[?Name==$CLUSTER_NAME.e2e.ci.sighup.cc.)].Id")
 aws route53 list-resource-record-sets \
   --hosted-zone-id "$hosted_zone_id" | \
 jq -c '.ResourceRecordSets[]' | \

--- a/tests/e2e/ekscluster/e2e-ekscluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster.sh
@@ -5,6 +5,9 @@
 
 set -e
 
+echo $PWD
+echo ls
+
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
 tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
@@ -92,11 +95,9 @@ while read -r resourcerecordset; do
   type=$(echo "$resourcerecordset" | jq -r '.Type')
   
   if [ "$type" != "NS" ] && [ "$type" != "SOA" ]; then
-    aws route53 change-resource-record-sets \
+    echo aws route53 change-resource-record-sets \
     --hosted-zone-id "$hosted_zone_id" \
-    --change-batch '{"Changes":[{"Action":"DELETE","ResourceRecordSet":
-'"$resourcerecordset"'
-}]}' \
+    --change-batch '{"Changes":[{"Action":"DELETE","ResourceRecordSet": '"$resourcerecordset"' }]}' \
     --output text --query 'ChangeInfo.Id'
   fi
 done

--- a/tests/e2e/ekscluster/e2e-ekscluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster.sh
@@ -6,107 +6,107 @@
 set -e
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl for the initial setup"
-tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
-echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 echo "Testing that the components are running"
 bats -t tests/e2e/ekscluster/e2e-ekscluster-init-cluster.sh
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-cleanup-all.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl cleanup all modules and configurations"
-tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
-echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 bats -t tests/e2e/ekscluster/e2e-ekscluster-cleanup-all.sh
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
 echo "Resetting furyctl with the initial setup"
-tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
-echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 echo "Testing that the components are running"
 bats -t tests/e2e/ekscluster/e2e-ekscluster-init-cluster.sh
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-2-migrate-from-tempo-to-none.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl with the tempo migration to none"
-tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
-echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 bats -t tests/e2e/ekscluster/e2e-ekscluster-2-migrate-from-tempo-to-none.sh
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-3-migrate-from-kyverno-to-none.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl with the kyverno migration to none"
-tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
-echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 bats -t tests/e2e/ekscluster/e2e-ekscluster-3-migrate-from-kyverno-to-none.sh
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-4-migrate-from-velero-to-none.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl with the velero migration to none"
-tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
-echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 bats -t tests/e2e/ekscluster/e2e-ekscluster-4-migrate-from-velero-to-none.sh
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-5-migrate-from-loki-to-none.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl with the logging migration to none"
-tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
-echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 bats -t tests/e2e/ekscluster/e2e-ekscluster-5-migrate-from-loki-to-none.sh
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-6-migrate-from-mimir-to-none.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl with the mimir migration to none"
-tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
-echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 bats -t tests/e2e/ekscluster/e2e-ekscluster-6-migrate-from-mimir-to-none.sh
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl with the auth basic to sso migration"
-tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
-echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 bats -t tests/e2e/ekscluster/e2e-ekscluster-7-migrate-from-basicAuth-to-sso.sh
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-8-migrate-from-sso-to-none.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl with the auth basic to sso migration"
-tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
-echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 bats -t tests/e2e/ekscluster/e2e-ekscluster-8-migrate-from-sso-to-none.sh
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-9-migrate-from-none-to-safe-values.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl testing migrations from none (SAFE)"
-echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
-tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-10-migrate-from-kyverno-default-policies-to-disabled.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl testing kyverno uninstall policies (SAFE)"
-tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
-echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 bats -t tests/e2e/ekscluster/e2e-ekscluster-10-migrate-from-kyverno-default-policies-to-disabled.sh
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-11-migrate-from-alertmanagerconfigs-to-disabled.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"
 echo "Executing furyctl testing alertmanagerconfigs uninstall (SAFE)"
-tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
-echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 bats -t tests/e2e/ekscluster/e2e-ekscluster-11-migrate-from-alertmanagerconfigs-to-disabled.sh
 

--- a/tests/e2e/ekscluster/e2e-ekscluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster.sh
@@ -71,13 +71,14 @@ tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
 echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 bats -t tests/e2e/ekscluster/e2e-ekscluster-6-migrate-from-mimir-to-none.sh
 
-# LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
-# tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
-# echo "----------------------------------------------------------------------------"
-# echo "Executing furyctl with the auth basic to sso migration"
-# tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
-# echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
-# bats -t tests/e2e/ekscluster/e2e-ekscluster-7-migrate-from-basicAuth-to-sso.sh
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl with the auth basic to sso migration"
+tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+export KUBECONFIG=./kubeconfig
+echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
+bats -t tests/e2e/ekscluster/e2e-ekscluster-7-migrate-from-basicAuth-to-sso.sh
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-8-migrate-from-sso-to-none.yaml
 tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"

--- a/tests/e2e/ekscluster/e2e-ekscluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster.sh
@@ -5,9 +5,6 @@
 
 set -e
 
-echo "$PWD"
-echo ls
-
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
 tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
 echo "----------------------------------------------------------------------------"

--- a/tests/e2e/ekscluster/e2e-ekscluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env sh
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set -e
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl for the initial setup"
+tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+echo "Testing that the components are running"
+bats -t tests/e2e/ekscluster/e2e-ekscluster-init-cluster.sh
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-cleanup-all.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl cleanup all modules and configurations"
+tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+bats -t tests/e2e/ekscluster/e2e-ekscluster-cleanup-all.sh
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+echo "----------------------------------------------------------------------------"
+echo "Resetting furyctl with the initial setup"
+tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+echo "Testing that the components are running"
+bats -t tests/e2e/ekscluster/e2e-ekscluster-init-cluster.sh
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-2-migrate-from-tempo-to-none.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl with the tempo migration to none"
+tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+bats -t tests/e2e/ekscluster/e2e-ekscluster-2-migrate-from-tempo-to-none.sh
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-3-migrate-from-kyverno-to-none.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl with the kyverno migration to none"
+tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+bats -t tests/e2e/ekscluster/e2e-ekscluster-3-migrate-from-kyverno-to-none.sh
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-4-migrate-from-velero-to-none.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl with the velero migration to none"
+tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+bats -t tests/e2e/ekscluster/e2e-ekscluster-4-migrate-from-velero-to-none.sh
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-5-migrate-from-loki-to-none.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl with the logging migration to none"
+tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+bats -t tests/e2e/ekscluster/e2e-ekscluster-5-migrate-from-loki-to-none.sh
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-6-migrate-from-mimir-to-none.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl with the mimir migration to none"
+tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+bats -t tests/e2e/ekscluster/e2e-ekscluster-6-migrate-from-mimir-to-none.sh
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl with the auth basic to sso migration"
+tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+bats -t tests/e2e/ekscluster/e2e-ekscluster-7-migrate-from-basicAuth-to-sso.sh
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-8-migrate-from-sso-to-none.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl with the auth basic to sso migration"
+tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+bats -t tests/e2e/ekscluster/e2e-ekscluster-8-migrate-from-sso-to-none.sh
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-9-migrate-from-none-to-safe-values.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl testing migrations from none (SAFE)"
+echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-10-migrate-from-kyverno-default-policies-to-disabled.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl testing kyverno uninstall policies (SAFE)"
+tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+bats -t tests/e2e/ekscluster/e2e-ekscluster-10-migrate-from-kyverno-default-policies-to-disabled.sh
+
+LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-11-migrate-from-alertmanagerconfigs-to-disabled.yaml
+tests/e2e/ekscluster/replace_variables.sh --distribution-version $DISTRIBUTION_VERSION --cluster-name $CLUSTER_NAME --furyctl-yaml $LAST_FURYCTL_YAML
+echo "----------------------------------------------------------------------------"
+echo "Executing furyctl testing alertmanagerconfigs uninstall (SAFE)"
+tests/e2e/ekscluster/furyctl_apply.expect $LAST_FURYCTL_YAML
+echo $LAST_FURYCTL_YAML > last_furyctl_yaml.txt
+bats -t tests/e2e/ekscluster/e2e-ekscluster-11-migrate-from-alertmanagerconfigs-to-disabled.sh
+

--- a/tests/e2e/ekscluster/e2e-ekscluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster.sh
@@ -83,15 +83,14 @@ bats -t tests/e2e/ekscluster/e2e-ekscluster-7-migrate-from-basicAuth-to-sso.sh
 #Temporary fix to delete pomerium dns 
 hosted_zone_id=$(aws route53 list-hosted-zones \
   --output text \
-  --query 'HostedZones[?Name==`$CLUSTER_NAME.e2e.ci.sighup.cc.`].Id')
+  --query "HostedZones[?Name==`$CLUSTER_NAME.e2e.ci.sighup.cc.`].Id")
 aws route53 list-resource-record-sets \
-  --hosted-zone-id $hosted_zone_id | \
+  --hosted-zone-id "$hosted_zone_id" | \
 jq -c '.ResourceRecordSets[]' | \
 while read -r resourcerecordset; do
-  read -r name type <<<$(echo $(jq -r '.Name,.Type' <<<"$resourcerecordset"))
-  if [ $type != "NS" -a $type != "SOA" ]; then
+  if [ "$type" != "NS" -a "$type" != "SOA" ]; then
     aws route53 change-resource-record-sets \
-      --hosted-zone-id $hosted_zone_id \
+      --hosted-zone-id "$hosted_zone_id" \
       --change-batch '{"Changes":[{"Action":"DELETE","ResourceRecordSet":
           '"$resourcerecordset"'
         }]}' \

--- a/tests/e2e/ekscluster/e2e-ekscluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster.sh
@@ -83,7 +83,7 @@ bats -t tests/e2e/ekscluster/e2e-ekscluster-7-migrate-from-basicAuth-to-sso.sh
 #Temporary fix to delete pomerium dns 
 hosted_zone_id=$(aws route53 list-hosted-zones \
 --output text \
---query "HostedZones[?Name==$CLUSTER_NAME.e2e.ci.sighup.cc.)].Id")
+--query "HostedZones[?Name==\"$CLUSTER_NAME.e2e.ci.sighup.cc.\"].Id")
 
 aws route53 list-resource-record-sets \
 --hosted-zone-id "$hosted_zone_id" | \

--- a/tests/e2e/ekscluster/e2e-ekscluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster.sh
@@ -83,7 +83,7 @@ bats -t tests/e2e/ekscluster/e2e-ekscluster-7-migrate-from-basicAuth-to-sso.sh
 #Temporary fix to delete pomerium dns 
 hosted_zone_id=$(aws route53 list-hosted-zones \
   --output text \
-  --query "HostedZones[?Name==`$CLUSTER_NAME.e2e.ci.sighup.cc.`].Id")
+  --query "HostedZones[?Name==$("$CLUSTER_NAME".e2e.ci.sighup.cc.)].Id")
 aws route53 list-resource-record-sets \
   --hosted-zone-id "$hosted_zone_id" | \
 jq -c '.ResourceRecordSets[]' | \

--- a/tests/e2e/ekscluster/e2e-ekscluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster.sh
@@ -88,6 +88,7 @@ aws route53 list-resource-record-sets \
   --hosted-zone-id "$hosted_zone_id" | \
 jq -c '.ResourceRecordSets[]' | \
 while read -r resourcerecordset; do
+    read -r name type <<<$(echo $(jq -r '.Name,.Type' <<<"$resourcerecordset"))
   if [ "$type" != "NS" -a "$type" != "SOA" ]; then
     aws route53 change-resource-record-sets \
       --hosted-zone-id "$hosted_zone_id" \

--- a/tests/e2e/ekscluster/e2e-ekscluster.sh
+++ b/tests/e2e/ekscluster/e2e-ekscluster.sh
@@ -71,13 +71,13 @@ tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
 echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
 bats -t tests/e2e/ekscluster/e2e-ekscluster-6-migrate-from-mimir-to-none.sh
 
-LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
-tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
-echo "----------------------------------------------------------------------------"
-echo "Executing furyctl with the auth basic to sso migration"
-tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
-echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
-bats -t tests/e2e/ekscluster/e2e-ekscluster-7-migrate-from-basicAuth-to-sso.sh
+# LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
+# tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"
+# echo "----------------------------------------------------------------------------"
+# echo "Executing furyctl with the auth basic to sso migration"
+# tests/e2e/ekscluster/furyctl_apply.expect "$LAST_FURYCTL_YAML"
+# echo "$LAST_FURYCTL_YAML" > last_furyctl_yaml.txt
+# bats -t tests/e2e/ekscluster/e2e-ekscluster-7-migrate-from-basicAuth-to-sso.sh
 
 LAST_FURYCTL_YAML=tests/e2e/ekscluster/manifests/furyctl-8-migrate-from-sso-to-none.yaml
 tests/e2e/ekscluster/replace_variables.sh --distribution-version "$DISTRIBUTION_VERSION" --cluster-name "$CLUSTER_NAME" --furyctl-yaml "$LAST_FURYCTL_YAML"

--- a/tests/e2e/ekscluster/furyctl_apply.expect
+++ b/tests/e2e/ekscluster/furyctl_apply.expect
@@ -31,7 +31,7 @@ if { ![info exists env(AWS_ACCESS_KEY_ID)] || \
 
 
 # Start furyctl apply.
-spawn furyctl apply --outdir $outdir -D --config $configFilePath
+spawn furyctl apply --outdir $outdir --debug --disable-analytics --config $configFilePath
 set furyctl_id $spawn_id
 
 expect {
@@ -48,7 +48,7 @@ expect {
         exit 1
     }
     eof {
-        puts "Furyctl process ended."
+        puts "furyctl process ended."
     }
 }
 

--- a/tests/e2e/ekscluster/furyctl_apply.expect
+++ b/tests/e2e/ekscluster/furyctl_apply.expect
@@ -11,6 +11,15 @@ if {[llength $argv] == 0} {
     puts "Usage: furyctl_apply.expect /path/to/furyctl.yaml"
     exit 1
 }
+
+if {[llength $argv] >= 2} { 
+    set outdir [lindex $argv 1] 
+    puts "Using specified output directory: $outdir" 
+} else { 
+    set outdir $env(PWD) 
+    puts "Using current directory as output directory: $outdir" 
+}
+
 set configFilePath [lindex $argv 0]
 # Verify that necessary AWS environment variables exist.
 if { ![info exists env(AWS_ACCESS_KEY_ID)] || \
@@ -22,7 +31,7 @@ if { ![info exists env(AWS_ACCESS_KEY_ID)] || \
 
 
 # Start furyctl apply.
-spawn furyctl apply --outdir $env(PWD) -D --config $configFilePath
+spawn furyctl apply --outdir $outdir -D --config $configFilePath
 set furyctl_id $spawn_id
 
 expect {

--- a/tests/e2e/ekscluster/furyctl_apply.expect
+++ b/tests/e2e/ekscluster/furyctl_apply.expect
@@ -1,0 +1,57 @@
+#!/usr/bin/expect -f
+# Increase timeout as needed:
+set timeout 3600
+puts "Current working directory: $env(PWD)"
+if {[llength $argv] == 0} {
+    puts "Usage: furyctl_apply.expect /path/to/furyctl.yaml"
+    exit 1
+}
+set configFilePath [lindex $argv 0]
+# Verify that necessary AWS environment variables exist.
+if { ![info exists env(AWS_ACCESS_KEY_ID)] || \
+     ![info exists env(AWS_SECRET_ACCESS_KEY)] || \
+     ![info exists env(AWS_REGION)] } {
+    puts "One or more AWS environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION) are not set."
+    exit 1
+}
+
+
+# Start furyctl apply.
+spawn furyctl apply --outdir $env(PWD) -D --config $configFilePath
+set furyctl_id $spawn_id
+
+expect {
+
+     -re {.*Are you sure you want to continue\? Only 'yes' will be accepted to confirm.*} {
+        puts "Confirmation prompt detected, sending 'yes'"
+        send -i $furyctl_id "yes\r"
+        exp_continue
+    }
+    timeout {
+        puts "Timed out waiting for the interactive prompt."
+        catch {kill -s INT [exp_pid -i $furyctl_id]}
+        sleep 5
+        exit 1
+    }
+    eof {
+        puts "Furyctl process ended."
+    }
+}
+
+
+# Wait until furyctl has finished and capture its exit code
+set exit_code 0
+if {[catch {wait -i $furyctl_id} result]} {
+    puts "Process already exited, trying to get exit code from result: $result"
+    # Try to extract exit code from the result if possible
+    if {[llength $result] >= 4} {
+        set exit_code [lindex $result 3]
+    }
+} else {
+    # Normal case: extract exit code from wait result
+    puts "Furyctl exit status: $result"
+    set exit_code [lindex $result 3]
+}
+
+puts "Script completed with exit code $exit_code."
+exit $exit_code

--- a/tests/e2e/ekscluster/furyctl_apply.expect
+++ b/tests/e2e/ekscluster/furyctl_apply.expect
@@ -1,4 +1,9 @@
 #!/usr/bin/expect -f
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
 # Increase timeout as needed:
 set timeout 3600
 puts "Current working directory: $env(PWD)"

--- a/tests/e2e/ekscluster/furyctl_delete.expect
+++ b/tests/e2e/ekscluster/furyctl_delete.expect
@@ -1,0 +1,129 @@
+#!/usr/bin/expect -f
+# Increase timeout as needed:
+set timeout 3600
+puts "Current working directory: $env(PWD)"
+if {[llength $argv] == 0} {
+    puts "Usage: furyctl_apply.expect /path/to/furyctl.yaml"
+    exit 1
+}
+set configFilePath [lindex $argv 0]
+# Verify that necessary AWS environment variables exist.
+if { ![info exists env(AWS_ACCESS_KEY_ID)] || \
+     ![info exists env(AWS_SECRET_ACCESS_KEY)] || \
+     ![info exists env(AWS_REGION)] } {
+    puts "One or more AWS environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION) are not set."
+    exit 1
+}
+
+# # Function to check if OpenVPN is already running
+# proc is_openvpn_running {} {
+#     set openvpn_running [catch {exec pgrep -f "openvpn --config"} result]
+#     return [expr {$openvpn_running == 0}]
+# }
+
+# # Function to start OpenVPN and wait for initialization
+# proc start_openvpn {config_file} {
+#     set vpn_timeout 300
+#     puts "Starting OpenVPN connection..."
+    
+#     # Spawn OpenVPN process
+#     spawn openvpn --config $config_file
+#     set vpn_id $spawn_id
+    
+#     # Wait for initialization to complete
+#     set initialized 0
+#     expect {
+#         -re {.*Initialization Sequence Completed.*} {
+#             puts "OpenVPN connection established successfully."
+#             set initialized 1
+#         }
+#         timeout {
+#             puts "Timed out waiting for OpenVPN to initialize."
+#             catch {exec kill -9 [exp_pid -i $vpn_id]}
+#             return 0
+#         }
+#         eof {
+#             puts "OpenVPN process terminated unexpectedly."
+#             return 0
+#         }
+#     }
+    
+#     if {$initialized} {
+#         # Detach the process but keep it running
+#         set vpn_pid [exp_pid -i $vpn_id]
+#         puts "OpenVPN running with PID: $vpn_pid"
+        
+#         return 1
+#     }
+    
+#     return 0
+# }
+
+# Start furyctl apply.
+spawn furyctl delete cluster --outdir $env(PWD) -D --config $configFilePath
+set furyctl_id $spawn_id
+# set prompt_count 0
+
+expect {
+    # -re {.*Press ENTER when you are ready to continue.*} {
+    #     incr prompt_count
+    #     if {$prompt_count == 1} {
+    #         # First prompt: check if OpenVPN is already connected, if not, connect
+    #         sleep 5
+            
+    #         # Check if VPN is already running
+    #         if {[is_openvpn_running]} {
+    #             puts "OpenVPN is already running. Continuing without restarting."
+    #         } else {
+    #             # Start OpenVPN and wait for initialization
+    #             set vpn_config "$env(PWD)/e2e-drone.ovpn"
+    #             if {![start_openvpn $vpn_config]} {
+    #                 puts "Failed to establish OpenVPN connection. Exiting..."
+    #                 exit 1
+    #             }
+    #         }
+            
+    #         # Continue with furyctl
+    #         send -i $furyctl_id "\r"
+    #         exp_continue
+    #     } elseif {$prompt_count == 2} {
+    #         # Second prompt: Just press enter
+    #         send -i $furyctl_id "\r"
+    #         exp_continue
+    #     }
+    # }
+     -re {.*Are you sure you want to continue\? Only 'yes' will be accepted to confirm.*} {
+        puts "Confirmation prompt detected, sending 'yes'"
+        send -i $furyctl_id "yes\r"
+        exp_continue
+    }
+    timeout {
+        puts "Timed out waiting for the interactive prompt."
+        catch {kill -s INT [exp_pid -i $furyctl_id]}
+        sleep 5
+        exit 1
+    }
+    eof {
+        puts "Furyctl process ended."
+    }
+}
+
+
+# Wait until furyctl has finished and capture its exit code
+set exit_code 0
+if {[catch {wait -i $furyctl_id} result]} {
+    puts "Process already exited, trying to get exit code from result: $result"
+    # Try to extract exit code from the result if possible
+    if {[llength $result] >= 4} {
+        set exit_code [lindex $result 3]
+    }
+} else {
+    # Normal case: extract exit code from wait result
+    puts "Furyctl exit status: $result"
+    set exit_code [lindex $result 3]
+}
+
+puts "Script completed with exit code $exit_code."
+exit $exit_code
+
+exec aws s3 rm s3://e2e-drone-eks/$env(CLUSTER_NAME) --recursive

--- a/tests/e2e/ekscluster/furyctl_delete.expect
+++ b/tests/e2e/ekscluster/furyctl_delete.expect
@@ -22,7 +22,7 @@ if { ![info exists env(AWS_ACCESS_KEY_ID)] || \
 
 
 # Start furyctl apply.
-spawn furyctl delete cluster --outdir $env(PWD) -D --config $configFilePath
+spawn furyctl delete cluster --outdir $env(PWD) --debug --disable-analytics --config $configFilePath
 set furyctl_id $spawn_id
 
 expect {
@@ -38,7 +38,7 @@ expect {
         exit 1
     }
     eof {
-        puts "Furyctl process ended."
+        puts "furyctl process ended."
     }
 }
 

--- a/tests/e2e/ekscluster/furyctl_delete.expect
+++ b/tests/e2e/ekscluster/furyctl_delete.expect
@@ -1,4 +1,9 @@
 #!/usr/bin/expect -f
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
 # Increase timeout as needed:
 set timeout 3600
 puts "Current working directory: $env(PWD)"

--- a/tests/e2e/ekscluster/helper.bash
+++ b/tests/e2e/ekscluster/helper.bash
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2154,SC2034,SC2086
+
+apply (){
+  kustomize build $1 >&2
+  kustomize build $1 | kubectl apply -f - --server-side 2>&3
+}
+
+delete (){
+  kustomize build $1 >&2
+  kustomize build $1 | kubectl delete -f - 2>&3
+}
+
+info(){
+  echo -e "${BATS_TEST_NUMBER}: ${BATS_TEST_DESCRIPTION}" >&3
+}
+
+loop_it(){
+  retry_counter=0
+  max_retry=${2:-100}
+  wait_time=${3:-2}
+  run ${1}
+  ko=${status}
+  loop_it_result=${ko}
+  while [[ ko -ne 0 ]]
+  do
+    if [ $retry_counter -ge $max_retry ]; then
+      echo "Timeout waiting for the command to success."
+      echo "Last command output was:"
+      echo "${output}"
+      return 1
+    fi
+    sleep ${wait_time} && echo "# waiting..." $retry_counter >&3
+    run ${1}
+    ko=${status}
+    loop_it_result=${ko}
+    retry_counter=$((retry_counter + 1))
+  done
+  return 0
+}

--- a/tests/e2e/ekscluster/manifests/furyctl-10-migrate-from-kyverno-default-policies-to-disabled.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-10-migrate-from-kyverno-default-policies-to-disabled.yaml
@@ -13,48 +13,32 @@
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
-  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
-  name: e2e-drone
+  name: e2e-test-eks
 spec:
-  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
-  # it supports git tags and branches
-  distributionVersion: "DISTRIBUTION_VERSION"
-  # This sections defines where to store the terraform state files used by furyctl
+  distributionVersion: v1.31.0
   toolsConfiguration:
     terraform:
       state:
         s3:
-          # This value defines which bucket will be used to store all the states
           bucketName: e2e-drone-eks
-          # This value defines which folder will be used to store all the states inside the bucket
-          keyPrefix:  "CLUSTER_NAME/"
-          # This value defines in which region the bucket is
+          keyPrefix: e2e-test-eks
           region: eu-west-1
-  # This value defines in which AWS region the cluster and all the related resources will be created
   region: eu-west-1
-  # This map defines which will be the common tags that will be added to all the resources created on AWS
   tags:
-    env:  "CLUSTER_NAME"
-  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
-  # If you already have a VPC, you can remove this key from the configuration file
+    env: e2e-test-eks
   infrastructure:
-    # This key defines the VPC that will be created in AWS
     vpc:
       network:
-        # This is the CIDR of the VPC
         cidr: 10.1.0.0/16
         subnetsCidrs:
-          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
           private:
             - 10.1.0.0/20
             - 10.1.16.0/20
             - 10.1.32.0/20
-          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
           public:
             - 10.1.48.0/24
             - 10.1.49.0/24
             - 10.1.50.0/24
-    # This section defines the creation of VPN bastions
     vpn:
       instances: 0
       port: 1194
@@ -68,78 +52,41 @@ spec:
           - Filo01
         allowedFromCidrs:
           - 0.0.0.0/0
-  # This section describes how the EKS cluster will be created
   kubernetes:
-    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
     nodePoolGlobalAmiType: alinux2
-    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
-    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
-    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
-    nodePoolsLaunchKind: "launch_templates"
-    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
-    # logRetentionDays: 90
-    # This map defines the access to the Kubernetes API server
+    nodePoolsLaunchKind: launch_templates
     apiServer:
       privateAccess: true
       publicAccess: true
-      privateAccessCidrs: ['0.0.0.0/0']
-      publicAccessCidrs: ['0.0.0.0/0']
-    # This array contains the definition of the nodepools in the cluster
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
     nodePools:
-        # This is the name of the nodepool
       - name: infra
         type: eks-managed
-        # This map defines the max and min number of nodes in the nodepool autoscaling group
         size:
           min: 5
           max: 7
-        # This map defines the characteristics of the instance that will be used in the node pool
         instance:
-          # The instance type
           type: t3.xlarge
-          # If the instance is a spot instance
           spot: true
-          # The instance disk size in GB
           volumeSize: 50
-          # The instance disk type
           volumeType: gp2
         labels:
           nodepool: infra
           node.kubernetes.io/role: infra
-        # taints:
-        #   - node.kubernetes.io/role=infra:NoSchedule
         tags:
-          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
-          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
-    awsAuth: 
-     additionalAccounts: []
-    #    - "777777777777"
-    #    - "88888888888"
-     users:
-       - username: "filippo.ravaglia"
-         groups:
-           - system:masters
-         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
-     roles: []
-      #  - username: "example"
-      #    groups:
-      #      - example:masters
-      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
-  # This section describes how the KFD distribution will be installed
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
   distribution:
-    # This common configuration will be applied to all the packages that will be installed in the cluster
-    # common:
-      # networkPoliciesEnabled: true
-      # The node selector to use to place the pods for all the KFD packages
-      # nodeSelector:
-      #   node.kubernetes.io/role: infra
-      # The tolerations that will be added to the pods for all the KFD packages
-      # tolerations:
-      #   - effect: NoSchedule
-      #     key: node.kubernetes.io/role
-      #     value: infra
     modules:
-      # This section contains all the configurations for the ingress module
       ingress:
         baseDomain: internal.e2e.ci.sighup.io
         nginx:
@@ -152,23 +99,17 @@ spec:
             email: test@sighup.io
             type: http01
         dns:
-          # the public DNS zone definition
           public:
-            # the name of the zone
-            name: "e2e.ci.sighup.io"
-            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: e2e.ci.sighup.io
             create: true
-          # the private DNS zone definition, that will be attached to the VPC
           private:
-            # the name of the zone
-            name: "internal.e2e.ci.sighup.io"
-            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: internal.e2e.ci.sighup.io
             create: true
       logging:
         type: loki
         loki:
           backend: minio
-          tsdbStartDate: "2024-11-21"
+          tsdbStartDate: '2024-11-21'
         minio:
           storageSize: 20Gi
           rootUser:
@@ -202,18 +143,15 @@ spec:
       policy:
         type: kyverno
         kyverno:
-          additionalExcludedNamespaces: ["local-path-storage"]
+          additionalExcludedNamespaces:
+            - local-path-storage
           installDefaultPolicies: false
           validationFailureAction: Enforce
       dr:
         type: eks
-        # Configurations for the velero package
         velero:
-          # Velero configurations for EKS cluster
           eks:
-            # The S3 bucket that will be created to store the backups
-            bucketName:  "CLUSTER_NAME-velero"
-            # The region where the bucket will be created (can be different from the overall region defined in .spec.region)
+            bucketName: e2e-test-eks
             region: eu-west-1
       auth:
         provider:

--- a/tests/e2e/ekscluster/manifests/furyctl-10-migrate-from-kyverno-default-policies-to-disabled.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-10-migrate-from-kyverno-default-policies-to-disabled.yaml
@@ -1,0 +1,223 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
+  name: e2e-drone
+spec:
+  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
+  # it supports git tags and branches
+  distributionVersion: "DISTRIBUTION_VERSION"
+  # This sections defines where to store the terraform state files used by furyctl
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          # This value defines which bucket will be used to store all the states
+          bucketName: e2e-drone-eks
+          # This value defines which folder will be used to store all the states inside the bucket
+          keyPrefix:  "CLUSTER_NAME/"
+          # This value defines in which region the bucket is
+          region: eu-west-1
+  # This value defines in which AWS region the cluster and all the related resources will be created
+  region: eu-west-1
+  # This map defines which will be the common tags that will be added to all the resources created on AWS
+  tags:
+    env:  "CLUSTER_NAME"
+  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
+  # If you already have a VPC, you can remove this key from the configuration file
+  infrastructure:
+    # This key defines the VPC that will be created in AWS
+    vpc:
+      network:
+        # This is the CIDR of the VPC
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    # This section defines the creation of VPN bastions
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  # This section describes how the EKS cluster will be created
+  kubernetes:
+    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodePoolGlobalAmiType: alinux2
+    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
+    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
+    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
+    nodePoolsLaunchKind: "launch_templates"
+    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
+    # logRetentionDays: 90
+    # This map defines the access to the Kubernetes API server
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs: ['0.0.0.0/0']
+      publicAccessCidrs: ['0.0.0.0/0']
+    # This array contains the definition of the nodepools in the cluster
+    nodePools:
+        # This is the name of the nodepool
+      - name: infra
+        type: eks-managed
+        # This map defines the max and min number of nodes in the nodepool autoscaling group
+        size:
+          min: 5
+          max: 7
+        # This map defines the characteristics of the instance that will be used in the node pool
+        instance:
+          # The instance type
+          type: t3.xlarge
+          # If the instance is a spot instance
+          spot: true
+          # The instance disk size in GB
+          volumeSize: 50
+          # The instance disk type
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        # taints:
+        #   - node.kubernetes.io/role=infra:NoSchedule
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
+    awsAuth: 
+     additionalAccounts: []
+    #    - "777777777777"
+    #    - "88888888888"
+     users:
+       - username: "filippo.ravaglia"
+         groups:
+           - system:masters
+         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
+     roles: []
+      #  - username: "example"
+      #    groups:
+      #      - example:masters
+      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
+  # This section describes how the KFD distribution will be installed
+  distribution:
+    # This common configuration will be applied to all the packages that will be installed in the cluster
+    # common:
+      # networkPoliciesEnabled: true
+      # The node selector to use to place the pods for all the KFD packages
+      # nodeSelector:
+      #   node.kubernetes.io/role: infra
+      # The tolerations that will be added to the pods for all the KFD packages
+      # tolerations:
+      #   - effect: NoSchedule
+      #     key: node.kubernetes.io/role
+      #     value: infra
+    modules:
+      # This section contains all the configurations for the ingress module
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          # the public DNS zone definition
+          public:
+            # the name of the zone
+            name: "e2e.ci.sighup.io"
+            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+          # the private DNS zone definition, that will be attached to the VPC
+          private:
+            # the name of the zone
+            name: "internal.e2e.ci.sighup.io"
+            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+      logging:
+        type: loki
+        loki:
+          backend: minio
+          tsdbStartDate: "2024-11-21"
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+      monitoring:
+        type: mimir
+        mimir:
+          backend: minio
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: tempo
+        tempo:
+          backend: minio
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: kyverno
+        kyverno:
+          additionalExcludedNamespaces: ["local-path-storage"]
+          installDefaultPolicies: false
+          validationFailureAction: Enforce
+      dr:
+        type: eks
+        # Configurations for the velero package
+        velero:
+          # Velero configurations for EKS cluster
+          eks:
+            # The S3 bucket that will be created to store the backups
+            bucketName:  "CLUSTER_NAME-velero"
+            # The region where the bucket will be created (can be different from the overall region defined in .spec.region)
+            region: eu-west-1
+      auth:
+        provider:
+          type: basicAuth
+          basicAuth:
+            username: test
+            password: testpassword

--- a/tests/e2e/ekscluster/manifests/furyctl-10-migrate-from-kyverno-default-policies-to-disabled.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-10-migrate-from-kyverno-default-policies-to-disabled.yaml
@@ -53,8 +53,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster/manifests/furyctl-10-migrate-from-kyverno-default-policies-to-disabled.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-10-migrate-from-kyverno-default-policies-to-disabled.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: loki

--- a/tests/e2e/ekscluster/manifests/furyctl-11-migrate-from-alertmanagerconfigs-to-disabled.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-11-migrate-from-alertmanagerconfigs-to-disabled.yaml
@@ -53,8 +53,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster/manifests/furyctl-11-migrate-from-alertmanagerconfigs-to-disabled.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-11-migrate-from-alertmanagerconfigs-to-disabled.yaml
@@ -1,0 +1,225 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
+  name:  "CLUSTER_NAME"
+spec:
+  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
+  # it supports git tags and branches
+  distributionVersion: "DISTRIBUTION_VERSION"
+  # This sections defines where to store the terraform state files used by furyctl
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          # This value defines which bucket will be used to store all the states
+          bucketName: e2e-drone-eks
+          # This value defines which folder will be used to store all the states inside the bucket
+          keyPrefix:  "CLUSTER_NAME/"
+          # This value defines in which region the bucket is
+          region: eu-west-1
+  # This value defines in which AWS region the cluster and all the related resources will be created
+  region: eu-west-1
+  # This map defines which will be the common tags that will be added to all the resources created on AWS
+  tags:
+    env:  "CLUSTER_NAME"
+  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
+  # If you already have a VPC, you can remove this key from the configuration file
+  infrastructure:
+    # This key defines the VPC that will be created in AWS
+    vpc:
+      network:
+        # This is the CIDR of the VPC
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    # This section defines the creation of VPN bastions
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  # This section describes how the EKS cluster will be created
+  kubernetes:
+    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodePoolGlobalAmiType: alinux2
+    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
+    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
+    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
+    nodePoolsLaunchKind: "launch_templates"
+    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
+    # logRetentionDays: 90
+    # This map defines the access to the Kubernetes API server
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs: ['0.0.0.0/0']
+      publicAccessCidrs: ['0.0.0.0/0']
+    # This array contains the definition of the nodepools in the cluster
+    nodePools:
+        # This is the name of the nodepool
+      - name: infra
+        type: eks-managed
+        # This map defines the max and min number of nodes in the nodepool autoscaling group
+        size:
+          min: 5
+          max: 7
+        # This map defines the characteristics of the instance that will be used in the node pool
+        instance:
+          # The instance type
+          type: t3.xlarge
+          # If the instance is a spot instance
+          spot: true
+          # The instance disk size in GB
+          volumeSize: 50
+          # The instance disk type
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        # taints:
+        #   - node.kubernetes.io/role=infra:NoSchedule
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
+    awsAuth: 
+     additionalAccounts: []
+    #    - "777777777777"
+    #    - "88888888888"
+     users:
+       - username: "filippo.ravaglia"
+         groups:
+           - system:masters
+         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
+     roles: []
+      #  - username: "example"
+      #    groups:
+      #      - example:masters
+      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
+  # This section describes how the KFD distribution will be installed
+  distribution:
+    # This common configuration will be applied to all the packages that will be installed in the cluster
+    # common:
+      # networkPoliciesEnabled: true
+      # The node selector to use to place the pods for all the KFD packages
+      # nodeSelector:
+      #   node.kubernetes.io/role: infra
+      # The tolerations that will be added to the pods for all the KFD packages
+      # tolerations:
+      #   - effect: NoSchedule
+      #     key: node.kubernetes.io/role
+      #     value: infra
+    modules:
+      # This section contains all the configurations for the ingress module
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          # the public DNS zone definition
+          public:
+            # the name of the zone
+            name: "e2e.ci.sighup.io"
+            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+          # the private DNS zone definition, that will be attached to the VPC
+          private:
+            # the name of the zone
+            name: "internal.e2e.ci.sighup.io"
+            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+      logging:
+        type: loki
+        loki:
+          backend: minio
+          tsdbStartDate: "2024-11-21"
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+      monitoring:
+        type: mimir
+        mimir:
+          backend: minio
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+        alertmanager:
+          installDefaultRules: false
+      tracing:
+        type: tempo
+        tempo:
+          backend: minio
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: kyverno
+        kyverno:
+          additionalExcludedNamespaces: ["local-path-storage"]
+          installDefaultPolicies: false
+          validationFailureAction: Enforce
+      dr:
+        type: eks
+        # Configurations for the velero package
+        velero:
+          # Velero configurations for EKS cluster
+          eks:
+            # The S3 bucket that will be created to store the backups
+            bucketName:  "CLUSTER_NAME-velero"
+            # The region where the bucket will be created (can be different from the overall region defined in .spec.region)
+            region: eu-west-1
+      auth:
+        provider:
+          type: basicAuth
+          basicAuth:
+            username: test
+            password: testpassword

--- a/tests/e2e/ekscluster/manifests/furyctl-11-migrate-from-alertmanagerconfigs-to-disabled.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-11-migrate-from-alertmanagerconfigs-to-disabled.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: loki

--- a/tests/e2e/ekscluster/manifests/furyctl-11-migrate-from-alertmanagerconfigs-to-disabled.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-11-migrate-from-alertmanagerconfigs-to-disabled.yaml
@@ -13,48 +13,32 @@
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
-  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
-  name:  "CLUSTER_NAME"
+  name: e2e-test-eks
 spec:
-  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
-  # it supports git tags and branches
-  distributionVersion: "DISTRIBUTION_VERSION"
-  # This sections defines where to store the terraform state files used by furyctl
+  distributionVersion: v1.31.0
   toolsConfiguration:
     terraform:
       state:
         s3:
-          # This value defines which bucket will be used to store all the states
           bucketName: e2e-drone-eks
-          # This value defines which folder will be used to store all the states inside the bucket
-          keyPrefix:  "CLUSTER_NAME/"
-          # This value defines in which region the bucket is
+          keyPrefix: e2e-test-eks
           region: eu-west-1
-  # This value defines in which AWS region the cluster and all the related resources will be created
   region: eu-west-1
-  # This map defines which will be the common tags that will be added to all the resources created on AWS
   tags:
-    env:  "CLUSTER_NAME"
-  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
-  # If you already have a VPC, you can remove this key from the configuration file
+    env: e2e-test-eks
   infrastructure:
-    # This key defines the VPC that will be created in AWS
     vpc:
       network:
-        # This is the CIDR of the VPC
         cidr: 10.1.0.0/16
         subnetsCidrs:
-          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
           private:
             - 10.1.0.0/20
             - 10.1.16.0/20
             - 10.1.32.0/20
-          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
           public:
             - 10.1.48.0/24
             - 10.1.49.0/24
             - 10.1.50.0/24
-    # This section defines the creation of VPN bastions
     vpn:
       instances: 0
       port: 1194
@@ -68,78 +52,41 @@ spec:
           - Filo01
         allowedFromCidrs:
           - 0.0.0.0/0
-  # This section describes how the EKS cluster will be created
   kubernetes:
-    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
     nodePoolGlobalAmiType: alinux2
-    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
-    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
-    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
-    nodePoolsLaunchKind: "launch_templates"
-    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
-    # logRetentionDays: 90
-    # This map defines the access to the Kubernetes API server
+    nodePoolsLaunchKind: launch_templates
     apiServer:
       privateAccess: true
       publicAccess: true
-      privateAccessCidrs: ['0.0.0.0/0']
-      publicAccessCidrs: ['0.0.0.0/0']
-    # This array contains the definition of the nodepools in the cluster
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
     nodePools:
-        # This is the name of the nodepool
       - name: infra
         type: eks-managed
-        # This map defines the max and min number of nodes in the nodepool autoscaling group
         size:
           min: 5
           max: 7
-        # This map defines the characteristics of the instance that will be used in the node pool
         instance:
-          # The instance type
           type: t3.xlarge
-          # If the instance is a spot instance
           spot: true
-          # The instance disk size in GB
           volumeSize: 50
-          # The instance disk type
           volumeType: gp2
         labels:
           nodepool: infra
           node.kubernetes.io/role: infra
-        # taints:
-        #   - node.kubernetes.io/role=infra:NoSchedule
         tags:
-          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
-          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
-    awsAuth: 
-     additionalAccounts: []
-    #    - "777777777777"
-    #    - "88888888888"
-     users:
-       - username: "filippo.ravaglia"
-         groups:
-           - system:masters
-         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
-     roles: []
-      #  - username: "example"
-      #    groups:
-      #      - example:masters
-      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
-  # This section describes how the KFD distribution will be installed
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
   distribution:
-    # This common configuration will be applied to all the packages that will be installed in the cluster
-    # common:
-      # networkPoliciesEnabled: true
-      # The node selector to use to place the pods for all the KFD packages
-      # nodeSelector:
-      #   node.kubernetes.io/role: infra
-      # The tolerations that will be added to the pods for all the KFD packages
-      # tolerations:
-      #   - effect: NoSchedule
-      #     key: node.kubernetes.io/role
-      #     value: infra
     modules:
-      # This section contains all the configurations for the ingress module
       ingress:
         baseDomain: internal.e2e.ci.sighup.io
         nginx:
@@ -152,23 +99,17 @@ spec:
             email: test@sighup.io
             type: http01
         dns:
-          # the public DNS zone definition
           public:
-            # the name of the zone
-            name: "e2e.ci.sighup.io"
-            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: e2e.ci.sighup.io
             create: true
-          # the private DNS zone definition, that will be attached to the VPC
           private:
-            # the name of the zone
-            name: "internal.e2e.ci.sighup.io"
-            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: internal.e2e.ci.sighup.io
             create: true
       logging:
         type: loki
         loki:
           backend: minio
-          tsdbStartDate: "2024-11-21"
+          tsdbStartDate: '2024-11-21'
         minio:
           storageSize: 20Gi
           rootUser:
@@ -204,18 +145,15 @@ spec:
       policy:
         type: kyverno
         kyverno:
-          additionalExcludedNamespaces: ["local-path-storage"]
+          additionalExcludedNamespaces:
+            - local-path-storage
           installDefaultPolicies: false
           validationFailureAction: Enforce
       dr:
         type: eks
-        # Configurations for the velero package
         velero:
-          # Velero configurations for EKS cluster
           eks:
-            # The S3 bucket that will be created to store the backups
-            bucketName:  "CLUSTER_NAME-velero"
-            # The region where the bucket will be created (can be different from the overall region defined in .spec.region)
+            bucketName: e2e-test-eks
             region: eu-west-1
       auth:
         provider:

--- a/tests/e2e/ekscluster/manifests/furyctl-2-migrate-from-tempo-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-2-migrate-from-tempo-to-none.yaml
@@ -53,8 +53,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster/manifests/furyctl-2-migrate-from-tempo-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-2-migrate-from-tempo-to-none.yaml
@@ -1,0 +1,224 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
+  name:  "CLUSTER_NAME"
+spec:
+  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
+  # it supports git tags and branches
+  distributionVersion: "DISTRIBUTION_VERSION"
+  # This sections defines where to store the terraform state files used by furyctl
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          # This value defines which bucket will be used to store all the states
+          bucketName: e2e-drone-eks
+          # This value defines which folder will be used to store all the states inside the bucket
+          keyPrefix:  "CLUSTER_NAME/"
+          # This value defines in which region the bucket is
+          region: eu-west-1
+  # This value defines in which AWS region the cluster and all the related resources will be created
+  region: eu-west-1
+  # This map defines which will be the common tags that will be added to all the resources created on AWS
+  tags:
+    env:  "CLUSTER_NAME"
+  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
+  # If you already have a VPC, you can remove this key from the configuration file
+  infrastructure:
+    # This key defines the VPC that will be created in AWS
+    vpc:
+      network:
+        # This is the CIDR of the VPC
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    # This section defines the creation of VPN bastions
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  # This section describes how the EKS cluster will be created
+  kubernetes:
+    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodePoolGlobalAmiType: alinux2
+    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
+    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
+    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
+    nodePoolsLaunchKind: "launch_templates"
+    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
+    # logRetentionDays: 90
+    # This map defines the access to the Kubernetes API server
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs: ['0.0.0.0/0']
+      publicAccessCidrs: ['0.0.0.0/0']
+    # This array contains the definition of the nodepools in the cluster
+    nodePools:
+        # This is the name of the nodepool
+      - name: infra
+        type: eks-managed
+        # This map defines the max and min number of nodes in the nodepool autoscaling group
+        size:
+          min: 5
+          max: 7
+        # This map defines the characteristics of the instance that will be used in the node pool
+        instance:
+          # The instance type
+          type: t3.xlarge
+          # If the instance is a spot instance
+          spot: true
+          # The instance disk size in GB
+          volumeSize: 50
+          # The instance disk type
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        # taints:
+        #   - node.kubernetes.io/role=infra:NoSchedule
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
+    awsAuth: 
+     additionalAccounts: []
+    #    - "777777777777"
+    #    - "88888888888"
+     users:
+       - username: "filippo.ravaglia"
+         groups:
+           - system:masters
+         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
+     roles: []
+      #  - username: "example"
+      #    groups:
+      #      - example:masters
+      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
+  # This section describes how the KFD distribution will be installed
+  distribution:
+    # This common configuration will be applied to all the packages that will be installed in the cluster
+    # common:
+      # networkPoliciesEnabled: true
+      # The node selector to use to place the pods for all the KFD packages
+      # nodeSelector:
+      #   node.kubernetes.io/role: infra
+      # The tolerations that will be added to the pods for all the KFD packages
+      # tolerations:
+      #   - effect: NoSchedule
+      #     key: node.kubernetes.io/role
+      #     value: infra
+    modules:
+      # This section contains all the configurations for the ingress module
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          # the public DNS zone definition
+          public:
+            # the name of the zone
+            name: "e2e.ci.sighup.io"
+            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+          # the private DNS zone definition, that will be attached to the VPC
+          private:
+            # the name of the zone
+            name: "internal.e2e.ci.sighup.io"
+            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+      logging:
+        type: loki
+        loki:
+          backend: minio
+          tsdbStartDate: "2024-11-21"
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+      monitoring:
+        type: mimir
+        mimir:
+          backend: minio
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: none
+        tempo:
+          backend: minio
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: kyverno
+        kyverno:
+          additionalExcludedNamespaces: ["local-path-storage"]
+          installDefaultPolicies: true
+          validationFailureAction: Enforce
+      dr:
+        type: eks
+        # Configurations for the velero package
+        velero:
+          # Velero configurations for EKS cluster
+          eks:
+            # The S3 bucket that will be created to store the backups
+            bucketName:  "CLUSTER_NAME-velero"
+            # The region where the bucket will be created (can be different from the overall region defined in .spec.region)
+            region: eu-west-1
+      auth:
+        provider:
+          type: basicAuth
+          basicAuth:
+            username: test
+            password: testpassword
+    

--- a/tests/e2e/ekscluster/manifests/furyctl-2-migrate-from-tempo-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-2-migrate-from-tempo-to-none.yaml
@@ -13,48 +13,32 @@
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
-  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
-  name:  "CLUSTER_NAME"
+  name: e2e-test-eks
 spec:
-  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
-  # it supports git tags and branches
-  distributionVersion: "DISTRIBUTION_VERSION"
-  # This sections defines where to store the terraform state files used by furyctl
+  distributionVersion: v1.31.0
   toolsConfiguration:
     terraform:
       state:
         s3:
-          # This value defines which bucket will be used to store all the states
           bucketName: e2e-drone-eks
-          # This value defines which folder will be used to store all the states inside the bucket
-          keyPrefix:  "CLUSTER_NAME/"
-          # This value defines in which region the bucket is
+          keyPrefix: e2e-test-eks
           region: eu-west-1
-  # This value defines in which AWS region the cluster and all the related resources will be created
   region: eu-west-1
-  # This map defines which will be the common tags that will be added to all the resources created on AWS
   tags:
-    env:  "CLUSTER_NAME"
-  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
-  # If you already have a VPC, you can remove this key from the configuration file
+    env: e2e-test-eks
   infrastructure:
-    # This key defines the VPC that will be created in AWS
     vpc:
       network:
-        # This is the CIDR of the VPC
         cidr: 10.1.0.0/16
         subnetsCidrs:
-          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
           private:
             - 10.1.0.0/20
             - 10.1.16.0/20
             - 10.1.32.0/20
-          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
           public:
             - 10.1.48.0/24
             - 10.1.49.0/24
             - 10.1.50.0/24
-    # This section defines the creation of VPN bastions
     vpn:
       instances: 0
       port: 1194
@@ -68,78 +52,41 @@ spec:
           - Filo01
         allowedFromCidrs:
           - 0.0.0.0/0
-  # This section describes how the EKS cluster will be created
   kubernetes:
-    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
     nodePoolGlobalAmiType: alinux2
-    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
-    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
-    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
-    nodePoolsLaunchKind: "launch_templates"
-    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
-    # logRetentionDays: 90
-    # This map defines the access to the Kubernetes API server
+    nodePoolsLaunchKind: launch_templates
     apiServer:
       privateAccess: true
       publicAccess: true
-      privateAccessCidrs: ['0.0.0.0/0']
-      publicAccessCidrs: ['0.0.0.0/0']
-    # This array contains the definition of the nodepools in the cluster
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
     nodePools:
-        # This is the name of the nodepool
       - name: infra
         type: eks-managed
-        # This map defines the max and min number of nodes in the nodepool autoscaling group
         size:
           min: 5
           max: 7
-        # This map defines the characteristics of the instance that will be used in the node pool
         instance:
-          # The instance type
           type: t3.xlarge
-          # If the instance is a spot instance
           spot: true
-          # The instance disk size in GB
           volumeSize: 50
-          # The instance disk type
           volumeType: gp2
         labels:
           nodepool: infra
           node.kubernetes.io/role: infra
-        # taints:
-        #   - node.kubernetes.io/role=infra:NoSchedule
         tags:
-          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
-          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
-    awsAuth: 
-     additionalAccounts: []
-    #    - "777777777777"
-    #    - "88888888888"
-     users:
-       - username: "filippo.ravaglia"
-         groups:
-           - system:masters
-         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
-     roles: []
-      #  - username: "example"
-      #    groups:
-      #      - example:masters
-      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
-  # This section describes how the KFD distribution will be installed
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
   distribution:
-    # This common configuration will be applied to all the packages that will be installed in the cluster
-    # common:
-      # networkPoliciesEnabled: true
-      # The node selector to use to place the pods for all the KFD packages
-      # nodeSelector:
-      #   node.kubernetes.io/role: infra
-      # The tolerations that will be added to the pods for all the KFD packages
-      # tolerations:
-      #   - effect: NoSchedule
-      #     key: node.kubernetes.io/role
-      #     value: infra
     modules:
-      # This section contains all the configurations for the ingress module
       ingress:
         baseDomain: internal.e2e.ci.sighup.io
         nginx:
@@ -152,23 +99,17 @@ spec:
             email: test@sighup.io
             type: http01
         dns:
-          # the public DNS zone definition
           public:
-            # the name of the zone
-            name: "e2e.ci.sighup.io"
-            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: e2e.ci.sighup.io
             create: true
-          # the private DNS zone definition, that will be attached to the VPC
           private:
-            # the name of the zone
-            name: "internal.e2e.ci.sighup.io"
-            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: internal.e2e.ci.sighup.io
             create: true
       logging:
         type: loki
         loki:
           backend: minio
-          tsdbStartDate: "2024-11-21"
+          tsdbStartDate: '2024-11-21'
         minio:
           storageSize: 20Gi
           rootUser:
@@ -202,18 +143,15 @@ spec:
       policy:
         type: kyverno
         kyverno:
-          additionalExcludedNamespaces: ["local-path-storage"]
+          additionalExcludedNamespaces:
+            - local-path-storage
           installDefaultPolicies: true
           validationFailureAction: Enforce
       dr:
         type: eks
-        # Configurations for the velero package
         velero:
-          # Velero configurations for EKS cluster
           eks:
-            # The S3 bucket that will be created to store the backups
-            bucketName:  "CLUSTER_NAME-velero"
-            # The region where the bucket will be created (can be different from the overall region defined in .spec.region)
+            bucketName: e2e-test-eks
             region: eu-west-1
       auth:
         provider:
@@ -221,4 +159,3 @@ spec:
           basicAuth:
             username: test
             password: testpassword
-    

--- a/tests/e2e/ekscluster/manifests/furyctl-2-migrate-from-tempo-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-2-migrate-from-tempo-to-none.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: loki

--- a/tests/e2e/ekscluster/manifests/furyctl-3-migrate-from-kyverno-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-3-migrate-from-kyverno-to-none.yaml
@@ -1,0 +1,223 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
+  name:  "CLUSTER_NAME"
+spec:
+  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
+  # it supports git tags and branches
+  distributionVersion: "DISTRIBUTION_VERSION"
+  # This sections defines where to store the terraform state files used by furyctl
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          # This value defines which bucket will be used to store all the states
+          bucketName: e2e-drone-eks
+          # This value defines which folder will be used to store all the states inside the bucket
+          keyPrefix:  "CLUSTER_NAME/"
+          # This value defines in which region the bucket is
+          region: eu-west-1
+  # This value defines in which AWS region the cluster and all the related resources will be created
+  region: eu-west-1
+  # This map defines which will be the common tags that will be added to all the resources created on AWS
+  tags:
+    env:  "CLUSTER_NAME"
+  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
+  # If you already have a VPC, you can remove this key from the configuration file
+  infrastructure:
+    # This key defines the VPC that will be created in AWS
+    vpc:
+      network:
+        # This is the CIDR of the VPC
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    # This section defines the creation of VPN bastions
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  # This section describes how the EKS cluster will be created
+  kubernetes:
+    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodePoolGlobalAmiType: alinux2
+    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
+    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
+    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
+    nodePoolsLaunchKind: "launch_templates"
+    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
+    # logRetentionDays: 90
+    # This map defines the access to the Kubernetes API server
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs: ['0.0.0.0/0']
+      publicAccessCidrs: ['0.0.0.0/0']
+    # This array contains the definition of the nodepools in the cluster
+    nodePools:
+        # This is the name of the nodepool
+      - name: infra
+        type: eks-managed
+        # This map defines the max and min number of nodes in the nodepool autoscaling group
+        size:
+          min: 5
+          max: 7
+        # This map defines the characteristics of the instance that will be used in the node pool
+        instance:
+          # The instance type
+          type: t3.xlarge
+          # If the instance is a spot instance
+          spot: true
+          # The instance disk size in GB
+          volumeSize: 50
+          # The instance disk type
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        # taints:
+        #   - node.kubernetes.io/role=infra:NoSchedule
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
+    awsAuth: 
+     additionalAccounts: []
+    #    - "777777777777"
+    #    - "88888888888"
+     users:
+       - username: "filippo.ravaglia"
+         groups:
+           - system:masters
+         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
+     roles: []
+      #  - username: "example"
+      #    groups:
+      #      - example:masters
+      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
+  # This section describes how the KFD distribution will be installed
+  distribution:
+    # This common configuration will be applied to all the packages that will be installed in the cluster
+    # common:
+      # networkPoliciesEnabled: true
+      # The node selector to use to place the pods for all the KFD packages
+      # nodeSelector:
+      #   node.kubernetes.io/role: infra
+      # The tolerations that will be added to the pods for all the KFD packages
+      # tolerations:
+      #   - effect: NoSchedule
+      #     key: node.kubernetes.io/role
+      #     value: infra
+    modules:
+      # This section contains all the configurations for the ingress module
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          # the public DNS zone definition
+          public:
+            # the name of the zone
+            name: "e2e.ci.sighup.io"
+            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+          # the private DNS zone definition, that will be attached to the VPC
+          private:
+            # the name of the zone
+            name: "internal.e2e.ci.sighup.io"
+            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+      logging:
+        type: loki
+        loki:
+          backend: minio
+          tsdbStartDate: "2024-11-21"
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+      monitoring:
+        type: mimir
+        mimir:
+          backend: minio
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: none
+        tempo:
+          backend: minio
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: none
+        kyverno:
+          additionalExcludedNamespaces: ["local-path-storage"]
+          installDefaultPolicies: true
+          validationFailureAction: Enforce
+      dr:
+        type: eks
+        # Configurations for the velero package
+        velero:
+          # Velero configurations for EKS cluster
+          eks:
+            # The S3 bucket that will be created to store the backups
+            bucketName:  "CLUSTER_NAME-velero"
+            # The region where the bucket will be created (can be different from the overall region defined in .spec.region)
+            region: eu-west-1
+      auth:
+        provider:
+          type: basicAuth
+          basicAuth:
+            username: test
+            password: testpassword

--- a/tests/e2e/ekscluster/manifests/furyctl-3-migrate-from-kyverno-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-3-migrate-from-kyverno-to-none.yaml
@@ -53,8 +53,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster/manifests/furyctl-3-migrate-from-kyverno-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-3-migrate-from-kyverno-to-none.yaml
@@ -13,48 +13,32 @@
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
-  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
-  name:  "CLUSTER_NAME"
+  name: e2e-test-eks
 spec:
-  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
-  # it supports git tags and branches
-  distributionVersion: "DISTRIBUTION_VERSION"
-  # This sections defines where to store the terraform state files used by furyctl
+  distributionVersion: v1.31.0
   toolsConfiguration:
     terraform:
       state:
         s3:
-          # This value defines which bucket will be used to store all the states
           bucketName: e2e-drone-eks
-          # This value defines which folder will be used to store all the states inside the bucket
-          keyPrefix:  "CLUSTER_NAME/"
-          # This value defines in which region the bucket is
+          keyPrefix: e2e-test-eks
           region: eu-west-1
-  # This value defines in which AWS region the cluster and all the related resources will be created
   region: eu-west-1
-  # This map defines which will be the common tags that will be added to all the resources created on AWS
   tags:
-    env:  "CLUSTER_NAME"
-  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
-  # If you already have a VPC, you can remove this key from the configuration file
+    env: e2e-test-eks
   infrastructure:
-    # This key defines the VPC that will be created in AWS
     vpc:
       network:
-        # This is the CIDR of the VPC
         cidr: 10.1.0.0/16
         subnetsCidrs:
-          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
           private:
             - 10.1.0.0/20
             - 10.1.16.0/20
             - 10.1.32.0/20
-          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
           public:
             - 10.1.48.0/24
             - 10.1.49.0/24
             - 10.1.50.0/24
-    # This section defines the creation of VPN bastions
     vpn:
       instances: 0
       port: 1194
@@ -68,78 +52,41 @@ spec:
           - Filo01
         allowedFromCidrs:
           - 0.0.0.0/0
-  # This section describes how the EKS cluster will be created
   kubernetes:
-    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
     nodePoolGlobalAmiType: alinux2
-    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
-    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
-    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
-    nodePoolsLaunchKind: "launch_templates"
-    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
-    # logRetentionDays: 90
-    # This map defines the access to the Kubernetes API server
+    nodePoolsLaunchKind: launch_templates
     apiServer:
       privateAccess: true
       publicAccess: true
-      privateAccessCidrs: ['0.0.0.0/0']
-      publicAccessCidrs: ['0.0.0.0/0']
-    # This array contains the definition of the nodepools in the cluster
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
     nodePools:
-        # This is the name of the nodepool
       - name: infra
         type: eks-managed
-        # This map defines the max and min number of nodes in the nodepool autoscaling group
         size:
           min: 5
           max: 7
-        # This map defines the characteristics of the instance that will be used in the node pool
         instance:
-          # The instance type
           type: t3.xlarge
-          # If the instance is a spot instance
           spot: true
-          # The instance disk size in GB
           volumeSize: 50
-          # The instance disk type
           volumeType: gp2
         labels:
           nodepool: infra
           node.kubernetes.io/role: infra
-        # taints:
-        #   - node.kubernetes.io/role=infra:NoSchedule
         tags:
-          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
-          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
-    awsAuth: 
-     additionalAccounts: []
-    #    - "777777777777"
-    #    - "88888888888"
-     users:
-       - username: "filippo.ravaglia"
-         groups:
-           - system:masters
-         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
-     roles: []
-      #  - username: "example"
-      #    groups:
-      #      - example:masters
-      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
-  # This section describes how the KFD distribution will be installed
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
   distribution:
-    # This common configuration will be applied to all the packages that will be installed in the cluster
-    # common:
-      # networkPoliciesEnabled: true
-      # The node selector to use to place the pods for all the KFD packages
-      # nodeSelector:
-      #   node.kubernetes.io/role: infra
-      # The tolerations that will be added to the pods for all the KFD packages
-      # tolerations:
-      #   - effect: NoSchedule
-      #     key: node.kubernetes.io/role
-      #     value: infra
     modules:
-      # This section contains all the configurations for the ingress module
       ingress:
         baseDomain: internal.e2e.ci.sighup.io
         nginx:
@@ -152,23 +99,17 @@ spec:
             email: test@sighup.io
             type: http01
         dns:
-          # the public DNS zone definition
           public:
-            # the name of the zone
-            name: "e2e.ci.sighup.io"
-            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: e2e.ci.sighup.io
             create: true
-          # the private DNS zone definition, that will be attached to the VPC
           private:
-            # the name of the zone
-            name: "internal.e2e.ci.sighup.io"
-            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: internal.e2e.ci.sighup.io
             create: true
       logging:
         type: loki
         loki:
           backend: minio
-          tsdbStartDate: "2024-11-21"
+          tsdbStartDate: '2024-11-21'
         minio:
           storageSize: 20Gi
           rootUser:
@@ -202,18 +143,15 @@ spec:
       policy:
         type: none
         kyverno:
-          additionalExcludedNamespaces: ["local-path-storage"]
+          additionalExcludedNamespaces:
+            - local-path-storage
           installDefaultPolicies: true
           validationFailureAction: Enforce
       dr:
         type: eks
-        # Configurations for the velero package
         velero:
-          # Velero configurations for EKS cluster
           eks:
-            # The S3 bucket that will be created to store the backups
-            bucketName:  "CLUSTER_NAME-velero"
-            # The region where the bucket will be created (can be different from the overall region defined in .spec.region)
+            bucketName: e2e-test-eks
             region: eu-west-1
       auth:
         provider:

--- a/tests/e2e/ekscluster/manifests/furyctl-3-migrate-from-kyverno-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-3-migrate-from-kyverno-to-none.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: loki

--- a/tests/e2e/ekscluster/manifests/furyctl-4-migrate-from-velero-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-4-migrate-from-velero-to-none.yaml
@@ -53,8 +53,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster/manifests/furyctl-4-migrate-from-velero-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-4-migrate-from-velero-to-none.yaml
@@ -1,0 +1,215 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
+  name:  "CLUSTER_NAME"
+spec:
+  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
+  # it supports git tags and branches
+  distributionVersion: "DISTRIBUTION_VERSION"
+  # This sections defines where to store the terraform state files used by furyctl
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          # This value defines which bucket will be used to store all the states
+          bucketName: e2e-drone-eks
+          # This value defines which folder will be used to store all the states inside the bucket
+          keyPrefix:  "CLUSTER_NAME/"
+          # This value defines in which region the bucket is
+          region: eu-west-1
+  # This value defines in which AWS region the cluster and all the related resources will be created
+  region: eu-west-1
+  # This map defines which will be the common tags that will be added to all the resources created on AWS
+  tags:
+    env:  "CLUSTER_NAME"
+  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
+  # If you already have a VPC, you can remove this key from the configuration file
+  infrastructure:
+    # This key defines the VPC that will be created in AWS
+    vpc:
+      network:
+        # This is the CIDR of the VPC
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    # This section defines the creation of VPN bastions
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  # This section describes how the EKS cluster will be created
+  kubernetes:
+    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodePoolGlobalAmiType: alinux2
+    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
+    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
+    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
+    nodePoolsLaunchKind: "launch_templates"
+    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
+    # logRetentionDays: 90
+    # This map defines the access to the Kubernetes API server
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs: ['0.0.0.0/0']
+      publicAccessCidrs: ['0.0.0.0/0']
+    # This array contains the definition of the nodepools in the cluster
+    nodePools:
+        # This is the name of the nodepool
+      - name: infra
+        type: eks-managed
+        # This map defines the max and min number of nodes in the nodepool autoscaling group
+        size:
+          min: 5
+          max: 7
+        # This map defines the characteristics of the instance that will be used in the node pool
+        instance:
+          # The instance type
+          type: t3.xlarge
+          # If the instance is a spot instance
+          spot: true
+          # The instance disk size in GB
+          volumeSize: 50
+          # The instance disk type
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        # taints:
+        #   - node.kubernetes.io/role=infra:NoSchedule
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
+    awsAuth: 
+     additionalAccounts: []
+    #    - "777777777777"
+    #    - "88888888888"
+     users:
+       - username: "filippo.ravaglia"
+         groups:
+           - system:masters
+         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
+     roles: []
+      #  - username: "example"
+      #    groups:
+      #      - example:masters
+      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
+  # This section describes how the KFD distribution will be installed
+  distribution:
+    # This common configuration will be applied to all the packages that will be installed in the cluster
+    # common:
+      # networkPoliciesEnabled: true
+      # The node selector to use to place the pods for all the KFD packages
+      # nodeSelector:
+      #   node.kubernetes.io/role: infra
+      # The tolerations that will be added to the pods for all the KFD packages
+      # tolerations:
+      #   - effect: NoSchedule
+      #     key: node.kubernetes.io/role
+      #     value: infra
+    modules:
+      # This section contains all the configurations for the ingress module
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          # the public DNS zone definition
+          public:
+            # the name of the zone
+            name: "e2e.ci.sighup.io"
+            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+          # the private DNS zone definition, that will be attached to the VPC
+          private:
+            # the name of the zone
+            name: "internal.e2e.ci.sighup.io"
+            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+      logging:
+        type: loki
+        loki:
+          backend: minio
+          tsdbStartDate: "2024-11-21"
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+      monitoring:
+        type: mimir
+        mimir:
+          backend: minio
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: none
+        tempo:
+          backend: minio
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: none
+        kyverno:
+          additionalExcludedNamespaces: ["local-path-storage"]
+          installDefaultPolicies: true
+          validationFailureAction: Enforce
+      dr:
+        type: none
+      auth:
+        provider:
+          type: basicAuth
+          basicAuth:
+            username: test
+            password: testpassword

--- a/tests/e2e/ekscluster/manifests/furyctl-4-migrate-from-velero-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-4-migrate-from-velero-to-none.yaml
@@ -13,48 +13,32 @@
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
-  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
-  name:  "CLUSTER_NAME"
+  name: e2e-test-eks
 spec:
-  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
-  # it supports git tags and branches
-  distributionVersion: "DISTRIBUTION_VERSION"
-  # This sections defines where to store the terraform state files used by furyctl
+  distributionVersion: v1.31.0
   toolsConfiguration:
     terraform:
       state:
         s3:
-          # This value defines which bucket will be used to store all the states
           bucketName: e2e-drone-eks
-          # This value defines which folder will be used to store all the states inside the bucket
-          keyPrefix:  "CLUSTER_NAME/"
-          # This value defines in which region the bucket is
+          keyPrefix: e2e-test-eks
           region: eu-west-1
-  # This value defines in which AWS region the cluster and all the related resources will be created
   region: eu-west-1
-  # This map defines which will be the common tags that will be added to all the resources created on AWS
   tags:
-    env:  "CLUSTER_NAME"
-  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
-  # If you already have a VPC, you can remove this key from the configuration file
+    env: e2e-test-eks
   infrastructure:
-    # This key defines the VPC that will be created in AWS
     vpc:
       network:
-        # This is the CIDR of the VPC
         cidr: 10.1.0.0/16
         subnetsCidrs:
-          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
           private:
             - 10.1.0.0/20
             - 10.1.16.0/20
             - 10.1.32.0/20
-          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
           public:
             - 10.1.48.0/24
             - 10.1.49.0/24
             - 10.1.50.0/24
-    # This section defines the creation of VPN bastions
     vpn:
       instances: 0
       port: 1194
@@ -68,78 +52,41 @@ spec:
           - Filo01
         allowedFromCidrs:
           - 0.0.0.0/0
-  # This section describes how the EKS cluster will be created
   kubernetes:
-    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
     nodePoolGlobalAmiType: alinux2
-    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
-    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
-    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
-    nodePoolsLaunchKind: "launch_templates"
-    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
-    # logRetentionDays: 90
-    # This map defines the access to the Kubernetes API server
+    nodePoolsLaunchKind: launch_templates
     apiServer:
       privateAccess: true
       publicAccess: true
-      privateAccessCidrs: ['0.0.0.0/0']
-      publicAccessCidrs: ['0.0.0.0/0']
-    # This array contains the definition of the nodepools in the cluster
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
     nodePools:
-        # This is the name of the nodepool
       - name: infra
         type: eks-managed
-        # This map defines the max and min number of nodes in the nodepool autoscaling group
         size:
           min: 5
           max: 7
-        # This map defines the characteristics of the instance that will be used in the node pool
         instance:
-          # The instance type
           type: t3.xlarge
-          # If the instance is a spot instance
           spot: true
-          # The instance disk size in GB
           volumeSize: 50
-          # The instance disk type
           volumeType: gp2
         labels:
           nodepool: infra
           node.kubernetes.io/role: infra
-        # taints:
-        #   - node.kubernetes.io/role=infra:NoSchedule
         tags:
-          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
-          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
-    awsAuth: 
-     additionalAccounts: []
-    #    - "777777777777"
-    #    - "88888888888"
-     users:
-       - username: "filippo.ravaglia"
-         groups:
-           - system:masters
-         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
-     roles: []
-      #  - username: "example"
-      #    groups:
-      #      - example:masters
-      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
-  # This section describes how the KFD distribution will be installed
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
   distribution:
-    # This common configuration will be applied to all the packages that will be installed in the cluster
-    # common:
-      # networkPoliciesEnabled: true
-      # The node selector to use to place the pods for all the KFD packages
-      # nodeSelector:
-      #   node.kubernetes.io/role: infra
-      # The tolerations that will be added to the pods for all the KFD packages
-      # tolerations:
-      #   - effect: NoSchedule
-      #     key: node.kubernetes.io/role
-      #     value: infra
     modules:
-      # This section contains all the configurations for the ingress module
       ingress:
         baseDomain: internal.e2e.ci.sighup.io
         nginx:
@@ -152,23 +99,17 @@ spec:
             email: test@sighup.io
             type: http01
         dns:
-          # the public DNS zone definition
           public:
-            # the name of the zone
-            name: "e2e.ci.sighup.io"
-            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: e2e.ci.sighup.io
             create: true
-          # the private DNS zone definition, that will be attached to the VPC
           private:
-            # the name of the zone
-            name: "internal.e2e.ci.sighup.io"
-            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: internal.e2e.ci.sighup.io
             create: true
       logging:
         type: loki
         loki:
           backend: minio
-          tsdbStartDate: "2024-11-21"
+          tsdbStartDate: '2024-11-21'
         minio:
           storageSize: 20Gi
           rootUser:
@@ -202,7 +143,8 @@ spec:
       policy:
         type: none
         kyverno:
-          additionalExcludedNamespaces: ["local-path-storage"]
+          additionalExcludedNamespaces:
+            - local-path-storage
           installDefaultPolicies: true
           validationFailureAction: Enforce
       dr:

--- a/tests/e2e/ekscluster/manifests/furyctl-4-migrate-from-velero-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-4-migrate-from-velero-to-none.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: loki

--- a/tests/e2e/ekscluster/manifests/furyctl-5-migrate-from-loki-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-5-migrate-from-loki-to-none.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: none

--- a/tests/e2e/ekscluster/manifests/furyctl-5-migrate-from-loki-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-5-migrate-from-loki-to-none.yaml
@@ -53,8 +53,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster/manifests/furyctl-5-migrate-from-loki-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-5-migrate-from-loki-to-none.yaml
@@ -13,48 +13,32 @@
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
-  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
-  name:  "CLUSTER_NAME"
+  name: e2e-test-eks
 spec:
-  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
-  # it supports git tags and branches
-  distributionVersion: "DISTRIBUTION_VERSION"
-  # This sections defines where to store the terraform state files used by furyctl
+  distributionVersion: v1.31.0
   toolsConfiguration:
     terraform:
       state:
         s3:
-          # This value defines which bucket will be used to store all the states
           bucketName: e2e-drone-eks
-          # This value defines which folder will be used to store all the states inside the bucket
-          keyPrefix: "CLUSTER_NAME/"
-          # This value defines in which region the bucket is
+          keyPrefix: e2e-test-eks
           region: eu-west-1
-  # This value defines in which AWS region the cluster and all the related resources will be created
   region: eu-west-1
-  # This map defines which will be the common tags that will be added to all the resources created on AWS
   tags:
-    env:  "CLUSTER_NAME"
-  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
-  # If you already have a VPC, you can remove this key from the configuration file
+    env: e2e-test-eks
   infrastructure:
-    # This key defines the VPC that will be created in AWS
     vpc:
       network:
-        # This is the CIDR of the VPC
         cidr: 10.1.0.0/16
         subnetsCidrs:
-          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
           private:
             - 10.1.0.0/20
             - 10.1.16.0/20
             - 10.1.32.0/20
-          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
           public:
             - 10.1.48.0/24
             - 10.1.49.0/24
             - 10.1.50.0/24
-    # This section defines the creation of VPN bastions
     vpn:
       instances: 0
       port: 1194
@@ -68,78 +52,41 @@ spec:
           - Filo01
         allowedFromCidrs:
           - 0.0.0.0/0
-  # This section describes how the EKS cluster will be created
   kubernetes:
-    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
     nodePoolGlobalAmiType: alinux2
-    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
-    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
-    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
-    nodePoolsLaunchKind: "launch_templates"
-    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
-    # logRetentionDays: 90
-    # This map defines the access to the Kubernetes API server
+    nodePoolsLaunchKind: launch_templates
     apiServer:
       privateAccess: true
       publicAccess: true
-      privateAccessCidrs: ['0.0.0.0/0']
-      publicAccessCidrs: ['0.0.0.0/0']
-    # This array contains the definition of the nodepools in the cluster
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
     nodePools:
-        # This is the name of the nodepool
       - name: infra
         type: eks-managed
-        # This map defines the max and min number of nodes in the nodepool autoscaling group
         size:
           min: 5
           max: 7
-        # This map defines the characteristics of the instance that will be used in the node pool
         instance:
-          # The instance type
           type: t3.xlarge
-          # If the instance is a spot instance
           spot: true
-          # The instance disk size in GB
           volumeSize: 50
-          # The instance disk type
           volumeType: gp2
         labels:
           nodepool: infra
           node.kubernetes.io/role: infra
-        # taints:
-        #   - node.kubernetes.io/role=infra:NoSchedule
         tags:
-          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
-          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
-    awsAuth: 
-     additionalAccounts: []
-    #    - "777777777777"
-    #    - "88888888888"
-     users:
-       - username: "filippo.ravaglia"
-         groups:
-           - system:masters
-         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
-     roles: []
-      #  - username: "example"
-      #    groups:
-      #      - example:masters
-      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
-  # This section describes how the KFD distribution will be installed
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
   distribution:
-    # This common configuration will be applied to all the packages that will be installed in the cluster
-    # common:
-      # networkPoliciesEnabled: true
-      # The node selector to use to place the pods for all the KFD packages
-      # nodeSelector:
-      #   node.kubernetes.io/role: infra
-      # The tolerations that will be added to the pods for all the KFD packages
-      # tolerations:
-      #   - effect: NoSchedule
-      #     key: node.kubernetes.io/role
-      #     value: infra
     modules:
-      # This section contains all the configurations for the ingress module
       ingress:
         baseDomain: internal.e2e.ci.sighup.io
         nginx:
@@ -152,17 +99,11 @@ spec:
             email: test@sighup.io
             type: http01
         dns:
-          # the public DNS zone definition
           public:
-            # the name of the zone
-            name: "e2e.ci.sighup.io"
-            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: e2e.ci.sighup.io
             create: true
-          # the private DNS zone definition, that will be attached to the VPC
           private:
-            # the name of the zone
-            name: "internal.e2e.ci.sighup.io"
-            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: internal.e2e.ci.sighup.io
             create: true
       logging:
         type: none
@@ -199,7 +140,8 @@ spec:
       policy:
         type: none
         kyverno:
-          additionalExcludedNamespaces: ["local-path-storage"]
+          additionalExcludedNamespaces:
+            - local-path-storage
           installDefaultPolicies: true
           validationFailureAction: Enforce
       dr:

--- a/tests/e2e/ekscluster/manifests/furyctl-5-migrate-from-loki-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-5-migrate-from-loki-to-none.yaml
@@ -1,0 +1,212 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
+  name:  "CLUSTER_NAME"
+spec:
+  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
+  # it supports git tags and branches
+  distributionVersion: "DISTRIBUTION_VERSION"
+  # This sections defines where to store the terraform state files used by furyctl
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          # This value defines which bucket will be used to store all the states
+          bucketName: e2e-drone-eks
+          # This value defines which folder will be used to store all the states inside the bucket
+          keyPrefix: "CLUSTER_NAME/"
+          # This value defines in which region the bucket is
+          region: eu-west-1
+  # This value defines in which AWS region the cluster and all the related resources will be created
+  region: eu-west-1
+  # This map defines which will be the common tags that will be added to all the resources created on AWS
+  tags:
+    env:  "CLUSTER_NAME"
+  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
+  # If you already have a VPC, you can remove this key from the configuration file
+  infrastructure:
+    # This key defines the VPC that will be created in AWS
+    vpc:
+      network:
+        # This is the CIDR of the VPC
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    # This section defines the creation of VPN bastions
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  # This section describes how the EKS cluster will be created
+  kubernetes:
+    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodePoolGlobalAmiType: alinux2
+    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
+    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
+    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
+    nodePoolsLaunchKind: "launch_templates"
+    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
+    # logRetentionDays: 90
+    # This map defines the access to the Kubernetes API server
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs: ['0.0.0.0/0']
+      publicAccessCidrs: ['0.0.0.0/0']
+    # This array contains the definition of the nodepools in the cluster
+    nodePools:
+        # This is the name of the nodepool
+      - name: infra
+        type: eks-managed
+        # This map defines the max and min number of nodes in the nodepool autoscaling group
+        size:
+          min: 5
+          max: 7
+        # This map defines the characteristics of the instance that will be used in the node pool
+        instance:
+          # The instance type
+          type: t3.xlarge
+          # If the instance is a spot instance
+          spot: true
+          # The instance disk size in GB
+          volumeSize: 50
+          # The instance disk type
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        # taints:
+        #   - node.kubernetes.io/role=infra:NoSchedule
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
+    awsAuth: 
+     additionalAccounts: []
+    #    - "777777777777"
+    #    - "88888888888"
+     users:
+       - username: "filippo.ravaglia"
+         groups:
+           - system:masters
+         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
+     roles: []
+      #  - username: "example"
+      #    groups:
+      #      - example:masters
+      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
+  # This section describes how the KFD distribution will be installed
+  distribution:
+    # This common configuration will be applied to all the packages that will be installed in the cluster
+    # common:
+      # networkPoliciesEnabled: true
+      # The node selector to use to place the pods for all the KFD packages
+      # nodeSelector:
+      #   node.kubernetes.io/role: infra
+      # The tolerations that will be added to the pods for all the KFD packages
+      # tolerations:
+      #   - effect: NoSchedule
+      #     key: node.kubernetes.io/role
+      #     value: infra
+    modules:
+      # This section contains all the configurations for the ingress module
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          # the public DNS zone definition
+          public:
+            # the name of the zone
+            name: "e2e.ci.sighup.io"
+            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+          # the private DNS zone definition, that will be attached to the VPC
+          private:
+            # the name of the zone
+            name: "internal.e2e.ci.sighup.io"
+            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+      logging:
+        type: none
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+      monitoring:
+        type: mimir
+        mimir:
+          backend: minio
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: none
+        tempo:
+          backend: minio
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: none
+        kyverno:
+          additionalExcludedNamespaces: ["local-path-storage"]
+          installDefaultPolicies: true
+          validationFailureAction: Enforce
+      dr:
+        type: none
+      auth:
+        provider:
+          type: basicAuth
+          basicAuth:
+            username: test
+            password: testpassword

--- a/tests/e2e/ekscluster/manifests/furyctl-6-migrate-from-mimir-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-6-migrate-from-mimir-to-none.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: none

--- a/tests/e2e/ekscluster/manifests/furyctl-6-migrate-from-mimir-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-6-migrate-from-mimir-to-none.yaml
@@ -53,8 +53,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster/manifests/furyctl-6-migrate-from-mimir-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-6-migrate-from-mimir-to-none.yaml
@@ -13,48 +13,32 @@
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
-  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
-  name:  "CLUSTER_NAME"
+  name: e2e-test-eks
 spec:
-  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
-  # it supports git tags and branches
-  distributionVersion: "DISTRIBUTION_VERSION"
-  # This sections defines where to store the terraform state files used by furyctl
+  distributionVersion: v1.31.0
   toolsConfiguration:
     terraform:
       state:
         s3:
-          # This value defines which bucket will be used to store all the states
           bucketName: e2e-drone-eks
-          # This value defines which folder will be used to store all the states inside the bucket
-          keyPrefix:  "CLUSTER_NAME/"
-          # This value defines in which region the bucket is
+          keyPrefix: e2e-test-eks
           region: eu-west-1
-  # This value defines in which AWS region the cluster and all the related resources will be created
   region: eu-west-1
-  # This map defines which will be the common tags that will be added to all the resources created on AWS
   tags:
-    env:  "CLUSTER_NAME"
-  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
-  # If you already have a VPC, you can remove this key from the configuration file
+    env: e2e-test-eks
   infrastructure:
-    # This key defines the VPC that will be created in AWS
     vpc:
       network:
-        # This is the CIDR of the VPC
         cidr: 10.1.0.0/16
         subnetsCidrs:
-          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
           private:
             - 10.1.0.0/20
             - 10.1.16.0/20
             - 10.1.32.0/20
-          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
           public:
             - 10.1.48.0/24
             - 10.1.49.0/24
             - 10.1.50.0/24
-    # This section defines the creation of VPN bastions
     vpn:
       instances: 0
       port: 1194
@@ -68,78 +52,41 @@ spec:
           - Filo01
         allowedFromCidrs:
           - 0.0.0.0/0
-  # This section describes how the EKS cluster will be created
   kubernetes:
-    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
     nodePoolGlobalAmiType: alinux2
-    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
-    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
-    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
-    nodePoolsLaunchKind: "launch_templates"
-    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
-    # logRetentionDays: 90
-    # This map defines the access to the Kubernetes API server
+    nodePoolsLaunchKind: launch_templates
     apiServer:
       privateAccess: true
       publicAccess: true
-      privateAccessCidrs: ['0.0.0.0/0']
-      publicAccessCidrs: ['0.0.0.0/0']
-    # This array contains the definition of the nodepools in the cluster
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
     nodePools:
-        # This is the name of the nodepool
       - name: infra
         type: eks-managed
-        # This map defines the max and min number of nodes in the nodepool autoscaling group
         size:
           min: 5
           max: 7
-        # This map defines the characteristics of the instance that will be used in the node pool
         instance:
-          # The instance type
           type: t3.xlarge
-          # If the instance is a spot instance
           spot: true
-          # The instance disk size in GB
           volumeSize: 50
-          # The instance disk type
           volumeType: gp2
         labels:
           nodepool: infra
           node.kubernetes.io/role: infra
-        # taints:
-        #   - node.kubernetes.io/role=infra:NoSchedule
         tags:
-          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
-          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
-    awsAuth: 
-     additionalAccounts: []
-    #    - "777777777777"
-    #    - "88888888888"
-     users:
-       - username: "filippo.ravaglia"
-         groups:
-           - system:masters
-         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
-     roles: []
-      #  - username: "example"
-      #    groups:
-      #      - example:masters
-      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
-  # This section describes how the KFD distribution will be installed
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
   distribution:
-    # This common configuration will be applied to all the packages that will be installed in the cluster
-    # common:
-      # networkPoliciesEnabled: true
-      # The node selector to use to place the pods for all the KFD packages
-      # nodeSelector:
-      #   node.kubernetes.io/role: infra
-      # The tolerations that will be added to the pods for all the KFD packages
-      # tolerations:
-      #   - effect: NoSchedule
-      #     key: node.kubernetes.io/role
-      #     value: infra
     modules:
-      # This section contains all the configurations for the ingress module
       ingress:
         baseDomain: internal.e2e.ci.sighup.io
         nginx:
@@ -152,17 +99,11 @@ spec:
             email: test@sighup.io
             type: http01
         dns:
-          # the public DNS zone definition
           public:
-            # the name of the zone
-            name: "e2e.ci.sighup.io"
-            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: e2e.ci.sighup.io
             create: true
-          # the private DNS zone definition, that will be attached to the VPC
           private:
-            # the name of the zone
-            name: "internal.e2e.ci.sighup.io"
-            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: internal.e2e.ci.sighup.io
             create: true
       logging:
         type: none
@@ -199,7 +140,8 @@ spec:
       policy:
         type: none
         kyverno:
-          additionalExcludedNamespaces: ["local-path-storage"]
+          additionalExcludedNamespaces:
+            - local-path-storage
           installDefaultPolicies: true
           validationFailureAction: Enforce
       dr:

--- a/tests/e2e/ekscluster/manifests/furyctl-6-migrate-from-mimir-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-6-migrate-from-mimir-to-none.yaml
@@ -1,0 +1,212 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
+  name:  "CLUSTER_NAME"
+spec:
+  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
+  # it supports git tags and branches
+  distributionVersion: "DISTRIBUTION_VERSION"
+  # This sections defines where to store the terraform state files used by furyctl
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          # This value defines which bucket will be used to store all the states
+          bucketName: e2e-drone-eks
+          # This value defines which folder will be used to store all the states inside the bucket
+          keyPrefix:  "CLUSTER_NAME/"
+          # This value defines in which region the bucket is
+          region: eu-west-1
+  # This value defines in which AWS region the cluster and all the related resources will be created
+  region: eu-west-1
+  # This map defines which will be the common tags that will be added to all the resources created on AWS
+  tags:
+    env:  "CLUSTER_NAME"
+  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
+  # If you already have a VPC, you can remove this key from the configuration file
+  infrastructure:
+    # This key defines the VPC that will be created in AWS
+    vpc:
+      network:
+        # This is the CIDR of the VPC
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    # This section defines the creation of VPN bastions
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  # This section describes how the EKS cluster will be created
+  kubernetes:
+    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodePoolGlobalAmiType: alinux2
+    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
+    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
+    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
+    nodePoolsLaunchKind: "launch_templates"
+    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
+    # logRetentionDays: 90
+    # This map defines the access to the Kubernetes API server
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs: ['0.0.0.0/0']
+      publicAccessCidrs: ['0.0.0.0/0']
+    # This array contains the definition of the nodepools in the cluster
+    nodePools:
+        # This is the name of the nodepool
+      - name: infra
+        type: eks-managed
+        # This map defines the max and min number of nodes in the nodepool autoscaling group
+        size:
+          min: 5
+          max: 7
+        # This map defines the characteristics of the instance that will be used in the node pool
+        instance:
+          # The instance type
+          type: t3.xlarge
+          # If the instance is a spot instance
+          spot: true
+          # The instance disk size in GB
+          volumeSize: 50
+          # The instance disk type
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        # taints:
+        #   - node.kubernetes.io/role=infra:NoSchedule
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
+    awsAuth: 
+     additionalAccounts: []
+    #    - "777777777777"
+    #    - "88888888888"
+     users:
+       - username: "filippo.ravaglia"
+         groups:
+           - system:masters
+         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
+     roles: []
+      #  - username: "example"
+      #    groups:
+      #      - example:masters
+      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
+  # This section describes how the KFD distribution will be installed
+  distribution:
+    # This common configuration will be applied to all the packages that will be installed in the cluster
+    # common:
+      # networkPoliciesEnabled: true
+      # The node selector to use to place the pods for all the KFD packages
+      # nodeSelector:
+      #   node.kubernetes.io/role: infra
+      # The tolerations that will be added to the pods for all the KFD packages
+      # tolerations:
+      #   - effect: NoSchedule
+      #     key: node.kubernetes.io/role
+      #     value: infra
+    modules:
+      # This section contains all the configurations for the ingress module
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          # the public DNS zone definition
+          public:
+            # the name of the zone
+            name: "e2e.ci.sighup.io"
+            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+          # the private DNS zone definition, that will be attached to the VPC
+          private:
+            # the name of the zone
+            name: "internal.e2e.ci.sighup.io"
+            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+      logging:
+        type: none
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+      monitoring:
+        type: none
+        mimir:
+          backend: minio
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: none
+        tempo:
+          backend: minio
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: none
+        kyverno:
+          additionalExcludedNamespaces: ["local-path-storage"]
+          installDefaultPolicies: true
+          validationFailureAction: Enforce
+      dr:
+        type: none
+      auth:
+        provider:
+          type: basicAuth
+          basicAuth:
+            username: test
+            password: testpassword

--- a/tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
@@ -1,3 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:

--- a/tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
@@ -1,19 +1,7 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
-# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
-# Use of this source code is governed by a BSD-style
-# license that can be found in the LICENSE file.
-
-
-# This is a sample configuration file to be used as a starting point. For the
-# complete reference of the configuration file schema, please refer to the
-# official documentation:
-# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
-
----
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
-  name: e2e-test-eks
+  name: e2e-eks-0
 spec:
   distributionVersion: v1.31.0
   toolsConfiguration:
@@ -21,11 +9,11 @@ spec:
       state:
         s3:
           bucketName: e2e-drone-eks
-          keyPrefix: e2e-test-eks
+          keyPrefix: e2e-eks-0
           region: eu-west-1
   region: eu-west-1
   tags:
-    env: e2e-test-eks
+    env: e2e-eks-0
   infrastructure:
     vpc:
       network:
@@ -53,8 +41,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
@@ -1,0 +1,246 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
+  name:  "CLUSTER_NAME"
+spec:
+  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
+  # it supports git tags and branches
+  distributionVersion: "DISTRIBUTION_VERSION"
+  # This sections defines where to store the terraform state files used by furyctl
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          # This value defines which bucket will be used to store all the states
+          bucketName: e2e-drone-eks
+          # This value defines which folder will be used to store all the states inside the bucket
+          keyPrefix:  "CLUSTER_NAME/"
+          # This value defines in which region the bucket is
+          region: eu-west-1
+  # This value defines in which AWS region the cluster and all the related resources will be created
+  region: eu-west-1
+  # This map defines which will be the common tags that will be added to all the resources created on AWS
+  tags:
+    env:  "CLUSTER_NAME"
+  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
+  # If you already have a VPC, you can remove this key from the configuration file
+  infrastructure:
+    # This key defines the VPC that will be created in AWS
+    vpc:
+      network:
+        # This is the CIDR of the VPC
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    # This section defines the creation of VPN bastions
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  # This section describes how the EKS cluster will be created
+  kubernetes:
+    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodePoolGlobalAmiType: alinux2
+    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
+    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
+    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
+    nodePoolsLaunchKind: "launch_templates"
+    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
+    # logRetentionDays: 90
+    # This map defines the access to the Kubernetes API server
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs: ['0.0.0.0/0']
+      publicAccessCidrs: ['0.0.0.0/0']
+    # This array contains the definition of the nodepools in the cluster
+    nodePools:
+        # This is the name of the nodepool
+      - name: infra
+        type: eks-managed
+        # This map defines the max and min number of nodes in the nodepool autoscaling group
+        size:
+          min: 5
+          max: 7
+        # This map defines the characteristics of the instance that will be used in the node pool
+        instance:
+          # The instance type
+          type: t3.xlarge
+          # If the instance is a spot instance
+          spot: true
+          # The instance disk size in GB
+          volumeSize: 50
+          # The instance disk type
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        # taints:
+        #   - node.kubernetes.io/role=infra:NoSchedule
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
+    awsAuth: 
+     additionalAccounts: []
+    #    - "777777777777"
+    #    - "88888888888"
+     users:
+       - username: "filippo.ravaglia"
+         groups:
+           - system:masters
+         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
+     roles: []
+      #  - username: "example"
+      #    groups:
+      #      - example:masters
+      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
+  # This section describes how the KFD distribution will be installed
+  distribution:
+    # This common configuration will be applied to all the packages that will be installed in the cluster
+    # common:
+      # networkPoliciesEnabled: true
+      # The node selector to use to place the pods for all the KFD packages
+      # nodeSelector:
+      #   node.kubernetes.io/role: infra
+      # The tolerations that will be added to the pods for all the KFD packages
+      # tolerations:
+      #   - effect: NoSchedule
+      #     key: node.kubernetes.io/role
+      #     value: infra
+    modules:
+      # This section contains all the configurations for the ingress module
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          # the public DNS zone definition
+          public:
+            # the name of the zone
+            name: "e2e.ci.sighup.io"
+            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+          # the private DNS zone definition, that will be attached to the VPC
+          private:
+            # the name of the zone
+            name: "internal.e2e.ci.sighup.io"
+            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+      logging:
+        type: none
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+      monitoring:
+        type: none
+        mimir:
+          backend: minio
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: none
+        tempo:
+          backend: minio
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: none
+        kyverno:
+          additionalExcludedNamespaces: ["local-path-storage"]
+          installDefaultPolicies: true
+          validationFailureAction: Enforce
+      dr:
+        type: none
+      auth:
+        provider:
+          type: sso
+        pomerium:
+          policy: ""
+          secrets:
+            COOKIE_SECRET: "qKjzogH4/syhMfKipwByMrG6eVm9lXL7rF4TtTChKJU="
+            IDP_CLIENT_SECRET: "iebee2Xohs7giongaihuch8iu5shie0O"
+            SHARED_SECRET: "LEjtmaKtiCB2qA5rtFSHWiWAzkdFftADf/q2xWT64dg="
+            SIGNING_KEY: "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSU9DMHBBQmx4ZS84bjRQcHBBVUE1QnRxam96Z3dDZVpvRDI2c056TGRiS1hvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFRUpDc253MHlXODRLZXhVSjQ5M21MMG9tNFN5dzJBeGtWOGFpRkxDZFdKaVBYamtUMDE1QwowclJsV2tqNVdlQUhqYmVncmRNL2QyejZTbzY3MWs3TVpRPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo="
+        baseDomain: e2e.ci.sighup.io
+
+        dex:
+          connectors:
+            - type: ldap
+              id: ldap
+              name: LDAP
+              config:
+                host: ldap-server.demo-ldap.svc:389
+                insecureNoSSL: true
+                bindDN: CN=admin,DC=sighup,DC=io
+                bindPW: HatFriday
+                userSearch:
+                  baseDN: ou=people,DC=sighup,DC=io
+                  filter: "(objectClass=person)"
+                  username: cn
+                  idAttr: cn
+                  emailAttr: mail
+                  nameAttr: displayName
+                groupSearch:
+                  baseDN: DC=sighup,DC=io
+                  filter: "(objectClass=groupOfNames)"
+                  userMatchers:
+                    - userAttr: DN
+                      groupAttr: member
+                  nameAttr: cn
+  plugins:
+    kustomize:
+      - name: ldap-server
+        folder: ./plugins/ldap-server

--- a/tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: none
@@ -156,7 +156,7 @@ spec:
             IDP_CLIENT_SECRET: iebee2Xohs7giongaihuch8iu5shie0O
             SHARED_SECRET: LEjtmaKtiCB2qA5rtFSHWiWAzkdFftADf/q2xWT64dg=
             SIGNING_KEY: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSU9DMHBBQmx4ZS84bjRQcHBBVUE1QnRxam96Z3dDZVpvRDI2c056TGRiS1hvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFRUpDc253MHlXODRLZXhVSjQ5M21MMG9tNFN5dzJBeGtWOGFpRkxDZFdKaVBYamtUMDE1QwowclJsV2tqNVdlQUhqYmVncmRNL2QyejZTbzY3MWs3TVpRPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
-        baseDomain: e2e.ci.sighup.io
+        baseDomain: e2e.ci.sighup.cc
         dex:
           connectors:
             - type: ldap

--- a/tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-7-migrate-from-basicAuth-to-sso.yaml
@@ -13,48 +13,32 @@
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
-  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
-  name:  "CLUSTER_NAME"
+  name: e2e-test-eks
 spec:
-  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
-  # it supports git tags and branches
-  distributionVersion: "DISTRIBUTION_VERSION"
-  # This sections defines where to store the terraform state files used by furyctl
+  distributionVersion: v1.31.0
   toolsConfiguration:
     terraform:
       state:
         s3:
-          # This value defines which bucket will be used to store all the states
           bucketName: e2e-drone-eks
-          # This value defines which folder will be used to store all the states inside the bucket
-          keyPrefix:  "CLUSTER_NAME/"
-          # This value defines in which region the bucket is
+          keyPrefix: e2e-test-eks
           region: eu-west-1
-  # This value defines in which AWS region the cluster and all the related resources will be created
   region: eu-west-1
-  # This map defines which will be the common tags that will be added to all the resources created on AWS
   tags:
-    env:  "CLUSTER_NAME"
-  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
-  # If you already have a VPC, you can remove this key from the configuration file
+    env: e2e-test-eks
   infrastructure:
-    # This key defines the VPC that will be created in AWS
     vpc:
       network:
-        # This is the CIDR of the VPC
         cidr: 10.1.0.0/16
         subnetsCidrs:
-          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
           private:
             - 10.1.0.0/20
             - 10.1.16.0/20
             - 10.1.32.0/20
-          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
           public:
             - 10.1.48.0/24
             - 10.1.49.0/24
             - 10.1.50.0/24
-    # This section defines the creation of VPN bastions
     vpn:
       instances: 0
       port: 1194
@@ -68,78 +52,41 @@ spec:
           - Filo01
         allowedFromCidrs:
           - 0.0.0.0/0
-  # This section describes how the EKS cluster will be created
   kubernetes:
-    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
     nodePoolGlobalAmiType: alinux2
-    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
-    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
-    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
-    nodePoolsLaunchKind: "launch_templates"
-    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
-    # logRetentionDays: 90
-    # This map defines the access to the Kubernetes API server
+    nodePoolsLaunchKind: launch_templates
     apiServer:
       privateAccess: true
       publicAccess: true
-      privateAccessCidrs: ['0.0.0.0/0']
-      publicAccessCidrs: ['0.0.0.0/0']
-    # This array contains the definition of the nodepools in the cluster
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
     nodePools:
-        # This is the name of the nodepool
       - name: infra
         type: eks-managed
-        # This map defines the max and min number of nodes in the nodepool autoscaling group
         size:
           min: 5
           max: 7
-        # This map defines the characteristics of the instance that will be used in the node pool
         instance:
-          # The instance type
           type: t3.xlarge
-          # If the instance is a spot instance
           spot: true
-          # The instance disk size in GB
           volumeSize: 50
-          # The instance disk type
           volumeType: gp2
         labels:
           nodepool: infra
           node.kubernetes.io/role: infra
-        # taints:
-        #   - node.kubernetes.io/role=infra:NoSchedule
         tags:
-          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
-          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
-    awsAuth: 
-     additionalAccounts: []
-    #    - "777777777777"
-    #    - "88888888888"
-     users:
-       - username: "filippo.ravaglia"
-         groups:
-           - system:masters
-         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
-     roles: []
-      #  - username: "example"
-      #    groups:
-      #      - example:masters
-      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
-  # This section describes how the KFD distribution will be installed
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
   distribution:
-    # This common configuration will be applied to all the packages that will be installed in the cluster
-    # common:
-      # networkPoliciesEnabled: true
-      # The node selector to use to place the pods for all the KFD packages
-      # nodeSelector:
-      #   node.kubernetes.io/role: infra
-      # The tolerations that will be added to the pods for all the KFD packages
-      # tolerations:
-      #   - effect: NoSchedule
-      #     key: node.kubernetes.io/role
-      #     value: infra
     modules:
-      # This section contains all the configurations for the ingress module
       ingress:
         baseDomain: internal.e2e.ci.sighup.io
         nginx:
@@ -152,17 +99,11 @@ spec:
             email: test@sighup.io
             type: http01
         dns:
-          # the public DNS zone definition
           public:
-            # the name of the zone
-            name: "e2e.ci.sighup.io"
-            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: e2e.ci.sighup.io
             create: true
-          # the private DNS zone definition, that will be attached to the VPC
           private:
-            # the name of the zone
-            name: "internal.e2e.ci.sighup.io"
-            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: internal.e2e.ci.sighup.io
             create: true
       logging:
         type: none
@@ -199,7 +140,8 @@ spec:
       policy:
         type: none
         kyverno:
-          additionalExcludedNamespaces: ["local-path-storage"]
+          additionalExcludedNamespaces:
+            - local-path-storage
           installDefaultPolicies: true
           validationFailureAction: Enforce
       dr:
@@ -208,14 +150,13 @@ spec:
         provider:
           type: sso
         pomerium:
-          policy: ""
+          policy: ''
           secrets:
-            COOKIE_SECRET: "qKjzogH4/syhMfKipwByMrG6eVm9lXL7rF4TtTChKJU="
-            IDP_CLIENT_SECRET: "iebee2Xohs7giongaihuch8iu5shie0O"
-            SHARED_SECRET: "LEjtmaKtiCB2qA5rtFSHWiWAzkdFftADf/q2xWT64dg="
-            SIGNING_KEY: "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSU9DMHBBQmx4ZS84bjRQcHBBVUE1QnRxam96Z3dDZVpvRDI2c056TGRiS1hvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFRUpDc253MHlXODRLZXhVSjQ5M21MMG9tNFN5dzJBeGtWOGFpRkxDZFdKaVBYamtUMDE1QwowclJsV2tqNVdlQUhqYmVncmRNL2QyejZTbzY3MWs3TVpRPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo="
+            COOKIE_SECRET: qKjzogH4/syhMfKipwByMrG6eVm9lXL7rF4TtTChKJU=
+            IDP_CLIENT_SECRET: iebee2Xohs7giongaihuch8iu5shie0O
+            SHARED_SECRET: LEjtmaKtiCB2qA5rtFSHWiWAzkdFftADf/q2xWT64dg=
+            SIGNING_KEY: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSU9DMHBBQmx4ZS84bjRQcHBBVUE1QnRxam96Z3dDZVpvRDI2c056TGRiS1hvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFRUpDc253MHlXODRLZXhVSjQ5M21MMG9tNFN5dzJBeGtWOGFpRkxDZFdKaVBYamtUMDE1QwowclJsV2tqNVdlQUhqYmVncmRNL2QyejZTbzY3MWs3TVpRPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
         baseDomain: e2e.ci.sighup.io
-
         dex:
           connectors:
             - type: ldap
@@ -228,14 +169,14 @@ spec:
                 bindPW: HatFriday
                 userSearch:
                   baseDN: ou=people,DC=sighup,DC=io
-                  filter: "(objectClass=person)"
+                  filter: (objectClass=person)
                   username: cn
                   idAttr: cn
                   emailAttr: mail
                   nameAttr: displayName
                 groupSearch:
                   baseDN: DC=sighup,DC=io
-                  filter: "(objectClass=groupOfNames)"
+                  filter: (objectClass=groupOfNames)
                   userMatchers:
                     - userAttr: DN
                       groupAttr: member

--- a/tests/e2e/ekscluster/manifests/furyctl-8-migrate-from-sso-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-8-migrate-from-sso-to-none.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: none

--- a/tests/e2e/ekscluster/manifests/furyctl-8-migrate-from-sso-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-8-migrate-from-sso-to-none.yaml
@@ -53,8 +53,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster/manifests/furyctl-8-migrate-from-sso-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-8-migrate-from-sso-to-none.yaml
@@ -1,0 +1,213 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
+  name:  "CLUSTER_NAME"
+spec:
+  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
+  # it supports git tags and branches
+  distributionVersion: "DISTRIBUTION_VERSION"
+  # This sections defines where to store the terraform state files used by furyctl
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          # This value defines which bucket will be used to store all the states
+          bucketName: e2e-drone-eks
+          # This value defines which folder will be used to store all the states inside the bucket
+          keyPrefix:  "CLUSTER_NAME/"
+          # This value defines in which region the bucket is
+          region: eu-west-1
+  # This value defines in which AWS region the cluster and all the related resources will be created
+  region: eu-west-1
+  # This map defines which will be the common tags that will be added to all the resources created on AWS
+  tags:
+    env:  "CLUSTER_NAME"
+  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
+  # If you already have a VPC, you can remove this key from the configuration file
+  infrastructure:
+    # This key defines the VPC that will be created in AWS
+    vpc:
+      network:
+        # This is the CIDR of the VPC
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    # This section defines the creation of VPN bastions
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  # This section describes how the EKS cluster will be created
+  kubernetes:
+    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodePoolGlobalAmiType: alinux2
+    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
+    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
+    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
+    nodePoolsLaunchKind: "launch_templates"
+    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
+    # logRetentionDays: 90
+    # This map defines the access to the Kubernetes API server
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs: ['0.0.0.0/0']
+      publicAccessCidrs: ['0.0.0.0/0']
+    # This array contains the definition of the nodepools in the cluster
+    nodePools:
+        # This is the name of the nodepool
+      - name: infra
+        type: eks-managed
+        # This map defines the max and min number of nodes in the nodepool autoscaling group
+        size:
+          min: 5
+          max: 7
+        # This map defines the characteristics of the instance that will be used in the node pool
+        instance:
+          # The instance type
+          type: t3.xlarge
+          # If the instance is a spot instance
+          spot: true
+          # The instance disk size in GB
+          volumeSize: 50
+          # The instance disk type
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        # taints:
+        #   - node.kubernetes.io/role=infra:NoSchedule
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
+    awsAuth: 
+     additionalAccounts: []
+    #    - "777777777777"
+    #    - "88888888888"
+     users:
+       - username: "filippo.ravaglia"
+         groups:
+           - system:masters
+         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
+     roles: []
+      #  - username: "example"
+      #    groups:
+      #      - example:masters
+      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
+  # This section describes how the KFD distribution will be installed
+  distribution:
+    # This common configuration will be applied to all the packages that will be installed in the cluster
+    # common:
+      # networkPoliciesEnabled: true
+      # The node selector to use to place the pods for all the KFD packages
+      # nodeSelector:
+      #   node.kubernetes.io/role: infra
+      # The tolerations that will be added to the pods for all the KFD packages
+      # tolerations:
+      #   - effect: NoSchedule
+      #     key: node.kubernetes.io/role
+      #     value: infra
+    modules:
+      # This section contains all the configurations for the ingress module
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          # the public DNS zone definition
+          public:
+            # the name of the zone
+            name: "e2e.ci.sighup.io"
+            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+          # the private DNS zone definition, that will be attached to the VPC
+          private:
+            # the name of the zone
+            name: "internal.e2e.ci.sighup.io"
+            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+      logging:
+        type: none
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+      monitoring:
+        type: none
+        mimir:
+          backend: minio
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: none
+        tempo:
+          backend: minio
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: none
+        kyverno:
+          additionalExcludedNamespaces: ["local-path-storage"]
+          installDefaultPolicies: true
+          validationFailureAction: Enforce
+      dr:
+        type: none
+      auth:
+        provider:
+          type: none
+  plugins:
+    kustomize:
+      - name: ldap-server
+        folder: ./plugins/ldap-server

--- a/tests/e2e/ekscluster/manifests/furyctl-8-migrate-from-sso-to-none.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-8-migrate-from-sso-to-none.yaml
@@ -13,48 +13,32 @@
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
-  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
-  name:  "CLUSTER_NAME"
+  name: e2e-test-eks
 spec:
-  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
-  # it supports git tags and branches
-  distributionVersion: "DISTRIBUTION_VERSION"
-  # This sections defines where to store the terraform state files used by furyctl
+  distributionVersion: v1.31.0
   toolsConfiguration:
     terraform:
       state:
         s3:
-          # This value defines which bucket will be used to store all the states
           bucketName: e2e-drone-eks
-          # This value defines which folder will be used to store all the states inside the bucket
-          keyPrefix:  "CLUSTER_NAME/"
-          # This value defines in which region the bucket is
+          keyPrefix: e2e-test-eks
           region: eu-west-1
-  # This value defines in which AWS region the cluster and all the related resources will be created
   region: eu-west-1
-  # This map defines which will be the common tags that will be added to all the resources created on AWS
   tags:
-    env:  "CLUSTER_NAME"
-  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
-  # If you already have a VPC, you can remove this key from the configuration file
+    env: e2e-test-eks
   infrastructure:
-    # This key defines the VPC that will be created in AWS
     vpc:
       network:
-        # This is the CIDR of the VPC
         cidr: 10.1.0.0/16
         subnetsCidrs:
-          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
           private:
             - 10.1.0.0/20
             - 10.1.16.0/20
             - 10.1.32.0/20
-          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
           public:
             - 10.1.48.0/24
             - 10.1.49.0/24
             - 10.1.50.0/24
-    # This section defines the creation of VPN bastions
     vpn:
       instances: 0
       port: 1194
@@ -68,78 +52,41 @@ spec:
           - Filo01
         allowedFromCidrs:
           - 0.0.0.0/0
-  # This section describes how the EKS cluster will be created
   kubernetes:
-    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
     nodePoolGlobalAmiType: alinux2
-    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
-    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
-    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
-    nodePoolsLaunchKind: "launch_templates"
-    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
-    # logRetentionDays: 90
-    # This map defines the access to the Kubernetes API server
+    nodePoolsLaunchKind: launch_templates
     apiServer:
       privateAccess: true
       publicAccess: true
-      privateAccessCidrs: ['0.0.0.0/0']
-      publicAccessCidrs: ['0.0.0.0/0']
-    # This array contains the definition of the nodepools in the cluster
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
     nodePools:
-        # This is the name of the nodepool
       - name: infra
         type: eks-managed
-        # This map defines the max and min number of nodes in the nodepool autoscaling group
         size:
           min: 5
           max: 7
-        # This map defines the characteristics of the instance that will be used in the node pool
         instance:
-          # The instance type
           type: t3.xlarge
-          # If the instance is a spot instance
           spot: true
-          # The instance disk size in GB
           volumeSize: 50
-          # The instance disk type
           volumeType: gp2
         labels:
           nodepool: infra
           node.kubernetes.io/role: infra
-        # taints:
-        #   - node.kubernetes.io/role=infra:NoSchedule
         tags:
-          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
-          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
-    awsAuth: 
-     additionalAccounts: []
-    #    - "777777777777"
-    #    - "88888888888"
-     users:
-       - username: "filippo.ravaglia"
-         groups:
-           - system:masters
-         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
-     roles: []
-      #  - username: "example"
-      #    groups:
-      #      - example:masters
-      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
-  # This section describes how the KFD distribution will be installed
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
   distribution:
-    # This common configuration will be applied to all the packages that will be installed in the cluster
-    # common:
-      # networkPoliciesEnabled: true
-      # The node selector to use to place the pods for all the KFD packages
-      # nodeSelector:
-      #   node.kubernetes.io/role: infra
-      # The tolerations that will be added to the pods for all the KFD packages
-      # tolerations:
-      #   - effect: NoSchedule
-      #     key: node.kubernetes.io/role
-      #     value: infra
     modules:
-      # This section contains all the configurations for the ingress module
       ingress:
         baseDomain: internal.e2e.ci.sighup.io
         nginx:
@@ -152,17 +99,11 @@ spec:
             email: test@sighup.io
             type: http01
         dns:
-          # the public DNS zone definition
           public:
-            # the name of the zone
-            name: "e2e.ci.sighup.io"
-            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: e2e.ci.sighup.io
             create: true
-          # the private DNS zone definition, that will be attached to the VPC
           private:
-            # the name of the zone
-            name: "internal.e2e.ci.sighup.io"
-            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: internal.e2e.ci.sighup.io
             create: true
       logging:
         type: none
@@ -199,7 +140,8 @@ spec:
       policy:
         type: none
         kyverno:
-          additionalExcludedNamespaces: ["local-path-storage"]
+          additionalExcludedNamespaces:
+            - local-path-storage
           installDefaultPolicies: true
           validationFailureAction: Enforce
       dr:

--- a/tests/e2e/ekscluster/manifests/furyctl-9-migrate-from-none-to-safe-values.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-9-migrate-from-none-to-safe-values.yaml
@@ -53,8 +53,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster/manifests/furyctl-9-migrate-from-none-to-safe-values.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-9-migrate-from-none-to-safe-values.yaml
@@ -1,0 +1,224 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
+  name:  "CLUSTER_NAME"
+spec:
+  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
+  # it supports git tags and branches
+  distributionVersion: "DISTRIBUTION_VERSION"
+  # This sections defines where to store the terraform state files used by furyctl
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          # This value defines which bucket will be used to store all the states
+          bucketName: e2e-drone-eks
+          # This value defines which folder will be used to store all the states inside the bucket
+          keyPrefix:  "CLUSTER_NAME/"
+          # This value defines in which region the bucket is
+          region: eu-west-1
+  # This value defines in which AWS region the cluster and all the related resources will be created
+  region: eu-west-1
+  # This map defines which will be the common tags that will be added to all the resources created on AWS
+  tags:
+    env:  "CLUSTER_NAME"
+  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
+  # If you already have a VPC, you can remove this key from the configuration file
+  infrastructure:
+    # This key defines the VPC that will be created in AWS
+    vpc:
+      network:
+        # This is the CIDR of the VPC
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    # This section defines the creation of VPN bastions
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  # This section describes how the EKS cluster will be created
+  kubernetes:
+    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodePoolGlobalAmiType: alinux2
+    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
+    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
+    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
+    nodePoolsLaunchKind: "launch_templates"
+    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
+    # logRetentionDays: 90
+    # This map defines the access to the Kubernetes API server
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs: ['0.0.0.0/0']
+      publicAccessCidrs: ['0.0.0.0/0']
+    # This array contains the definition of the nodepools in the cluster
+    nodePools:
+        # This is the name of the nodepool
+      - name: infra
+        type: eks-managed
+        # This map defines the max and min number of nodes in the nodepool autoscaling group
+        size:
+          min: 5
+          max: 7
+        # This map defines the characteristics of the instance that will be used in the node pool
+        instance:
+          # The instance type
+          type: t3.xlarge
+          # If the instance is a spot instance
+          spot: true
+          # The instance disk size in GB
+          volumeSize: 50
+          # The instance disk type
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        # taints:
+        #   - node.kubernetes.io/role=infra:NoSchedule
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
+    awsAuth: 
+     additionalAccounts: []
+    #    - "777777777777"
+    #    - "88888888888"
+     users:
+       - username: "filippo.ravaglia"
+         groups:
+           - system:masters
+         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
+     roles: []
+      #  - username: "example"
+      #    groups:
+      #      - example:masters
+      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
+  # This section describes how the KFD distribution will be installed
+  distribution:
+    # This common configuration will be applied to all the packages that will be installed in the cluster
+    # common:
+      # networkPoliciesEnabled: true
+      # The node selector to use to place the pods for all the KFD packages
+      # nodeSelector:
+      #   node.kubernetes.io/role: infra
+      # The tolerations that will be added to the pods for all the KFD packages
+      # tolerations:
+      #   - effect: NoSchedule
+      #     key: node.kubernetes.io/role
+      #     value: infra
+    modules:
+      # This section contains all the configurations for the ingress module
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          # the public DNS zone definition
+          public:
+            # the name of the zone
+            name: "e2e.ci.sighup.io"
+            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+          # the private DNS zone definition, that will be attached to the VPC
+          private:
+            # the name of the zone
+            name: "internal.e2e.ci.sighup.io"
+            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            create: true
+      logging:
+        type: loki
+        loki:
+          backend: minio
+          tsdbStartDate: "2024-11-21"
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+      monitoring:
+        type: mimir
+        mimir:
+          backend: minio
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: tempo
+        tempo:
+          backend: minio
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: kyverno
+        kyverno:
+          additionalExcludedNamespaces: ["local-path-storage"]
+          installDefaultPolicies: true
+          validationFailureAction: Enforce
+      dr:
+        type: eks
+        # Configurations for the velero package
+        velero:
+          # Velero configurations for EKS cluster
+          eks:
+            # The S3 bucket that will be created to store the backups
+            bucketName:  "CLUSTER_NAME-velero"
+            # The region where the bucket will be created (can be different from the overall region defined in .spec.region)
+            region: eu-west-1
+      auth:
+        provider:
+          type: basicAuth
+          basicAuth:
+            username: test
+            password: testpassword
+  

--- a/tests/e2e/ekscluster/manifests/furyctl-9-migrate-from-none-to-safe-values.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-9-migrate-from-none-to-safe-values.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: loki

--- a/tests/e2e/ekscluster/manifests/furyctl-9-migrate-from-none-to-safe-values.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-9-migrate-from-none-to-safe-values.yaml
@@ -13,48 +13,32 @@
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
-  # The name of the cluster, will be also used as a prefix for all the other resources created on AWS
-  name:  "CLUSTER_NAME"
+  name: e2e-test-eks
 spec:
-  # This value defines which KFD version will be installed and in consequence the Kubernetes version to use to create the cluster,
-  # it supports git tags and branches
-  distributionVersion: "DISTRIBUTION_VERSION"
-  # This sections defines where to store the terraform state files used by furyctl
+  distributionVersion: v1.31.0
   toolsConfiguration:
     terraform:
       state:
         s3:
-          # This value defines which bucket will be used to store all the states
           bucketName: e2e-drone-eks
-          # This value defines which folder will be used to store all the states inside the bucket
-          keyPrefix:  "CLUSTER_NAME/"
-          # This value defines in which region the bucket is
+          keyPrefix: e2e-test-eks
           region: eu-west-1
-  # This value defines in which AWS region the cluster and all the related resources will be created
   region: eu-west-1
-  # This map defines which will be the common tags that will be added to all the resources created on AWS
   tags:
-    env:  "CLUSTER_NAME"
-  # This first section, infrastructure, defines the underlying network and eventual VPN bastions that will be provisioned.
-  # If you already have a VPC, you can remove this key from the configuration file
+    env: e2e-test-eks
   infrastructure:
-    # This key defines the VPC that will be created in AWS
     vpc:
       network:
-        # This is the CIDR of the VPC
         cidr: 10.1.0.0/16
         subnetsCidrs:
-          # These are the CIRDs for the private subnets, where the nodes, the pods, and the private load balancers will be created
           private:
             - 10.1.0.0/20
             - 10.1.16.0/20
             - 10.1.32.0/20
-          # These are the CIDRs for the public subnets, where the public load balancers and the VPN servers will be created
           public:
             - 10.1.48.0/24
             - 10.1.49.0/24
             - 10.1.50.0/24
-    # This section defines the creation of VPN bastions
     vpn:
       instances: 0
       port: 1194
@@ -68,78 +52,41 @@ spec:
           - Filo01
         allowedFromCidrs:
           - 0.0.0.0/0
-  # This section describes how the EKS cluster will be created
   kubernetes:
-    nodeAllowedSshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc= filipporavaglia@ITMI-FIRA-NB.local"
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
     nodePoolGlobalAmiType: alinux2
-    # This key contains the ssh public key that can connect to the nodes via SSH using the ec2-user user
-    # nodeAllowedSshPublicKey: "{file://./id_rsa.pub}"
-    # Either `launch_configurations`, `launch_templates` or `both`. For new clusters use `launch_templates`, for existing cluster you'll need to migrate from `launch_configurations` to `launch_templates` using `both` as interim.
-    nodePoolsLaunchKind: "launch_templates"
-    # Optional Kubernetes Cluster log retention in days. Defaults to 90 days.
-    # logRetentionDays: 90
-    # This map defines the access to the Kubernetes API server
+    nodePoolsLaunchKind: launch_templates
     apiServer:
       privateAccess: true
       publicAccess: true
-      privateAccessCidrs: ['0.0.0.0/0']
-      publicAccessCidrs: ['0.0.0.0/0']
-    # This array contains the definition of the nodepools in the cluster
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
     nodePools:
-        # This is the name of the nodepool
       - name: infra
         type: eks-managed
-        # This map defines the max and min number of nodes in the nodepool autoscaling group
         size:
           min: 5
           max: 7
-        # This map defines the characteristics of the instance that will be used in the node pool
         instance:
-          # The instance type
           type: t3.xlarge
-          # If the instance is a spot instance
           spot: true
-          # The instance disk size in GB
           volumeSize: 50
-          # The instance disk type
           volumeType: gp2
         labels:
           nodepool: infra
           node.kubernetes.io/role: infra
-        # taints:
-        #   - node.kubernetes.io/role=infra:NoSchedule
         tags:
-          k8s.io/cluster-autoscaler/node-template/label/nodepool: "worker"
-          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: "worker"
-    awsAuth: 
-     additionalAccounts: []
-    #    - "777777777777"
-    #    - "88888888888"
-     users:
-       - username: "filippo.ravaglia"
-         groups:
-           - system:masters
-         userarn: "arn:aws:iam::996502747800:user/filippo.ravaglia"
-     roles: []
-      #  - username: "example"
-      #    groups:
-      #      - example:masters
-      #    rolearn: "arn:aws:iam::123456789012:role/k8s-example-role"
-  # This section describes how the KFD distribution will be installed
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users: []
+      roles: []
   distribution:
-    # This common configuration will be applied to all the packages that will be installed in the cluster
-    # common:
-      # networkPoliciesEnabled: true
-      # The node selector to use to place the pods for all the KFD packages
-      # nodeSelector:
-      #   node.kubernetes.io/role: infra
-      # The tolerations that will be added to the pods for all the KFD packages
-      # tolerations:
-      #   - effect: NoSchedule
-      #     key: node.kubernetes.io/role
-      #     value: infra
     modules:
-      # This section contains all the configurations for the ingress module
       ingress:
         baseDomain: internal.e2e.ci.sighup.io
         nginx:
@@ -152,23 +99,17 @@ spec:
             email: test@sighup.io
             type: http01
         dns:
-          # the public DNS zone definition
           public:
-            # the name of the zone
-            name: "e2e.ci.sighup.io"
-            # manage if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: e2e.ci.sighup.io
             create: true
-          # the private DNS zone definition, that will be attached to the VPC
           private:
-            # the name of the zone
-            name: "internal.e2e.ci.sighup.io"
-            # defines if we need to create the zone, or if it already exists and we only need to adopt/use it
+            name: internal.e2e.ci.sighup.io
             create: true
       logging:
         type: loki
         loki:
           backend: minio
-          tsdbStartDate: "2024-11-21"
+          tsdbStartDate: '2024-11-21'
         minio:
           storageSize: 20Gi
           rootUser:
@@ -202,18 +143,15 @@ spec:
       policy:
         type: kyverno
         kyverno:
-          additionalExcludedNamespaces: ["local-path-storage"]
+          additionalExcludedNamespaces:
+            - local-path-storage
           installDefaultPolicies: true
           validationFailureAction: Enforce
       dr:
         type: eks
-        # Configurations for the velero package
         velero:
-          # Velero configurations for EKS cluster
           eks:
-            # The S3 bucket that will be created to store the backups
-            bucketName:  "CLUSTER_NAME-velero"
-            # The region where the bucket will be created (can be different from the overall region defined in .spec.region)
+            bucketName: e2e-test-eks
             region: eu-west-1
       auth:
         provider:
@@ -221,4 +159,3 @@ spec:
           basicAuth:
             username: test
             password: testpassword
-  

--- a/tests/e2e/ekscluster/manifests/furyctl-cleanup-all.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-cleanup-all.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: none

--- a/tests/e2e/ekscluster/manifests/furyctl-cleanup-all.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-cleanup-all.yaml
@@ -1,0 +1,112 @@
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: e2e-eks-1740658260
+spec:
+  distributionVersion: v1.31.0
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: e2e-drone-eks
+          keyPrefix: e2e-eks-1740658260
+          region: eu-west-1
+  region: eu-west-1
+  tags:
+    env: e2e-eks-1740655762
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  kubernetes:
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
+    nodePoolGlobalAmiType: alinux2
+    nodePoolsLaunchKind: launch_templates
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
+    nodePools:
+      - name: infra
+        type: eks-managed
+        size:
+          min: 5
+          max: 7
+        instance:
+          type: t3.xlarge
+          spot: true
+          volumeSize: 50
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users:
+        - username: filippo.ravaglia
+          groups:
+            - system:masters
+          userarn: arn:aws:iam::996502747800:user/filippo.ravaglia
+      roles: []
+  distribution:
+    modules:
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          public:
+            name: e2e.ci.sighup.io
+            create: true
+          private:
+            name: internal.e2e.ci.sighup.io
+            create: true
+      logging:
+        type: none
+      monitoring:
+        type: none
+      tracing:
+        type: none
+      policy:
+        type: none
+      dr:
+        type: none
+      auth:
+        provider:
+          type: none

--- a/tests/e2e/ekscluster/manifests/furyctl-cleanup-all.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-cleanup-all.yaml
@@ -53,8 +53,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster/manifests/furyctl-cleanup-all.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-cleanup-all.yaml
@@ -1,7 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
-  name: e2e-eks-1740658260
+  name: e2e-test-eks
 spec:
   distributionVersion: v1.31.0
   toolsConfiguration:
@@ -9,11 +21,11 @@ spec:
       state:
         s3:
           bucketName: e2e-drone-eks
-          keyPrefix: e2e-eks-1740658260
+          keyPrefix: e2e-test-eks
           region: eu-west-1
   region: eu-west-1
   tags:
-    env: e2e-eks-1740655762
+    env: e2e-test-eks
   infrastructure:
     vpc:
       network:
@@ -71,11 +83,7 @@ spec:
           k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
     awsAuth:
       additionalAccounts: []
-      users:
-        - username: filippo.ravaglia
-          groups:
-            - system:masters
-          userarn: arn:aws:iam::996502747800:user/filippo.ravaglia
+      users: []
       roles: []
   distribution:
     modules:

--- a/tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
@@ -1,0 +1,149 @@
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: e2e-eks-1740661534
+spec:
+  distributionVersion: v1.31.0
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: e2e-drone-eks
+          keyPrefix: e2e-eks-1740661534
+          region: eu-west-1
+  region: eu-west-1
+  tags:
+    env: e2e-eks-1740661534
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.1.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.1.0.0/20
+            - 10.1.16.0/20
+            - 10.1.32.0/20
+          public:
+            - 10.1.48.0/24
+            - 10.1.49.0/24
+            - 10.1.50.0/24
+    vpn:
+      instances: 0
+      port: 1194
+      instanceType: t3.micro
+      diskSize: 50
+      operatorName: sighup
+      dhParamsBits: 2048
+      vpnClientsSubnetCidr: 172.16.0.0/16
+      ssh:
+        githubUsersName:
+          - Filo01
+        allowedFromCidrs:
+          - 0.0.0.0/0
+  kubernetes:
+    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
+      filipporavaglia@ITMI-FIRA-NB.local
+    nodePoolGlobalAmiType: alinux2
+    nodePoolsLaunchKind: launch_templates
+    apiServer:
+      privateAccess: true
+      publicAccess: true
+      privateAccessCidrs:
+        - 0.0.0.0/0
+      publicAccessCidrs:
+        - 0.0.0.0/0
+    nodePools:
+      - name: infra
+        type: eks-managed
+        size:
+          min: 5
+          max: 7
+        instance:
+          type: t3.xlarge
+          spot: true
+          volumeSize: 50
+          volumeType: gp2
+        labels:
+          nodepool: infra
+          node.kubernetes.io/role: infra
+        tags:
+          k8s.io/cluster-autoscaler/node-template/label/nodepool: worker
+          k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
+    awsAuth:
+      additionalAccounts: []
+      users:
+        - username: filippo.ravaglia
+          groups:
+            - system:masters
+          userarn: arn:aws:iam::996502747800:user/filippo.ravaglia
+      roles: []
+  distribution:
+    modules:
+      ingress:
+        baseDomain: internal.e2e.ci.sighup.io
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: test@sighup.io
+            type: http01
+        dns:
+          public:
+            name: e2e.ci.sighup.io
+            create: true
+          private:
+            name: internal.e2e.ci.sighup.io
+            create: true
+      logging:
+        type: loki
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword1
+        loki:
+          backend: minio
+          tsdbStartDate: '2024-11-21'
+      monitoring:
+        type: mimir
+        prometheus:
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword2
+      tracing:
+        type: tempo
+        minio:
+          storageSize: 20Gi
+          rootUser:
+            username: sighup
+            password: secretpassword3
+      policy:
+        type: kyverno
+        kyverno:
+          additionalExcludedNamespaces:
+            - local-path-storage
+          validationFailureAction: Enforce
+          installDefaultPolicies: true
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: e2e-eks-1740658260
+            region: eu-west-1
+      auth:
+        provider:
+          type: basicAuth
+          basicAuth:
+            username: test
+            password: testpassword

--- a/tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
@@ -53,8 +53,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodeAllowedSshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC73e7PMR9NmrehChjfC+cP6HifDPAaxtC9pAjsJQwymZlccwIMl65y3s7mGE5RO1GAMh6EzmgJQX3OuxwbJgI7jcGGzm6Oa6sjW40rAE3qaZSqz98uUT6TURCNaDNSx2ZtgcFL68yVErzyVpaMGsnw25G8ZdfRELlVeVTDRGcL+tpISy+2r9SOznA+twn7Nie/IK3YocoSM2JO6l5sZxPwIw7HoFeZE9yQsmeBkAMAd7tTSWdGiLUHrMRw/G++mS1OENS6JwHPoO66KmdxUlls7xy6WvTBI3kaBV03J4TUqQqtD3L+6tGAgWk9za9FJdg+8IpJFKCV9v+q9GiJb20MfObMMjXDpD+CwQM/ApwMb7pXPjAB2z9uxOgCJOfsnMxBjgCD6hYzJwhytoIFg2Z6ugVLsFeW5xkvfBUB8CWbBI6ZNjeVzN6cHQ/XHL98lSZfI0VRG33eX6O9FCRM0LWqSxmUX1PAkyQd/VHCr6Ig4eIM4djyqBmf7UWtcTg/Kvc=
-      filipporavaglia@ITMI-FIRA-NB.local
+    nodeAllowedSshPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA1xMG9TEH97YhkmoehlMaAMwqi9NOIx2ItXKNv2KVnI
     nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: launch_templates
     apiServer:

--- a/tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
@@ -1,7 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sighupio/fury-distribution/v1.31.0/schemas/public/ekscluster-kfd-v1alpha2.json
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+# This is a sample configuration file to be used as a starting point. For the
+# complete reference of the configuration file schema, please refer to the
+# official documentation:
+# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+
+---
 apiVersion: kfd.sighup.io/v1alpha2
 kind: EKSCluster
 metadata:
-  name: e2e-eks-1740661534
+  name: e2e-test-eks
 spec:
   distributionVersion: v1.31.0
   toolsConfiguration:
@@ -9,11 +21,11 @@ spec:
       state:
         s3:
           bucketName: e2e-drone-eks
-          keyPrefix: e2e-eks-1740661534
+          keyPrefix: e2e-test-eks
           region: eu-west-1
   region: eu-west-1
   tags:
-    env: e2e-eks-1740661534
+    env: e2e-test-eks
   infrastructure:
     vpc:
       network:
@@ -71,11 +83,7 @@ spec:
           k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role: worker
     awsAuth:
       additionalAccounts: []
-      users:
-        - username: filippo.ravaglia
-          groups:
-            - system:masters
-          userarn: arn:aws:iam::996502747800:user/filippo.ravaglia
+      users: []
       roles: []
   distribution:
     modules:
@@ -139,7 +147,7 @@ spec:
         type: eks
         velero:
           eks:
-            bucketName: e2e-eks-1740658260
+            bucketName: e2e-test-eks
             region: eu-west-1
       auth:
         provider:

--- a/tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
+++ b/tests/e2e/ekscluster/manifests/furyctl-init-cluster.yaml
@@ -88,7 +88,7 @@ spec:
   distribution:
     modules:
       ingress:
-        baseDomain: internal.e2e.ci.sighup.io
+        baseDomain: internal.e2e.ci.sighup.cc
         nginx:
           type: dual
           tls:
@@ -100,10 +100,10 @@ spec:
             type: http01
         dns:
           public:
-            name: e2e.ci.sighup.io
+            name: e2e.ci.sighup.cc
             create: true
           private:
-            name: internal.e2e.ci.sighup.io
+            name: internal.e2e.ci.sighup.cc
             create: true
       logging:
         type: loki

--- a/tests/e2e/ekscluster/manifests/plugins/ldap-server/kustomization.yaml
+++ b/tests/e2e/ekscluster/manifests/plugins/ldap-server/kustomization.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: demo-ldap
+resources:
+  - ns.yaml
+  - ldap-server.yaml
+
+configMapGenerator:
+  - files:
+      - ./sighup.io-groups.ldif
+    name: ldap-ldif

--- a/tests/e2e/ekscluster/manifests/plugins/ldap-server/ldap-server.yaml
+++ b/tests/e2e/ekscluster/manifests/plugins/ldap-server/ldap-server.yaml
@@ -1,0 +1,83 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: ldap-server
+  name: ldap
+stringData:
+  LDAP_ADMIN_PASSWORD: HatFriday
+---
+kind: ConfigMap
+metadata:
+  labels:
+    app: ldap-server
+  name: ldap
+apiVersion: v1
+data:
+  LDAP_ORGANISATION: SIGHUP
+  LDAP_DOMAIN: sighup.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ldap-server
+spec:
+  ports:
+    - name: "tcp-389"
+      port: 389
+      protocol: TCP
+      targetPort: 389
+    - name: "tcp-363"
+      port: 636
+      protocol: TCP
+      targetPort: 636
+  selector:
+    app: ldap-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ldap-server
+  name: ldap-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ldap-server
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: ldap-server
+    spec:
+      volumes:
+        - name: ldap-ldif
+          configMap:
+            name: ldap-ldif
+      containers:
+        - name: ldap-server
+          image: registry.sighup.io/fury/osixia/openldap:1.5.0
+          command:
+            - "sh"
+            - "-c"
+            - "cp -R /tmp/ldif /container/service/slapd/assets/config/bootstrap/ldif/custom && /container/tool/run"
+          envFrom:
+            - configMapRef:
+                name: ldap
+            - secretRef:
+                name: ldap
+          ports:
+            - containerPort: 389
+              name: "tcp-389"
+            - containerPort: 636
+              name: "tcp-636"
+          resources: {}
+          volumeMounts:
+            - name: ldap-ldif
+              mountPath: /tmp/ldif

--- a/tests/e2e/ekscluster/manifests/plugins/ldap-server/ns.yaml
+++ b/tests/e2e/ekscluster/manifests/plugins/ldap-server/ns.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo-ldap
+spec: {}
+status: {}

--- a/tests/e2e/ekscluster/manifests/plugins/ldap-server/sighup.io-groups.ldif
+++ b/tests/e2e/ekscluster/manifests/plugins/ldap-server/sighup.io-groups.ldif
@@ -1,0 +1,27 @@
+version: 1
+
+dn: ou=groups,dc=sighup,dc=io
+objectClass: top
+objectClass: organizationalUnit
+ou: groups
+
+dn: ou=people,dc=sighup,dc=io
+objectClass: top
+objectClass: organizationalUnit
+ou: people
+
+dn: cn=ramiro,ou=people,dc=sighup,dc=io
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+cn: samuele
+sn: chiocca
+mail: samuele@sighup.io
+displayName: "Samuele Chiocca"
+userPassword: samuele
+
+dn: cn=engineering,ou=groups,dc=sighup,dc=io
+objectClass: top
+objectClass: groupOfNames
+cn: engineering
+member: cn=samuele,ou=people,dc=sighup,dc=io

--- a/tests/e2e/ekscluster/replace_variables.sh
+++ b/tests/e2e/ekscluster/replace_variables.sh
@@ -47,10 +47,10 @@ if [ -z "$DISTRIBUTION_VERSION" ] || [ -z "$CLUSTER_NAME" ] || [ -z "$FURYCTL_YA
     exit 1
 fi
 
-yq -eiy ".spec.distributionVersion = \"$DISTRIBUTION_VERSION\"" $FURYCTL_YAML
-yq -eiy ".metadata.name = \"$CLUSTER_NAME\"" $FURYCTL_YAML
-yq -eiy ".spec.toolsConfiguration.terraform.state.s3.keyPrefix = \"$CLUSTER_NAME\"" $FURYCTL_YAML
-yq -eiy ".spec.tags.env = \"$CLUSTER_NAME\"" $FURYCTL_YAML
-if [[ $(yq '.spec.distribution.modules.dr.velero.eks | has("bucketName")' $FURYCTL_YAML) == "true" ]]; then
-  yq -eiy ".spec.distribution.modules.dr.velero.eks.bucketName = \"$CLUSTER_NAME\"" $FURYCTL_YAML
+yq -eiy ".spec.distributionVersion = \"$DISTRIBUTION_VERSION\"" "$FURYCTL_YAML"
+yq -eiy ".metadata.name = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
+yq -eiy ".spec.toolsConfiguration.terraform.state.s3.keyPrefix = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
+yq -eiy ".spec.tags.env = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
+if [[ $(yq '.spec.distribution.modules.dr.velero.eks | has("bucketName")' "$FURYCTL_YAML") == "true" ]]; then
+  yq -eiy ".spec.distribution.modules.dr.velero.eks.bucketName = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
 fi

--- a/tests/e2e/ekscluster/replace_variables.sh
+++ b/tests/e2e/ekscluster/replace_variables.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+DISTRIBUTION_VERSION=""
+CLUSTER_NAME=""
+FURYCTL_YAML=""
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -d|--distribution-version)
+      DISTRIBUTION_VERSION="$2"
+      shift 2
+      ;;
+    -c|--cluster-name)
+      CLUSTER_NAME="$2"
+      shift 2
+      ;;
+    -f|--furyctl-yaml)
+      FURYCTL_YAML="$2"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: $0 [options]"
+      echo "Options:"
+      echo "  -d, --distribution-version   Specify the distribution version"
+      echo "  -c, --cluster-name           Specify the cluster name"
+      echo "  -f, --furyctl-yaml           Specify the furyctl YAML file path"
+      echo "  -h, --help                   Show this help message"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Use -h or --help for usage information"
+      exit 1
+      ;;
+  esac
+done
+
+# Check if all required arguments are provided
+if [ -z "$DISTRIBUTION_VERSION" ] || [ -z "$CLUSTER_NAME" ] || [ -z "$FURYCTL_YAML" ]; then
+    echo "Error: Missing required arguments"
+    echo "Usage: $0 -d <distribution_version> -c <cluster_name> -f <furyctl_yaml>"
+    exit 1
+fi
+
+yq -eiy ".spec.distributionVersion = \"$DISTRIBUTION_VERSION\"" $FURYCTL_YAML
+yq -eiy ".metadata.name = \"$CLUSTER_NAME\"" $FURYCTL_YAML
+yq -eiy ".spec.toolsConfiguration.terraform.state.s3.keyPrefix = \"$CLUSTER_NAME\"" $FURYCTL_YAML
+yq -eiy ".spec.tags.env = \"$CLUSTER_NAME\"" $FURYCTL_YAML
+if [ yq '.spec.distribution.modules.dr.velero.eks | has("bucketName")' $FURYCTL_YAML == 'true' ]; then
+  yq -eiy ".spec.distribution.modules.dr.velero.eks.bucketName = \"$CLUSTER_NAME\"" $FURYCTL_YAML
+fi

--- a/tests/e2e/ekscluster/replace_variables.sh
+++ b/tests/e2e/ekscluster/replace_variables.sh
@@ -48,28 +48,28 @@ if [ -z "$CLUSTER_NAME" ] || [ -z "$FURYCTL_YAML" ]; then
 fi
 
 if [[ -v $DISTRIBUTION_VERSION ]]; then
-  yq -eiy ".spec.distributionVersion = \"$DISTRIBUTION_VERSION\"" "$FURYCTL_YAML"
+  yq -ei ".spec.distributionVersion = \"$DISTRIBUTION_VERSION\"" "$FURYCTL_YAML"
 fi
-yq -eiy ".metadata.name = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
-yq -eiy ".spec.toolsConfiguration.terraform.state.s3.keyPrefix = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
-yq -eiy ".spec.tags.env = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
+yq -ei ".metadata.name = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
+yq -ei ".spec.toolsConfiguration.terraform.state.s3.keyPrefix = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
+yq -ei ".spec.tags.env = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
 if [[ $(yq '.spec.distribution.modules.dr.velero.eks | has("bucketName")' "$FURYCTL_YAML") == "true" ]]; then
-  yq -eiy ".spec.distribution.modules.dr.velero.eks.bucketName = \"$CLUSTER_NAME-velero\"" "$FURYCTL_YAML"
+  yq -ei ".spec.distribution.modules.dr.velero.eks.bucketName = \"$CLUSTER_NAME-velero\"" "$FURYCTL_YAML"
 fi
 
 if [[ $(yq '.spec.distribution.modules.ingress | has("baseDomain")' "$FURYCTL_YAML") == "true" ]]; then
-  yq -eiy ".spec.distribution.modules.ingress.baseDomain = \"internal.$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
+  yq -ei ".spec.distribution.modules.ingress.baseDomain = \"internal.$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
 fi
 if [[ $(yq '.spec.distribution.modules.ingress.dns.public | has("name")' "$FURYCTL_YAML") == "true" ]]; then
-  yq -eiy ".spec.distribution.modules.ingress.dns.public.name = \"$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
+  yq -ei ".spec.distribution.modules.ingress.dns.public.name = \"$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
 fi
 
 if [[ $(yq '.spec.distribution.modules.ingress.dns.private | has("name")' "$FURYCTL_YAML") == "true" ]]; then
-  yq -eiy ".spec.distribution.modules.ingress.dns.private.name = \"internal.$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
+  yq -ei ".spec.distribution.modules.ingress.dns.private.name = \"internal.$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
 fi
 
 if [[ $(yq '.spec.distribution.modules.auth | has("baseDomain")' "$FURYCTL_YAML") == "true" ]]; then
-  yq -eiy ".spec.distribution.modules.auth.baseDomain = \"$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
+  yq -ei ".spec.distribution.modules.auth.baseDomain = \"$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
 fi
 
 

--- a/tests/e2e/ekscluster/replace_variables.sh
+++ b/tests/e2e/ekscluster/replace_variables.sh
@@ -56,3 +56,16 @@ yq -eiy ".spec.tags.env = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
 if [[ $(yq '.spec.distribution.modules.dr.velero.eks | has("bucketName")' "$FURYCTL_YAML") == "true" ]]; then
   yq -eiy ".spec.distribution.modules.dr.velero.eks.bucketName = \"$CLUSTER_NAME-velero\"" "$FURYCTL_YAML"
 fi
+
+if [[ $(yq '.spec.distribution.modules.ingress | has("baseDomain")' "$FURYCTL_YAML") == "true" ]]; then
+  yq -eiy ".spec.distribution.modules.ingress.baseDomain = \"internal.$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
+fi
+if [[ $(yq '.spec.distribution.modules.dns.public | has("name")' "$FURYCTL_YAML") == "true" ]]; then
+  yq -eiy ".spec.distribution.modules.dns.public.name = \"$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
+fi
+
+if [[ $(yq '.spec.distribution.modules.dns.private | has("name")' "$FURYCTL_YAML") == "true" ]]; then
+  yq -eiy ".spec.distribution.modules.dns.private.name = \"internal.$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
+fi
+
+

--- a/tests/e2e/ekscluster/replace_variables.sh
+++ b/tests/e2e/ekscluster/replace_variables.sh
@@ -41,16 +41,18 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Check if all required arguments are provided
-if [ -z "$DISTRIBUTION_VERSION" ] || [ -z "$CLUSTER_NAME" ] || [ -z "$FURYCTL_YAML" ]; then
+if [ -z "$CLUSTER_NAME" ] || [ -z "$FURYCTL_YAML" ]; then
     echo "Error: Missing required arguments"
-    echo "Usage: $0 -d <distribution_version> -c <cluster_name> -f <furyctl_yaml>"
+    echo "Usage: $0 -c <cluster_name> -f <furyctl_yaml>"
     exit 1
 fi
 
-yq -eiy ".spec.distributionVersion = \"$DISTRIBUTION_VERSION\"" "$FURYCTL_YAML"
+if [[ -v $DISTRIBUTION_VERSION ]]; then
+  yq -eiy ".spec.distributionVersion = \"$DISTRIBUTION_VERSION\"" "$FURYCTL_YAML"
+fi
 yq -eiy ".metadata.name = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
 yq -eiy ".spec.toolsConfiguration.terraform.state.s3.keyPrefix = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
 yq -eiy ".spec.tags.env = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
 if [[ $(yq '.spec.distribution.modules.dr.velero.eks | has("bucketName")' "$FURYCTL_YAML") == "true" ]]; then
-  yq -eiy ".spec.distribution.modules.dr.velero.eks.bucketName = \"$CLUSTER_NAME\"" "$FURYCTL_YAML"
+  yq -eiy ".spec.distribution.modules.dr.velero.eks.bucketName = \"$CLUSTER_NAME-velero\"" "$FURYCTL_YAML"
 fi

--- a/tests/e2e/ekscluster/replace_variables.sh
+++ b/tests/e2e/ekscluster/replace_variables.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 set -e
 DISTRIBUTION_VERSION=""
 CLUSTER_NAME=""
@@ -47,6 +51,6 @@ yq -eiy ".spec.distributionVersion = \"$DISTRIBUTION_VERSION\"" $FURYCTL_YAML
 yq -eiy ".metadata.name = \"$CLUSTER_NAME\"" $FURYCTL_YAML
 yq -eiy ".spec.toolsConfiguration.terraform.state.s3.keyPrefix = \"$CLUSTER_NAME\"" $FURYCTL_YAML
 yq -eiy ".spec.tags.env = \"$CLUSTER_NAME\"" $FURYCTL_YAML
-if [ yq '.spec.distribution.modules.dr.velero.eks | has("bucketName")' $FURYCTL_YAML == 'true' ]; then
+if [[ $(yq '.spec.distribution.modules.dr.velero.eks | has("bucketName")' $FURYCTL_YAML) == "true" ]]; then
   yq -eiy ".spec.distribution.modules.dr.velero.eks.bucketName = \"$CLUSTER_NAME\"" $FURYCTL_YAML
 fi

--- a/tests/e2e/ekscluster/replace_variables.sh
+++ b/tests/e2e/ekscluster/replace_variables.sh
@@ -60,12 +60,16 @@ fi
 if [[ $(yq '.spec.distribution.modules.ingress | has("baseDomain")' "$FURYCTL_YAML") == "true" ]]; then
   yq -eiy ".spec.distribution.modules.ingress.baseDomain = \"internal.$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
 fi
-if [[ $(yq '.spec.distribution.modules.dns.public | has("name")' "$FURYCTL_YAML") == "true" ]]; then
-  yq -eiy ".spec.distribution.modules.dns.public.name = \"$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
+if [[ $(yq '.spec.distribution.modules.ingress.dns.public | has("name")' "$FURYCTL_YAML") == "true" ]]; then
+  yq -eiy ".spec.distribution.modules.ingress.dns.public.name = \"$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
 fi
 
-if [[ $(yq '.spec.distribution.modules.dns.private | has("name")' "$FURYCTL_YAML") == "true" ]]; then
-  yq -eiy ".spec.distribution.modules.dns.private.name = \"internal.$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
+if [[ $(yq '.spec.distribution.modules.ingress.dns.private | has("name")' "$FURYCTL_YAML") == "true" ]]; then
+  yq -eiy ".spec.distribution.modules.ingress.dns.private.name = \"internal.$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
+fi
+
+if [[ $(yq '.spec.distribution.modules.auth | has("baseDomain")' "$FURYCTL_YAML") == "true" ]]; then
+  yq -eiy ".spec.distribution.modules.auth.baseDomain = \"$CLUSTER_NAME.e2e.ci.sighup.cc\"" "$FURYCTL_YAML"
 fi
 
 


### PR DESCRIPTION
### Summary 💡

Added e2e tests for EKSInstaller
The CI tests are triggered by tags `e2e-full-**`
Everyday at 11PM aws nuke is ran to cleanup leftover resources in case of errors during the e2e pipeline

### Description 📝

- Added e2e tests for EKSInstaller in `tests/e2e/ekscluster` + `tests/e2e/ekscluster-upgrades`
- The CI tests are triggered by tags `e2e-full-**`
- The tests create an eks cluster and then try to apply some modifications to the installed modules
- After the tests are run the cluster is deleted immediately
- at 11PM every day the CI launches aws-nuke to delete all the resources that cost money on aws to cleanup test resources, it can also be triggered via a tag `aws-nuke-ci-**`

### Tests performed 🧪

- ran locally with drone cli
- ran on actual drone ci

### Future work 🔧

To avoid using a priviledged runner on the drone pipeline we decided against using the vpn, so there are no tests for it.

While developing the tests I encountered 2 small issues:
- You cannot use the aws region `us-east-1` for the terraform state bucket/velero bucket because it's the default when not specified on aws and aws rejects aws region `us-east-1` if explicitly set. This causes an error since it's mandatory in the furyctl.yaml schema -> there is already[ an open issue](https://github.com/sighupio/fury-distribution/issues/270)
- Taints may not be properly applied to the `mimir` module (I tried running the tests with a single `infra` nodegroup with taints and tolerations and mimir pods would remain unschedulable - I have not investigated further) -> I will try to reproduce it and open an issue
- I added a temporary fix in the e2e test because pomerium would not delete the dns entry and it would break  -> I will try to reproduce it and open an issue