### PR TITLE
feat(monitoring): bump prometheus-agent to v3.5.0

### DIFF
--- a/templates/distribution/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml.tpl
@@ -9,7 +9,7 @@ metadata:
   namespace: monitoring
 spec:
   # image should be the same as the one used in prometheus-operated
-  image: registry.sighup.io/fury/prometheus/prometheus:v2.46.0
+  image: registry.sighup.io/fury/prometheus/prometheus:v3.5.0
   # version: 2.46.0
   replicas: 2
   externalLabels:


### PR DESCRIPTION
### Summary 💡

Bump Prometheus Agent to v3.5.0

Relates and depends on:
- See https://github.com/sighupio/module-monitoring/pull/206



### Description 📝

This PR is a placeholder.

It updates the image used by Prometheus Agent mode and should be merged together with the bumping of the Monitoring module to v4.0.0 that includes the new Prometheus version.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested the change with SD version 1.33.0 on prem rc.3

### Future work 🔧

None
