### PR TITLE
feat(kustomize): update to version v5 (5.6.0)

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -16,7 +16,7 @@ The distribution is maintained with ❤️ by the team [SIGHUP](https://sighup.i
 
 ## Breaking changes 💔
 
-- TBD
+- [[#358](https://github.com/sighupio/fury-distribution/pull/358)] **Upgrade kustomize to version 5.6.0**: plugins that used old deprecated constructs in their `kustomization.yaml` may not work anymore. Please refer to the release notes of `kustomize` version [4.0.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.0.0) and version [5.0.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.0) for breaking changes that might affect your plugins.
 
 ## New features 🌟
 

--- a/kfd.yaml
+++ b/kfd.yaml
@@ -37,7 +37,7 @@ tools:
     kubectl:
       version: 1.31.4
     kustomize:
-      version: 3.10.0
+      version: 5.6.0
     terraform:
       version: 1.4.6
     yq:

--- a/kfd.yaml
+++ b/kfd.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-version: v1.32.0
+version: v1.31.0
 modules:
   auth: v0.4.0
   aws: v4.3.0

--- a/kfd.yaml
+++ b/kfd.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-version: v1.31.0
+version: v1.32.0
 modules:
   auth: v0.4.0
   aws: v4.3.0

--- a/templates/distribution/scripts/apply.sh.tpl
+++ b/templates/distribution/scripts/apply.sh.tpl
@@ -8,7 +8,7 @@ kubectlbin="{{ .paths.kubectl }}"
 yqbin="{{ .paths.yq }}"
 vendorPath="{{ .paths.vendorPath }}"
 
-$kustomizebin build --load_restrictor LoadRestrictionsNone . > out.yaml
+$kustomizebin build --load-restrictor LoadRestrictionsNone . > out.yaml
 
 {{- if and (index .spec.distribution.common "registry") (ne .spec.distribution.common.registry "") }}
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/templates/distribution/scripts/delete.sh.tpl
+++ b/templates/distribution/scripts/delete.sh.tpl
@@ -7,7 +7,7 @@ kubectlbin="{{ .paths.kubectl }}"
 yqbin="{{ .paths.yq }}"
 vendorPath="{{ .paths.vendorPath }}"
 
-$kustomizebin build --load_restrictor LoadRestrictionsNone . > out.yaml
+$kustomizebin build --load-restrictor LoadRestrictionsNone . > out.yaml
 
 {{- if eq .spec.distribution.modules.monitoring.type "none" }}
 if ! $kubectlbin get apiservice v1.monitoring.coreos.com; then

--- a/templates/plugins/scripts/apply.sh.tpl
+++ b/templates/plugins/scripts/apply.sh.tpl
@@ -13,7 +13,7 @@ yqbin="{{ .paths.yq }}"
 
 echo "Deploying plugin {{ .name }}..."
 
-$kustomizebin build --load_restrictor LoadRestrictionsNone {{ .folder }} > out.yaml
+$kustomizebin build --load-restrictor LoadRestrictionsNone {{ .folder }} > out.yaml
 
 $kappbin deploy -a kfd-plugin-{{ .name }} -n kube-system -f out.yaml --allow-all-ns -y --default-label-scoping-rules=false --apply-default-update-strategy=fallback-on-replace -c
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.

By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterwards.

Opening a PR in draft allows other team members to know that you are working on this change, and let's you have a
place to track your work in progress.

When opening PRs in Draft, **don't assign reviewers until the PR is ready for review**.

Once you are confortable with the status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡
Upgrade Kustomize from version 3.10 to the latest version (at the time of writing this is 5.6.0).

Relates: https://github.com/sighupio/product-management/issues/630

### Description 📝
Since we were falling a little behind with the Kustomize versions, we are now updating to version v5 of Kustomize.

### Breaking Changes 💔
`--load_restrictor` flag is now `--load-restrictor`.

### Tests performed 🧪
- [x] Built a cluster with the existing v1.31.0 fury-distribution, which uses kustomize version 3.10.0.
- [x] Manually built a new `out.yaml` with the new kustomize version.
  - [x] Diff between the "old" `out.yaml` and the newly generated `out.yaml`. Checked if there was any major difference.
- [x] Built a cluster with the not-yet existing fury-distribution with the new kustomize version 5.6.0.
- [x] Tested plugins apply with the new kustomize version (5.6.0).
- [x] Tested custom patches with the new kustomize version (5.6.0). 

### Future work 🔧

Follow implementation on `furyctl` too.
