### PR TITLE
docs: add readme to docs folder pointing to docs site

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,1 +1,4 @@
 # Contributing guidelines
+
+Please refer to <https://docs.sighup.io/docs/contribute/>.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# SIGHUP Distribution Documentation
+
+This folder contains documentation related to the development of the SIGHUP Distribution.
+
+For the full end-user documentation of SD please visit the documentation site at <https://docs.sighup.io>.
+


### PR DESCRIPTION
### Summary 💡

- Add readme to the docs folder pointing the users to the documentation site, because most docs are not found in this folder.
- Link to the contributing documentation in the CONTRIBUTING.md file.

### Description 📝

See summary

### Breaking Changes 💔

N/A

### Tests performed 🧪

N/A

### Future work 🔧

N/A