### PR TITLE
fix(templates/distribution/monitoring/minio): use right node placement

### DIFF
--- a/templates/distribution/manifests/monitoring/patches/infra-nodes.yml.tpl
+++ b/templates/distribution/manifests/monitoring/patches/infra-nodes.yml.tpl
@@ -173,6 +173,7 @@ spec:
       tolerations:
         {{ template "tolerations" $mimirArgs }}
 {{- if eq .spec.distribution.modules.monitoring.mimir.backend "minio" }}
+{{- $minioArgs := dict "module" "monitoring" "package" "minio" "spec" .spec }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -183,9 +184,22 @@ spec:
   template:
     spec:
       nodeSelector:
-        {{ template "nodeSelector" $mimirArgs }}
+        {{ template "nodeSelector" $minioArgs }}
       tolerations:
-        {{ template "tolerations" $mimirArgs }}
+        {{ template "tolerations" $minioArgs }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-monitoring-buckets-setup
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      nodeSelector:
+        {{ template "nodeSelector" $minioArgs }}
+      tolerations:
+        {{ template "tolerations" $minioArgs }}
 {{- end }}
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
### Summary 💡

Use the right node placement for Monitoring's Minio:
- Add missing placement patch to Minio's setup job.
- Use Minio's overrides instead of Mimir's for Minio's StatefulSet placement.

Closes #363 


<!-- If this PR is related to changes produced in other repos, like a Module, please link them below. -->
Relates: #357 


### Description 📝

See Summary and Linked Issue.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested that Minio gets placed in the right nodes using the `.spec.distribution.common` tolerations and nodeSelectors.
- [x] Tested that Minio gets placed in the right nodes using the `.spec.distribution.modules.monitoring.minio.overrides` nodeSelector and tolerations.


### Future work 🔧

None