### PR TITLE
fix: small fixes in template config files

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -60,6 +60,7 @@ To make use of this new feature, you need to define the hosts where etcd will be
 - [[#336](https://github.com/sighupio/fury-distribution/pull/336)] **Fix race condition when deleting Kyverno**: changing the policy module type from `kyverno` to `none` could, sometimes, end up in a race condition where the API for ClusterPolicy CRD is unregistered before the deletion of the ClusterPolicy objects, resulting in an error in the deletion command execution. The deletion command has been tweaked to avoid this condition.
 - [[#344](https://github.com/sighupio/fury-distribution/pull/344)] **Fix Cidr Block additional firewall rule in EKS Cluster**: remove the limitation to have a single CIDR Block additional firewall rule as the EKS installer supports a list.
 - [[#348](https://github.com/sighupio/fury-distribution/pull/348)] **Fix `Get previous cluster configuration` failure on first apply**: fixed an issue on `furyctl apply` for on-premises clusters that made it fail with an `ansible-playbook create-playbook.yaml: command failed - exit status 2` error on the very first time it was executed.
+- [[#362](https://github.com/sighupio/fury-distribution/pull/348)] **Fix template config files**: fix wrong documentation links inside configuration files created with `furyctl create config`.
 
 ## Upgrade procedure
 

--- a/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/ekscluster-kfd-v1alpha2.yaml.tpl
@@ -7,7 +7,7 @@
 # This is a sample configuration file to be used as a starting point. For the
 # complete reference of the configuration file schema, please refer to the
 # official documentation:
-# https://docs.kubernetesfury.com/docs/furyctl/providers/ekscluster
+# https://docs.kubernetesfury.com/docs/installation/kfd-configuration/providers/EKSCluster
 
 ---
 apiVersion: kfd.sighup.io/v1alpha2

--- a/templates/config/kfddistribution-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/kfddistribution-kfd-v1alpha2.yaml.tpl
@@ -7,7 +7,7 @@
 # This is a sample configuration file to be used as a starting point. For the
 # complete reference of the configuration file schema, please refer to the
 # official documentation:
-# https://docs.kubernetesfury.com/docs/furyctl/providers/kfddistribution
+# https://docs.kubernetesfury.com/docs/installation/kfd-configuration/providers/KFDDistribution
 
 ---
 apiVersion: kfd.sighup.io/v1alpha2

--- a/templates/config/onpremises-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/onpremises-kfd-v1alpha2.yaml.tpl
@@ -47,7 +47,7 @@ spec:
         interface: eth1
         ip: 192.168.1.201/24
         virtualRouterId: "201"
-        passphrase: "123aaaccc321"
+        passphrase: "123ab321"
       stats:
         username: admin
         password: password

--- a/templates/config/onpremises-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/onpremises-kfd-v1alpha2.yaml.tpl
@@ -7,7 +7,7 @@
 # This is a sample configuration file to be used as a starting point. For the
 # complete reference of the configuration file schema, please refer to the
 # official documentation:
-# https://docs.kubernetesfury.com/docs/furyctl/providers/onpremises
+# https://docs.kubernetesfury.com/docs/installation/kfd-configuration/providers/OnPremises
 
 ---
 apiVersion: kfd.sighup.io/v1alpha2


### PR DESCRIPTION
### Summary 💡

This PR fixes two small issues with the template config files that `furyctl create config` uses:

- Link to documentation in the heading: correction after the refactoring of the documentation website
- Keepalived passphrase: after recent changes in the schema, the `spec.kubernetes.loadBalances.keepalived.passphrase` parameter in the OnPremises template needed to be changed

### Description 📝

When you create a `furyctl.yaml` config file using `furyctl create config`, the heading is directing users to an old documentation link that does not work anymore, because the refactoring of the documentation site changed the path of the Providers' explanations.

Also, after the [recent changes to the schema](https://github.com/sighupio/fury-distribution/commit/8a647a748032d3b99f89fdc9be63a7f569ebb800), the template config file for the OnPremises provider failed validations during the creation with `furyctl create config` because the template contained a keepalived passphrase longer than the allowed max length. This PR aligns the template with the schema's new constraints.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested the link after using `furyctl create config --kind {OnPremises|KFDDistribution|EKSCluster} --version v1.31.0 --distro-location <path-to-local-kfd-distro>`

### Future work 🔧

N/A