### PR TITLE
Working around aws-nuke failing to delete a CloudWatchLogsLogGroup 

### DIFF
--- a/tests/e2e/ekscluster/awsnuke/config.yml
+++ b/tests/e2e/ekscluster/awsnuke/config.yml
@@ -37,4 +37,7 @@ resource-types:
     - Route53ResolverRuleAssociation
 
 accounts:
-  ACCOUNT_ID_PLACEHOLDER: {}
+  ACCOUNT_ID_PLACEHOLDER:
+    filters:
+      CloudWatchLogsLogGroup:
+      - "/aws/lambda/aws-controltower-NotificationForwarder"


### PR DESCRIPTION
### Summary 💡

After the reorganization of the AWS accounts, we now need to avoid trying to delete the `/aws/lambda/aws-controltower-NotificationForwarder` log group. This PR adds an `aws-nuke` filter to avoid trying to delete that specific resource.

Closes: https://github.com/sighupio/product-management/issues/661

### Description 📝
Add the filter to the Drone AWS account.
```yaml
accounts:
  ACCOUNT_ID_PLACEHOLDER:
    filters:
      CloudWatchLogsLogGroup:
      - "/aws/lambda/aws-controltower-NotificationForwarder"
```

### Breaking Changes 💔
None.

### Tests performed 🧪
Performed a local execution of `aws-nuke` with Drone's AWS credentials. First dry-run then with a ad-hoc test VPC.

### Future work 🔧
None.
