### PR TITLE
fix(monitoring): add ScrapeConfig for etcd on dedicated nodes

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -12,6 +12,7 @@ N/A
 
 - [[#497]](https://github.com/sighupio/distribution/pull/497) When the distribution network-policies are enabled, traffic between SD monitoring and logging namespaces, and from haproxy ingress controller to the monitoring namespace, is now allowed.
 - [[#498]](https://github.com/sighupio/distribution/pull/498) Fixes schema validation error caused by missing nginx field in the generated configuration file for all providers.
+- [[#501]](https://github.com/sighupio/distribution/pull/501) This resolves the issue where the etcd Grafana dashboard did not display data when etcd is running on dedicated nodes. Now, when `spec.kubernetes.etcd` is configured, a `ScrapeConfig` resource is generated to collect etcd metrics directly from the dedicated etcd nodes.
 
 ## Breaking changes 💔
 

--- a/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
@@ -31,9 +31,9 @@ resources:
   - {{ print $vendorPrefix "/modules/monitoring/katalog/haproxy" }}
   - resources/haproxy-scrapeConfig.yaml
     {{- end }}
-    {{- if index .spec.kubernetes "etcd" }}
+  {{- end }}
+  {{- if .spec | digAny "kubernetes" "etcd" nil }}
   - resources/etcd-scrapeConfig.yaml
-    {{- end }}
   {{- end }}
 {{- end }}
 {{- if eq .spec.distribution.common.provider.type "eks" }}

--- a/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
@@ -70,6 +70,22 @@ resources:
 
 patches:
   - path: patches/infra-nodes.yml
+{{- if .spec | digAny "kubernetes" "etcd" nil }}
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: etcd-metrics
+        namespace: kube-system
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1
+      kind: ServiceMonitor
+      metadata:
+        name: etcd-metrics
+        namespace: kube-system
+{{- end }}
 {{- if eq .spec.distribution.common.provider.type "eks" }}{{/* in EKS there are no files to monitor on nodes */}}
   - patch: |-
       $patch: delete

--- a/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
@@ -31,6 +31,9 @@ resources:
   - {{ print $vendorPrefix "/modules/monitoring/katalog/haproxy" }}
   - resources/haproxy-scrapeConfig.yaml
     {{- end }}
+    {{- if index .spec.kubernetes "etcd" }}
+  - resources/etcd-scrapeConfig.yaml
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- if eq .spec.distribution.common.provider.type "eks" }}

--- a/templates/distribution/manifests/monitoring/policies/prometheus.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/policies/prometheus.yaml.tpl
@@ -109,6 +109,24 @@ spec:
         - port: 8405
           protocol: TCP
 ---
+{{- if .spec | digAny "kubernetes" "etcd" nil }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-egress-external-etcd
+  namespace: monitoring
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  egress:
+    - ports:
+        - port: 2378
+          protocol: TCP
+---
+{{- end }}
 {{- if eq .spec.distribution.modules.monitoring.mimir.backend "minio" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/templates/distribution/manifests/monitoring/resources/etcd-scrapeConfig.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/etcd-scrapeConfig.yaml.tpl
@@ -1,12 +1,10 @@
-
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
 
 {{- if eq .spec.distribution.common.provider.type "none" }}
-{{- if hasKeyAny .spec "kubernetes" }}
-{{- if index .spec.kubernetes "etcd" }}
+{{- if .spec | digAny "kubernetes" "etcd" nil }}
 ---
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
@@ -23,6 +21,5 @@ spec:
         {{- range $h := .spec.kubernetes.etcd.hosts }}
         - {{ $h.ip }}:2378
         {{- end }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/distribution/manifests/monitoring/resources/etcd-scrapeConfig.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/etcd-scrapeConfig.yaml.tpl
@@ -1,0 +1,28 @@
+
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+
+{{- if eq .spec.distribution.common.provider.type "none" }}
+{{- if hasKeyAny .spec "kubernetes" }}
+{{- if index .spec.kubernetes "etcd" }}
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: external-etcd
+  namespace: monitoring
+  labels:
+    prometheus: k8s
+spec:
+  staticConfigs:
+    - labels:
+        job: etcd-metrics
+      targets:
+        {{- range $h := .spec.kubernetes.etcd.hosts }}
+        - {{ $h.ip }}:2378
+        {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
### Summary 💡

Fix the etcd Grafana dashboard showing no data when etcd runs on dedicated nodes. When `spec.kubernetes.etcd` is configured, a `ScrapeConfig` resource is now generated to scrape etcd metrics directly from the dedicated etcd nodes.

Closes: https://github.com/sighupio/distribution/issues/500

### Description 📝

See the details of the related issue.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Deployed an on-premises cluster with external etcd 
- [x] Deployed an on-premises cluster with etcd on control plane nodes for regressions

### Future work 🔧

None.