### PR TITLE
docs: fix README.md previous distro versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Current supported versions of SD are:
 |                                  SD Version                               | Kubernetes Version |
 | :-----------------------------------------------------------------------: | :----------------: |
 | [`1.33.1`](https://github.com/sighupio/distribution/releases/tag/v1.33.1) |      `1.33.x`      |
-| [`1.32.0`](https://github.com/sighupio/distribution/releases/tag/v1.32.0) |      `1.32.x`      |
-| [`1.31.1`](https://github.com/sighupio/distribution/releases/tag/v1.31.1) |      `1.31.x`      |
+| [`1.32.1`](https://github.com/sighupio/distribution/releases/tag/v1.32.1) |      `1.32.x`      |
+| [`1.31.2`](https://github.com/sighupio/distribution/releases/tag/v1.31.2) |      `1.31.x`      |
 
 Check the [compatibility matrix][compatibility-matrix] for additional information about previous releases of the Distribution and the compatibility with `furyctl`.
 


### PR DESCRIPTION
### Summary 💡

fix README.md previous supported versions 1.32.1, 1.31.2

Closes:


Relates:


### Description 📝


### Breaking Changes 💔


### Tests performed 🧪

### Future work 🔧

