### PR TITLE
fix(templates): fix indentation on DR's kustomize

### DIFF
--- a/templates/distribution/manifests/dr/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/dr/kustomization.yaml.tpl
@@ -112,10 +112,10 @@ configMapGenerator:
 {{- if eq .spec.distribution.common.provider.type "none" }}
 secretGenerator:
 {{- if eq .spec.distribution.modules.dr.velero.backend "externalEndpoint" }}
-- name: cloud-credentials
-  namespace: kube-system
-  files:
-    - cloud=secrets/cloud-credentials.config
+  - name: cloud-credentials
+    namespace: kube-system
+    files:
+      - cloud=secrets/cloud-credentials.config
 {{- end }}
 {{- if eq .spec.distribution.modules.dr.etcdBackup.type "all" "s3" }}
   - name: etcd-backup-s3-rclone-conf


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.

By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterwards.

Opening a PR in draft allows other team members to know that you are working on this change, and let's you have a
place to track your work in progress.

When opening PRs in Draft, **don't assign reviewers until the PR is ready for review**.

Once you are confortable with the status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

Fix indentation on DR kustomization that breaks when both velero and etcd have S3 enabled.

Closes #431

### Description 📝

See linked Issue.

Note: CI failures are not linked to this PR.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested the change with SD `main` version 

### Future work 🔧

None
