### PR TITLE
feat(kapp): bump to 0.64.1

### DIFF
--- a/kfd.yaml
+++ b/kfd.yaml
@@ -47,7 +47,7 @@ tools:
     helmfile:
       version: 0.156.0
     kapp:
-      version: 0.64.0
+      version: 0.64.1
   eks:
     awscli:
       version: ">= 2.8.12"


### PR DESCRIPTION
### Summary 💡

Bump kapp to latest version 0.64.1, that includes some security patching and no functional modifications:

https://github.com/carvel-dev/kapp/releases/tag/v0.64.1

### Description 📝

See summary

### Breaking Changes 💔

None

### Tests performed 🧪

Being that there are no functional changes and is a patch release, I think we can test this in the release process.

### Future work 🔧

None
