### PR TITLE
chore(templates,distribution): move snapshot-controller to EKS Addon

### DIFF
--- a/templates/distribution/manifests/aws/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/aws/kustomization.yaml.tpl
@@ -10,7 +10,6 @@ kind: Kustomization
 
 resources:
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/aws/katalog/cluster-autoscaler/v" $version.Major "." $version.Minor ".x" }}
-  - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/aws/katalog/snapshot-controller" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/aws/katalog/load-balancer-controller" }}
   - {{ print "../" .spec.distribution.common.relativeVendorPath "/modules/aws/katalog/node-termination-handler" }}
   - resources/storageclasses.yml

--- a/templates/distribution/manifests/aws/patches/infra-nodes.yml.tpl
+++ b/templates/distribution/manifests/aws/patches/infra-nodes.yml.tpl
@@ -33,16 +33,3 @@ spec:
         {{ template "nodeSelector" $clusterAutoscalerArgs }}
       tolerations:
         {{ template "tolerations" $clusterAutoscalerArgs }}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: snapshot-controller
-  namespace: kube-system
-spec:
-  template:
-    spec:
-      nodeSelector:
-        {{ template "nodeSelector" $ebsSnapshotControllerArgs }}
-      tolerations:
-        {{ template "tolerations" $ebsSnapshotControllerArgs }}

--- a/templates/distribution/terraform/eks-addons.tf.tpl
+++ b/templates/distribution/terraform/eks-addons.tf.tpl
@@ -7,5 +7,77 @@ module "eks_addons" {
   cluster_name = "{{ .metadata.name }}"
   ebs_csi_driver = {
     service_account_role_arn = module.ebs_csi_driver_iam_role.ebs_csi_driver_iam_role_arn
+    configuration_values = jsonencode({
+      controller =  {
+          tolerations = [
+            {{- range $toleration := .spec.distribution.common.tolerations }}
+            {
+              {{- if $toleration.key }}
+              key = "{{ $toleration.key }}"
+              {{- end }}
+              {{- if $toleration.value }}
+              value = "{{ $toleration.value }}"
+              {{- end }}
+              {{- if $toleration.effect }}
+              effect = "{{ $toleration.effect }}"
+              {{- end }}
+            }
+          {{- end }}
+          ]
+          nodeSelector = {
+            {{- range $k,$v := .spec.distribution.common.nodeSelector }}
+              "{{ $k }}" = "{{ $v }}"
+            {{- end }}
+          }
+        }
+    })
+  }
+  coredns = {
+    configuration_values = jsonencode({
+      tolerations = [
+        {{- range $toleration := .spec.distribution.common.tolerations }}
+        {
+          {{- if $toleration.key }}
+          key = "{{ $toleration.key }}"
+          {{- end }}
+          {{- if $toleration.value }}
+          value = "{{ $toleration.value }}"
+          {{- end }}
+          {{- if $toleration.effect }}
+          effect = "{{ $toleration.effect }}"
+          {{- end }}
+        }
+      {{- end }}
+      ]
+      nodeSelector = {
+        {{- range $k,$v := .spec.distribution.common.nodeSelector }}
+          "{{ $k }}" = "{{ $v }}"
+        {{- end }}
+      }
+    })
+  }
+  snapshot_controller = {
+    configuration_values = jsonencode({
+      tolerations = [
+        {{- range $toleration := .spec.distribution.common.tolerations }}
+        {
+          {{- if $toleration.key }}
+          key = "{{ $toleration.key }}"
+          {{- end }}
+          {{- if $toleration.value }}
+          value = "{{ $toleration.value }}"
+          {{- end }}
+          {{- if $toleration.effect }}
+          effect = "{{ $toleration.effect }}"
+          {{- end }}
+        }
+      {{- end }}
+      ]
+      nodeSelector = {
+        {{- range $k,$v := .spec.distribution.common.nodeSelector }}
+          "{{ $k }}" = "{{ $v }}"
+        {{- end }}
+      }
+    })
   }
 }


### PR DESCRIPTION
### Summary 💡

This PR moves the Snapshot Controller from Kustomization to EKS Add-ons, simplifying its deployment and management. This aligns with best practices for integrating AWS-managed components and reduces the overhead of maintaining custom manifests.

<!--
If there's an existing issue for your change, please link to it below inserting a link or the issue number.

If there's _not_ an existing issue, please open one first if the problem you are solving needs to be clearly identified,
for example is an error message that other users could get and google it.
-->
Closes: https://github.com/sighupio/product-management/issues/592


<!-- If this PR is related to changes produced in other repos, like a Module, please link them below. -->
Relates:


### Description 📝

<!--
Let us know what you are changing. Share anything that could provide the most context.

Feel free to add screenshots, code examples, the Description could end up in the release notes to help users adopt the new feature or changes that you are introducing.

Expand on the reasoning behind some decision that you could have made to help reviewers understand the diff in the PR.
-->

### Breaking Changes 💔

<!--
If this PR introduces Breaking Changes, please include all the relevant information:
- What is changing
- What should the process for updating be
- Include examples if you can
-->

### Tests performed 🧪

<!--
Create a checklist with all the tests that you performed on your changes, being manual or automated.

If you are opening a Draft PR, you can use the checklist to track the tests that you want to do and mark them once you have performed them.

Example:

- [ ] Tested the change with KFD version X.Y.Z
- [ ] Tested an upgrade from the previous version X
-->

### Future work 🔧

<!--
If there's any future work that could improve or extend on the work you've done in this PR you can mention it so
this PR can be used as context for that.
-->
