### PR TITLE
fix(onpremises): allow arbitrary keys under auth.overrides.ingresses

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -75,6 +75,7 @@ steps: # qa
     commands:
       - eval "$(mise activate bash --shims)"
       - bats -t tests/e2e/kfddistribution/schema.sh
+      - bats -t tests/e2e/onpremises/schema.sh
 
   - name: test-create-config
     image: quay.io/sighup/mise:v2025.4.4

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -782,58 +782,9 @@ Override the common configuration with a particular configuration for the Auth m
 
 ## .spec.distribution.modules.auth.overrides.ingresses
 
-### Properties
-
-| Property                                                             | Type     | Required |
-|:---------------------------------------------------------------------|:---------|:---------|
-| [dex](#specdistributionmodulesauthoverridesingressesdex)             | `object` | Optional |
-| [gangplank](#specdistributionmodulesauthoverridesingressesgangplank) | `object` | Optional |
-
 ### Description
 
 Override the definition of the Auth module ingresses.
-
-## .spec.distribution.modules.auth.overrides.ingresses.dex
-
-### Properties
-
-| Property                                                                      | Type     | Required |
-|:------------------------------------------------------------------------------|:---------|:---------|
-| [host](#specdistributionmodulesauthoverridesingressesdexhost)                 | `string` | Required |
-| [ingressClass](#specdistributionmodulesauthoverridesingressesdexingressclass) | `string` | Required |
-
-## .spec.distribution.modules.auth.overrides.ingresses.dex.host
-
-### Description
-
-Use this host for the ingress instead of the default one.
-
-## .spec.distribution.modules.auth.overrides.ingresses.dex.ingressClass
-
-### Description
-
-Use this ingress class for the ingress instead of the default one.
-
-## .spec.distribution.modules.auth.overrides.ingresses.gangplank
-
-### Properties
-
-| Property                                                                            | Type     | Required |
-|:------------------------------------------------------------------------------------|:---------|:---------|
-| [host](#specdistributionmodulesauthoverridesingressesgangplankhost)                 | `string` | Required |
-| [ingressClass](#specdistributionmodulesauthoverridesingressesgangplankingressclass) | `string` | Required |
-
-## .spec.distribution.modules.auth.overrides.ingresses.gangplank.host
-
-### Description
-
-Use this host for the ingress instead of the default one.
-
-## .spec.distribution.modules.auth.overrides.ingresses.gangplank.ingressClass
-
-### Description
-
-Use this ingress class for the ingress instead of the default one.
 
 ## .spec.distribution.modules.auth.overrides.nodeSelector
 

--- a/pkg/apis/ekscluster/v1alpha2/private/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/private/schema.go
@@ -5,8 +5,9 @@ package private
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sighupio/go-jsonschema/pkg/types"
 	"reflect"
+
+	"github.com/sighupio/go-jsonschema/pkg/types"
 )
 
 // A SD Cluster deployed on top of AWS's Elastic Kubernetes Service (EKS).

--- a/pkg/apis/ekscluster/v1alpha2/public/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/public/schema.go
@@ -5,8 +5,9 @@ package public
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sighupio/go-jsonschema/pkg/types"
 	"reflect"
+
+	"github.com/sighupio/go-jsonschema/pkg/types"
 )
 
 // A SD Cluster deployed on top of AWS's Elastic Kubernetes Service (EKS).

--- a/pkg/apis/kfddistribution/v1alpha2/public/schema.go
+++ b/pkg/apis/kfddistribution/v1alpha2/public/schema.go
@@ -5,8 +5,9 @@ package public
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sighupio/go-jsonschema/pkg/types"
 	"reflect"
+
+	"github.com/sighupio/go-jsonschema/pkg/types"
 )
 
 // SD modules deployed on top of an existing Kubernetes cluster.

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -5,8 +5,9 @@ package public
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sighupio/go-jsonschema/pkg/types"
 	"reflect"
+
+	"github.com/sighupio/go-jsonschema/pkg/types"
 )
 
 type Metadata struct {
@@ -404,7 +405,7 @@ type SpecDistributionModulesAuthOIDCKubernetesAuth struct {
 // module.
 type SpecDistributionModulesAuthOverrides struct {
 	// Override the definition of the Auth module ingresses.
-	Ingresses *SpecDistributionModulesAuthOverridesIngresses `json:"ingresses,omitempty" yaml:"ingresses,omitempty" mapstructure:"ingresses,omitempty"`
+	Ingresses SpecDistributionModulesAuthOverridesIngresses `json:"ingresses,omitempty" yaml:"ingresses,omitempty" mapstructure:"ingresses,omitempty"`
 
 	// Set to override the node selector used to place the pods of the Auth module.
 	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
@@ -423,13 +424,7 @@ type SpecDistributionModulesAuthOverridesIngress struct {
 }
 
 // Override the definition of the Auth module ingresses.
-type SpecDistributionModulesAuthOverridesIngresses struct {
-	// Dex corresponds to the JSON schema field "dex".
-	Dex *SpecDistributionModulesAuthOverridesIngress `json:"dex,omitempty" yaml:"dex,omitempty" mapstructure:"dex,omitempty"`
-
-	// Gangplank corresponds to the JSON schema field "gangplank".
-	Gangplank *SpecDistributionModulesAuthOverridesIngress `json:"gangplank,omitempty" yaml:"gangplank,omitempty" mapstructure:"gangplank,omitempty"`
-}
+type SpecDistributionModulesAuthOverridesIngresses map[string]SpecDistributionModulesAuthOverridesIngress
 
 type SpecDistributionModulesAuthPomerium interface{}
 

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -3071,16 +3071,10 @@
           "description": "Set to override the tolerations that will be added to the pods of the Auth module."
         },
         "ingresses": {
-          "additionalProperties": false,
           "type": "object",
           "description": "Override the definition of the Auth module ingresses.",
-          "properties": {
-            "gangplank": {
-              "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
-            },
-            "dex": {
-              "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
-            }
+          "additionalProperties": {
+            "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
           }
         }
       }

--- a/tests/e2e/onpremises/schema.sh
+++ b/tests/e2e/onpremises/schema.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+load ./helper
+
+expect_ok() {
+    [ "${1}" -eq 0 ]
+}
+
+expect_no() {
+    [ "${1}" -eq 1 ]
+}
+
+# Helper function to check if error output contains both path and message
+# This makes tests resilient to jv version format changes
+assert_error_contains() {
+    local path="$1"
+    local message="$2"
+
+    # Check for path (flexible to different formats: "at '/path'" or "[I#/path]")
+    if [[ "${output}" != *"${path}"* ]]; then
+        echo "Expected path '${path}' not found in output" >&3
+        return 2
+    fi
+
+    # Check for error message
+    if [[ "${output}" != *"${message}"* ]]; then
+        echo "Expected message '${message}' not found in output" >&3
+        return 3
+    fi
+}
+
+# Preflight check: verify jv version and error format
+preflight_check() {
+    echo "Running preflight checks..." >&3
+
+    # Check if jv is available
+    if ! command -v jv >/dev/null 2>&1; then
+        echo "ERROR: jv command not found" >&3
+        echo "Make sure mise tools are installed and activated" >&3
+        return 1
+    fi
+
+    # Show which jv is being used
+    local JV_PATH
+    JV_PATH=$(command -v jv)
+    echo "Using jv from: ${JV_PATH}" >&3
+
+    # Create a test to verify error format
+    local TMPDIR_TEST
+    TMPDIR_TEST=$(mktemp -d -t "fury-jv-preflight-XXXXXXXXXX")
+
+    # Create minimal invalid JSON to test error format
+    echo '{"type": "string"}' > "${TMPDIR_TEST}/test-schema.json"
+    echo '123' > "${TMPDIR_TEST}/test-instance.json"
+
+    local TEST_OUTPUT
+    TEST_OUTPUT=$(jv "${TMPDIR_TEST}/test-schema.json" "${TMPDIR_TEST}/test-instance.json" 2>&1 || true)
+
+    rm -rf "${TMPDIR_TEST}"
+
+    # Check if error format matches v0.7.0 expectations
+    if [[ "${TEST_OUTPUT}" == *"got"*"want"* ]]; then
+        echo "✓ jv error format verified (v0.7.0)" >&3
+        return 0
+    elif [[ "${TEST_OUTPUT}" == *"expected"*"but got"* ]]; then
+        echo "ERROR: jv is using different error format (older v0.4.0)" >&3
+        echo "Expected: 'got X, want Y' (v0.7.0 format)" >&3
+        echo "Got: 'expected X, but got Y' (v0.4.0 format)" >&3
+        echo "Remove old jv binary and use mise-installed version" >&3
+        return 1
+    else
+        echo "WARNING: Could not verify jv error format" >&3
+        echo "Test output: ${TEST_OUTPUT}" >&3
+        return 0  # Don't fail, let tests proceed
+    fi
+}
+
+# Setup function called by bats before all tests
+setup_file() {
+    # Run preflight check once before all tests
+    if ! preflight_check; then
+        exit 1
+    fi
+}
+
+test_schema() {
+    local KIND=${1}
+    local APIVER=${2}
+    local EXAMPLE=${3}
+    local verify_expectation=${4}
+    local validate_status=""
+    local validate_output=""
+    local verify_expectation_status=""
+
+    TMPDIR=$(mktemp -d -t "fury-distribution-test-XXXXXXXXXX")
+
+    mkdir -p "${TMPDIR}/tests/schemas/${KIND}/${APIVER}"
+
+    yq "tests/schemas/${KIND}/${APIVER}/${EXAMPLE}.yaml" -o json  > "${TMPDIR}/tests/schemas/${KIND}/${APIVER}/${EXAMPLE}.json"
+
+    validate() {
+        jv "schemas/${KIND}/${APIVER}.json" "${TMPDIR}/tests/schemas/${KIND}/${APIVER}/${EXAMPLE}.json" 2>&1
+    }
+
+    run validate
+    validate_status="${status}"
+    validate_output="${output}"
+
+    run "${verify_expectation}" "${validate_status}"
+    verify_expectation_status="${status}"
+
+    rm -rf "${TMPDIR}"
+
+    if [ "${verify_expectation_status}" -ne 0 ]; then
+        echo "${validate_output}" >&3
+
+        return 1
+    fi
+
+    return 0
+}
+
+@test "001 - ok (pomerium override accepted)" {
+    info
+
+    test_schema "public" "onpremises-kfd-v1alpha2" "001-ok" expect_ok
+}
+
+@test "002 - ok (dex + gangplank + pomerium overrides)" {
+    info
+
+    test_schema "public" "onpremises-kfd-v1alpha2" "002-ok" expect_ok
+}
+
+@test "003 - no (pomerium override missing ingressClass)" {
+    info
+
+    expect() {
+        expect_no "${1}"
+
+        assert_error_contains "/spec/distribution/modules/auth/overrides/ingresses/pomerium" "missing property" || return $?
+        assert_error_contains "/spec/distribution/modules/auth/overrides/ingresses/pomerium" "'ingressClass'" || return $?
+    }
+
+    test_schema "public" "onpremises-kfd-v1alpha2" "003-no" expect
+}

--- a/tests/schemas/public/onpremises-kfd-v1alpha2/001-ok.yaml
+++ b/tests/schemas/public/onpremises-kfd-v1alpha2/001-ok.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given a valid OnPremises config
+# And "spec.distribution.modules.auth.overrides.ingresses.pomerium" is specified
+# And the Pomerium override contains "host" and "ingressClass"
+# When I validate the config against the schema
+# Then no errors are returned
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: OnPremises
+metadata:
+  name: onpremises-test-pomerium-override
+spec:
+  distributionVersion: v1.34.0
+  distribution:
+    modules:
+      auth:
+        provider:
+          type: sso
+        baseDomain: example.test
+        dex:
+          connectors: []
+        pomerium:
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        overrides:
+          ingresses:
+            pomerium:
+              host: pomerium.example.test
+              ingressClass: nginx
+      dr:
+        type: none
+      ingress:
+        baseDomain: example.test
+        nginx:
+          type: single
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-example
+            email: example@example.test
+            type: http01
+      logging:
+        type: none
+      policy:
+        type: none

--- a/tests/schemas/public/onpremises-kfd-v1alpha2/002-ok.yaml
+++ b/tests/schemas/public/onpremises-kfd-v1alpha2/002-ok.yaml
@@ -1,0 +1,59 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given a valid OnPremises config
+# And "spec.distribution.modules.auth.overrides.ingresses" contains dex, gangplank, and pomerium
+# And each override contains "host" and "ingressClass"
+# When I validate the config against the schema
+# Then no errors are returned
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: OnPremises
+metadata:
+  name: onpremises-test-pomerium-override
+spec:
+  distributionVersion: v1.34.0
+  distribution:
+    modules:
+      auth:
+        provider:
+          type: sso
+        baseDomain: example.test
+        dex:
+          connectors: []
+        pomerium:
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        overrides:
+          ingresses:
+            dex:
+              host: dex.example.test
+              ingressClass: nginx
+            gangplank:
+              host: gangplank.example.test
+              ingressClass: nginx
+            pomerium:
+              host: pomerium.example.test
+              ingressClass: nginx
+      dr:
+        type: none
+      ingress:
+        baseDomain: example.test
+        nginx:
+          type: single
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-example
+            email: example@example.test
+            type: http01
+      logging:
+        type: none
+      policy:
+        type: none

--- a/tests/schemas/public/onpremises-kfd-v1alpha2/003-no.yaml
+++ b/tests/schemas/public/onpremises-kfd-v1alpha2/003-no.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given an OnPremises config
+# And "spec.distribution.modules.auth.overrides.ingresses.pomerium" is specified
+# And the Pomerium override is missing "ingressClass"
+# When I validate the config against the schema
+# Then a validation error is returned for the Pomerium override
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: OnPremises
+metadata:
+  name: onpremises-test-pomerium-override
+spec:
+  distributionVersion: v1.34.0
+  distribution:
+    modules:
+      auth:
+        provider:
+          type: sso
+        baseDomain: example.test
+        dex:
+          connectors: []
+        pomerium:
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        overrides:
+          ingresses:
+            pomerium:
+              host: pomerium.example.test
+      dr:
+        type: none
+      ingress:
+        baseDomain: example.test
+        nginx:
+          type: single
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-example
+            email: example@example.test
+            type: http01
+      logging:
+        type: none
+      policy:
+        type: none


### PR DESCRIPTION
### Summary 💡

The OnPremises Go templates already consume `.spec.distribution.modules.auth.overrides.ingresses.pomerium.host` through the generic auth ingress helpers and the Pomerium-specific templates. However, `schemas/public/onpremises-kfd-v1alpha2.json` declared `auth.overrides.ingresses` as a closed object whose only allowed keys were `dex` and `gangplank`, with `additionalProperties: false`.

As a result, schema validation rejected any OnPremises configuration that overrode the Pomerium ingress, even though the rendered manifests already support that override.

This PR aligns the OnPremises schema with the convention already used by `ekscluster` and `kfddistribution`: `auth.overrides.ingresses` becomes an open map with `additionalProperties` referencing the existing `Spec.Distribution.Modules.Auth.Overrides.Ingress` schema.

It also adds the missing OnPremises schema fixtures and bats runner so this path is covered by schema tests, and wires the new runner into the Drone `qa` pipeline.

Closes:

Relates:

### Description 📝

**Why the change is correct.** `ekscluster` and `kfddistribution` already declare `Spec.Distribution.Modules.Auth.Overrides.properties.ingresses` as an open map:

```json
{
  "type": "object",
  "additionalProperties": {
    "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
  }
}
```

OnPremises was the only distribution declaring the same field as a closed object with `additionalProperties: false` and explicit `dex` / `gangplank` properties. The generated Go types reflected the same divergence: `ekscluster` and `kfddistribution` generated `SpecDistributionModulesAuthOverridesIngresses` as `map[string]SpecDistributionModulesAuthOverridesIngress`, while OnPremises generated a closed struct with only `Dex` and `Gangplank`.

This PR makes OnPremises match its sibling distributions.

**Why the change is needed.** The templates already handle auth ingress overrides generically by package name. Pomerium specifically uses `.spec.distribution.modules.auth.overrides.ingresses.pomerium.host` to render the Pomerium Ingress host (`pomerium-ingress.yml.tpl`), Pomerium environment configuration (`pomerium-config.env.tpl` → `FORWARD_AUTH_HOST`, `AUTHENTICATE_SERVICE_HOST`), and Dex OIDC redirect URI (`dex.yml.tpl`). Before this change, users could not pass a schema-valid OnPremises config that used the Pomerium override already implemented by the templates.

**What is generated, what is hand-written.** The schema change, fixtures, bats runner, and `.drone.yml` step are hand-written. `pkg/apis/onpremises/v1alpha2/public/schema.go` and `docs/schemas/onpremises-kfd-v1alpha2.md` are generated with:

```
mise run _generate-go-models
mise run format-go
mise run generate-docs
```

**Note on additional codegen drift.** Running the documented codegen pipeline also re-flowed imports in three pre-existing generated files (`pkg/apis/ekscluster/v1alpha2/private/schema.go`, `pkg/apis/ekscluster/v1alpha2/public/schema.go`, `pkg/apis/kfddistribution/v1alpha2/public/schema.go`). These are import-ordering fixes from `gci` that the previous tree had drifted on; the changes are isolated to the codegen commit so the next person to run the pipeline gets a clean tree. Codegen is idempotent on the resulting tree.

### Breaking Changes 💔

**JSON Schema** — none. Configurations that previously validated with `dex` and/or `gangplank` ingress overrides still validate. This change only allows additional auth ingress keys that conform to the same ingress override schema.

**Go API** — minor generated type shape change. The exported generated type `pkg/apis/onpremises/v1alpha2/public.SpecDistributionModulesAuthOverridesIngresses` changes from a closed struct to `map[string]SpecDistributionModulesAuthOverridesIngress`. External Go consumers importing this generated type directly must migrate from field access such as `.Dex` / `.Gangplank` to map indexing such as `["dex"]`, `["gangplank"]`, or `["pomerium"]`.

This matches the generated type shape already used by `ekscluster/v1alpha2/public` and `kfddistribution/v1alpha2/public`.

### Tests performed 🧪

- [x] `jq empty schemas/public/onpremises-kfd-v1alpha2.json`
- [x] `git diff -- schemas/public/onpremises-kfd-v1alpha2.json` shows only the `auth.overrides.ingresses` block changing from closed `properties` to open `additionalProperties`.
- [x] Direct `jv` validation of `tests/schemas/public/onpremises-kfd-v1alpha2/001-ok.yaml` exits 0.
- [x] Direct `jv` validation of `tests/schemas/public/onpremises-kfd-v1alpha2/002-ok.yaml` exits 0.
- [x] Direct `jv` validation of `tests/schemas/public/onpremises-kfd-v1alpha2/003-no.yaml` exits non-zero with the expected path `/spec/distribution/modules/auth/overrides/ingresses/pomerium` and message containing `missing property` and `'ingressClass'`.
- [x] `bats -t tests/e2e/onpremises/schema.sh` (3/3 ok)
- [x] `bats -t tests/e2e/kfddistribution/schema.sh` (24/24 ok — no regression)
- [x] `mise run license-check` clean
- [x] Replicated Drone `schema-check` step: `cat schemas/public/ekscluster-kfd-v1alpha2.json | json-patch -p schemas/private/ekscluster-kfd-v1alpha2.patch.json | jq -r > /tmp/eks-private.json && diff schemas/private/ekscluster-kfd-v1alpha2.json /tmp/eks-private.json` → no diff.
- [x] Replicated Drone `test-create-config`: `furyctl create config --kind OnPremises --version v1.34.1 --name test --distro-location $(pwd) --disable-analytics --no-tty --workdir /tmp/test-onpremises` succeeded; the generated `furyctl.yaml` validates against the updated schema with `jv`.
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `mise run lint-go` (Issues before processing: 6112, after processing: 0)
- [x] Codegen idempotence: re-ran `mise run _generate-go-models && mise run format-go && mise run generate-docs`; `git status` clean.

### Future work 🔧

- Move shared schema-test helpers from the distro-specific bats runners (`tests/e2e/kfddistribution/schema.sh`, `tests/e2e/onpremises/schema.sh`) into a common `tests/e2e/helpers.bash` to reduce duplication.
- Backfill more OnPremises schema fixtures to approach the broader schema coverage currently present for EKS fixtures (001–013). This PR adds the directory, runner, and the focused fixtures needed to cover the Pomerium ingress override bug.
