### PR TITLE
feat(auth): allow pomerium in overrides.ingresses

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -75,6 +75,7 @@ steps: # qa
     commands:
       - eval "$(mise activate bash --shims)"
       - bats -t tests/e2e/kfddistribution/schema.sh
+      - bats -t tests/e2e/onpremises/schema.sh
 
   - name: test-schema-immutable
     image: quay.io/sighup/mise:v2025.4.4

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -7,13 +7,14 @@ The distribution is maintained with ❤️ by the team [SIGHUP by ReeVo](https:/
 ## New features 🌟
 
 - [[#513](https://github.com/sighupio/distribution/pull/513)] Introduce new `Immutable` kind in alpha status, based on Flatcar Container Linux. This new kind allows to create kubernetes clusters from scracth provisioning fresh (baremetal or virtual) machines with Flatcar Container Linux, gaining immutability and security benefits for your kubernetes clusters.
+- [[#519](https://github.com/sighupio/distribution/pull/519)] Allow overriding the `pomerium` auth ingress through `spec.distribution.modules.auth.overrides.ingresses.pomerium`.
 
 
 ## Bug Fixes 🐛
 
 ## Breaking changes 💔
 
-N/A
+- [[#519](https://github.com/sighupio/distribution/pull/519)] For the `EKSCluster` and `KFDDistribution` kinds, `spec.distribution.modules.auth.overrides.ingresses` now only accepts the `gangplank`, `dex` and `pomerium` keys. Previously any key was accepted; configurations using other keys will now fail schema validation.
 
 ## Upgrade procedure
 

--- a/docs/schemas/ekscluster-kfd-v1alpha2.md
+++ b/docs/schemas/ekscluster-kfd-v1alpha2.md
@@ -709,9 +709,80 @@ Override the common configuration with a particular configuration for the Auth m
 
 ## .spec.distribution.modules.auth.overrides.ingresses
 
+### Properties
+
+| Property                                                             | Type     | Required |
+|:---------------------------------------------------------------------|:---------|:---------|
+| [dex](#specdistributionmodulesauthoverridesingressesdex)             | `object` | Optional |
+| [gangplank](#specdistributionmodulesauthoverridesingressesgangplank) | `object` | Optional |
+| [pomerium](#specdistributionmodulesauthoverridesingressespomerium)   | `object` | Optional |
+
 ### Description
 
 Override the definition of the Auth module ingresses.
+
+## .spec.distribution.modules.auth.overrides.ingresses.dex
+
+### Properties
+
+| Property                                                                      | Type     | Required |
+|:------------------------------------------------------------------------------|:---------|:---------|
+| [host](#specdistributionmodulesauthoverridesingressesdexhost)                 | `string` | Required |
+| [ingressClass](#specdistributionmodulesauthoverridesingressesdexingressclass) | `string` | Required |
+
+## .spec.distribution.modules.auth.overrides.ingresses.dex.host
+
+### Description
+
+Use this host for the ingress instead of the default one.
+
+## .spec.distribution.modules.auth.overrides.ingresses.dex.ingressClass
+
+### Description
+
+Use this ingress class for the ingress instead of the default one.
+
+## .spec.distribution.modules.auth.overrides.ingresses.gangplank
+
+### Properties
+
+| Property                                                                            | Type     | Required |
+|:------------------------------------------------------------------------------------|:---------|:---------|
+| [host](#specdistributionmodulesauthoverridesingressesgangplankhost)                 | `string` | Required |
+| [ingressClass](#specdistributionmodulesauthoverridesingressesgangplankingressclass) | `string` | Required |
+
+## .spec.distribution.modules.auth.overrides.ingresses.gangplank.host
+
+### Description
+
+Use this host for the ingress instead of the default one.
+
+## .spec.distribution.modules.auth.overrides.ingresses.gangplank.ingressClass
+
+### Description
+
+Use this ingress class for the ingress instead of the default one.
+
+## .spec.distribution.modules.auth.overrides.ingresses.pomerium
+
+### Properties
+
+| Property                                                                           | Type     | Required |
+|:-----------------------------------------------------------------------------------|:---------|:---------|
+| [host](#specdistributionmodulesauthoverridesingressespomeriumhost)                 | `string` | Required |
+| [ingressClass](#specdistributionmodulesauthoverridesingressespomeriumingressclass) | `string` | Required |
+
+## .spec.distribution.modules.auth.overrides.ingresses.pomerium.host
+
+### Description
+
+Use this host for the ingress instead of the default one.
+
+## .spec.distribution.modules.auth.overrides.ingresses.pomerium.ingressClass
+
+### Description
+
+Use this ingress class for the ingress instead of the default one.
 
 ## .spec.distribution.modules.auth.overrides.nodeSelector
 

--- a/docs/schemas/kfddistribution-kfd-v1alpha2.md
+++ b/docs/schemas/kfddistribution-kfd-v1alpha2.md
@@ -717,9 +717,80 @@ Override the common configuration with a particular configuration for the Auth m
 
 ## .spec.distribution.modules.auth.overrides.ingresses
 
+### Properties
+
+| Property                                                             | Type     | Required |
+|:---------------------------------------------------------------------|:---------|:---------|
+| [dex](#specdistributionmodulesauthoverridesingressesdex)             | `object` | Optional |
+| [gangplank](#specdistributionmodulesauthoverridesingressesgangplank) | `object` | Optional |
+| [pomerium](#specdistributionmodulesauthoverridesingressespomerium)   | `object` | Optional |
+
 ### Description
 
 Override the definition of the Auth module ingresses.
+
+## .spec.distribution.modules.auth.overrides.ingresses.dex
+
+### Properties
+
+| Property                                                                      | Type     | Required |
+|:------------------------------------------------------------------------------|:---------|:---------|
+| [host](#specdistributionmodulesauthoverridesingressesdexhost)                 | `string` | Required |
+| [ingressClass](#specdistributionmodulesauthoverridesingressesdexingressclass) | `string` | Required |
+
+## .spec.distribution.modules.auth.overrides.ingresses.dex.host
+
+### Description
+
+Use this host for the ingress instead of the default one.
+
+## .spec.distribution.modules.auth.overrides.ingresses.dex.ingressClass
+
+### Description
+
+Use this ingress class for the ingress instead of the default one.
+
+## .spec.distribution.modules.auth.overrides.ingresses.gangplank
+
+### Properties
+
+| Property                                                                            | Type     | Required |
+|:------------------------------------------------------------------------------------|:---------|:---------|
+| [host](#specdistributionmodulesauthoverridesingressesgangplankhost)                 | `string` | Required |
+| [ingressClass](#specdistributionmodulesauthoverridesingressesgangplankingressclass) | `string` | Required |
+
+## .spec.distribution.modules.auth.overrides.ingresses.gangplank.host
+
+### Description
+
+Use this host for the ingress instead of the default one.
+
+## .spec.distribution.modules.auth.overrides.ingresses.gangplank.ingressClass
+
+### Description
+
+Use this ingress class for the ingress instead of the default one.
+
+## .spec.distribution.modules.auth.overrides.ingresses.pomerium
+
+### Properties
+
+| Property                                                                           | Type     | Required |
+|:-----------------------------------------------------------------------------------|:---------|:---------|
+| [host](#specdistributionmodulesauthoverridesingressespomeriumhost)                 | `string` | Required |
+| [ingressClass](#specdistributionmodulesauthoverridesingressespomeriumingressclass) | `string` | Required |
+
+## .spec.distribution.modules.auth.overrides.ingresses.pomerium.host
+
+### Description
+
+Use this host for the ingress instead of the default one.
+
+## .spec.distribution.modules.auth.overrides.ingresses.pomerium.ingressClass
+
+### Description
+
+Use this ingress class for the ingress instead of the default one.
 
 ## .spec.distribution.modules.auth.overrides.nodeSelector
 

--- a/docs/schemas/onpremises-kfd-v1alpha2.md
+++ b/docs/schemas/onpremises-kfd-v1alpha2.md
@@ -788,6 +788,7 @@ Override the common configuration with a particular configuration for the Auth m
 |:---------------------------------------------------------------------|:---------|:---------|
 | [dex](#specdistributionmodulesauthoverridesingressesdex)             | `object` | Optional |
 | [gangplank](#specdistributionmodulesauthoverridesingressesgangplank) | `object` | Optional |
+| [pomerium](#specdistributionmodulesauthoverridesingressespomerium)   | `object` | Optional |
 
 ### Description
 
@@ -830,6 +831,27 @@ Use this ingress class for the ingress instead of the default one.
 Use this host for the ingress instead of the default one.
 
 ## .spec.distribution.modules.auth.overrides.ingresses.gangplank.ingressClass
+
+### Description
+
+Use this ingress class for the ingress instead of the default one.
+
+## .spec.distribution.modules.auth.overrides.ingresses.pomerium
+
+### Properties
+
+| Property                                                                           | Type     | Required |
+|:-----------------------------------------------------------------------------------|:---------|:---------|
+| [host](#specdistributionmodulesauthoverridesingressespomeriumhost)                 | `string` | Required |
+| [ingressClass](#specdistributionmodulesauthoverridesingressespomeriumingressclass) | `string` | Required |
+
+## .spec.distribution.modules.auth.overrides.ingresses.pomerium.host
+
+### Description
+
+Use this host for the ingress instead of the default one.
+
+## .spec.distribution.modules.auth.overrides.ingresses.pomerium.ingressClass
 
 ### Description
 

--- a/pkg/apis/ekscluster/v1alpha2/private/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/private/schema.go
@@ -5,8 +5,9 @@ package private
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sighupio/go-jsonschema/pkg/types"
 	"reflect"
+
+	"github.com/sighupio/go-jsonschema/pkg/types"
 )
 
 // A SD Cluster deployed on top of AWS's Elastic Kubernetes Service (EKS).
@@ -377,7 +378,7 @@ type SpecDistributionModulesAuthDexExpiry struct {
 // module.
 type SpecDistributionModulesAuthOverrides struct {
 	// Override the definition of the Auth module ingresses.
-	Ingresses SpecDistributionModulesAuthOverridesIngresses `json:"ingresses,omitempty" yaml:"ingresses,omitempty" mapstructure:"ingresses,omitempty"`
+	Ingresses *SpecDistributionModulesAuthOverridesIngresses `json:"ingresses,omitempty" yaml:"ingresses,omitempty" mapstructure:"ingresses,omitempty"`
 
 	// Set to override the node selector used to place the pods of the Auth module.
 	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
@@ -396,7 +397,16 @@ type SpecDistributionModulesAuthOverridesIngress struct {
 }
 
 // Override the definition of the Auth module ingresses.
-type SpecDistributionModulesAuthOverridesIngresses map[string]SpecDistributionModulesAuthOverridesIngress
+type SpecDistributionModulesAuthOverridesIngresses struct {
+	// Dex corresponds to the JSON schema field "dex".
+	Dex *SpecDistributionModulesAuthOverridesIngress `json:"dex,omitempty" yaml:"dex,omitempty" mapstructure:"dex,omitempty"`
+
+	// Gangplank corresponds to the JSON schema field "gangplank".
+	Gangplank *SpecDistributionModulesAuthOverridesIngress `json:"gangplank,omitempty" yaml:"gangplank,omitempty" mapstructure:"gangplank,omitempty"`
+
+	// Pomerium corresponds to the JSON schema field "pomerium".
+	Pomerium *SpecDistributionModulesAuthOverridesIngress `json:"pomerium,omitempty" yaml:"pomerium,omitempty" mapstructure:"pomerium,omitempty"`
+}
 
 type SpecDistributionModulesAuthPomerium interface{}
 

--- a/pkg/apis/ekscluster/v1alpha2/public/schema.go
+++ b/pkg/apis/ekscluster/v1alpha2/public/schema.go
@@ -5,8 +5,9 @@ package public
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sighupio/go-jsonschema/pkg/types"
 	"reflect"
+
+	"github.com/sighupio/go-jsonschema/pkg/types"
 )
 
 // A SD Cluster deployed on top of AWS's Elastic Kubernetes Service (EKS).
@@ -377,7 +378,7 @@ type SpecDistributionModulesAuthDexExpiry struct {
 // module.
 type SpecDistributionModulesAuthOverrides struct {
 	// Override the definition of the Auth module ingresses.
-	Ingresses SpecDistributionModulesAuthOverridesIngresses `json:"ingresses,omitempty" yaml:"ingresses,omitempty" mapstructure:"ingresses,omitempty"`
+	Ingresses *SpecDistributionModulesAuthOverridesIngresses `json:"ingresses,omitempty" yaml:"ingresses,omitempty" mapstructure:"ingresses,omitempty"`
 
 	// Set to override the node selector used to place the pods of the Auth module.
 	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
@@ -396,7 +397,16 @@ type SpecDistributionModulesAuthOverridesIngress struct {
 }
 
 // Override the definition of the Auth module ingresses.
-type SpecDistributionModulesAuthOverridesIngresses map[string]SpecDistributionModulesAuthOverridesIngress
+type SpecDistributionModulesAuthOverridesIngresses struct {
+	// Dex corresponds to the JSON schema field "dex".
+	Dex *SpecDistributionModulesAuthOverridesIngress `json:"dex,omitempty" yaml:"dex,omitempty" mapstructure:"dex,omitempty"`
+
+	// Gangplank corresponds to the JSON schema field "gangplank".
+	Gangplank *SpecDistributionModulesAuthOverridesIngress `json:"gangplank,omitempty" yaml:"gangplank,omitempty" mapstructure:"gangplank,omitempty"`
+
+	// Pomerium corresponds to the JSON schema field "pomerium".
+	Pomerium *SpecDistributionModulesAuthOverridesIngress `json:"pomerium,omitempty" yaml:"pomerium,omitempty" mapstructure:"pomerium,omitempty"`
+}
 
 type SpecDistributionModulesAuthPomerium interface{}
 

--- a/pkg/apis/kfddistribution/v1alpha2/public/schema.go
+++ b/pkg/apis/kfddistribution/v1alpha2/public/schema.go
@@ -5,8 +5,9 @@ package public
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sighupio/go-jsonschema/pkg/types"
 	"reflect"
+
+	"github.com/sighupio/go-jsonschema/pkg/types"
 )
 
 // SD modules deployed on top of an existing Kubernetes cluster.
@@ -364,7 +365,7 @@ type SpecDistributionModulesAuthDexExpiry struct {
 // module.
 type SpecDistributionModulesAuthOverrides struct {
 	// Override the definition of the Auth module ingresses.
-	Ingresses SpecDistributionModulesAuthOverridesIngresses `json:"ingresses,omitempty" yaml:"ingresses,omitempty" mapstructure:"ingresses,omitempty"`
+	Ingresses *SpecDistributionModulesAuthOverridesIngresses `json:"ingresses,omitempty" yaml:"ingresses,omitempty" mapstructure:"ingresses,omitempty"`
 
 	// Set to override the node selector used to place the pods of the Auth module.
 	NodeSelector TypesKubeNodeSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty" mapstructure:"nodeSelector,omitempty"`
@@ -383,7 +384,16 @@ type SpecDistributionModulesAuthOverridesIngress struct {
 }
 
 // Override the definition of the Auth module ingresses.
-type SpecDistributionModulesAuthOverridesIngresses map[string]SpecDistributionModulesAuthOverridesIngress
+type SpecDistributionModulesAuthOverridesIngresses struct {
+	// Dex corresponds to the JSON schema field "dex".
+	Dex *SpecDistributionModulesAuthOverridesIngress `json:"dex,omitempty" yaml:"dex,omitempty" mapstructure:"dex,omitempty"`
+
+	// Gangplank corresponds to the JSON schema field "gangplank".
+	Gangplank *SpecDistributionModulesAuthOverridesIngress `json:"gangplank,omitempty" yaml:"gangplank,omitempty" mapstructure:"gangplank,omitempty"`
+
+	// Pomerium corresponds to the JSON schema field "pomerium".
+	Pomerium *SpecDistributionModulesAuthOverridesIngress `json:"pomerium,omitempty" yaml:"pomerium,omitempty" mapstructure:"pomerium,omitempty"`
+}
 
 type SpecDistributionModulesAuthPomerium interface{}
 

--- a/pkg/apis/onpremises/v1alpha2/public/schema.go
+++ b/pkg/apis/onpremises/v1alpha2/public/schema.go
@@ -2,10 +2,13 @@
 
 package public
 
-import "encoding/json"
-import "fmt"
-import "github.com/sighupio/go-jsonschema/pkg/types"
-import "reflect"
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/sighupio/go-jsonschema/pkg/types"
+)
 
 type Metadata struct {
 	// The name of the cluster. It will also be used as a prefix for all the other
@@ -423,6 +426,9 @@ type SpecDistributionModulesAuthOverridesIngresses struct {
 
 	// Gangplank corresponds to the JSON schema field "gangplank".
 	Gangplank *SpecDistributionModulesAuthOverridesIngress `json:"gangplank,omitempty" yaml:"gangplank,omitempty" mapstructure:"gangplank,omitempty"`
+
+	// Pomerium corresponds to the JSON schema field "pomerium".
+	Pomerium *SpecDistributionModulesAuthOverridesIngress `json:"pomerium,omitempty" yaml:"pomerium,omitempty" mapstructure:"pomerium,omitempty"`
 }
 
 type SpecDistributionModulesAuthPomerium interface{}

--- a/schemas/private/ekscluster-kfd-v1alpha2.json
+++ b/schemas/private/ekscluster-kfd-v1alpha2.json
@@ -3204,10 +3204,19 @@
           "description": "Set to override the tolerations that will be added to the pods of the Auth module."
         },
         "ingresses": {
+          "additionalProperties": false,
           "type": "object",
           "description": "Override the definition of the Auth module ingresses.",
-          "additionalProperties": {
-            "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
+          "properties": {
+            "gangplank": {
+              "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
+            },
+            "dex": {
+              "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
+            },
+            "pomerium": {
+              "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
+            }
           }
         }
       }

--- a/schemas/public/ekscluster-kfd-v1alpha2.json
+++ b/schemas/public/ekscluster-kfd-v1alpha2.json
@@ -3153,10 +3153,19 @@
           "description": "Set to override the tolerations that will be added to the pods of the Auth module."
         },
         "ingresses": {
+          "additionalProperties": false,
           "type": "object",
           "description": "Override the definition of the Auth module ingresses.",
-          "additionalProperties": {
-            "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
+          "properties": {
+            "gangplank": {
+              "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
+            },
+            "dex": {
+              "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
+            },
+            "pomerium": {
+              "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
+            }
           }
         }
       }

--- a/schemas/public/kfddistribution-kfd-v1alpha2.json
+++ b/schemas/public/kfddistribution-kfd-v1alpha2.json
@@ -2094,10 +2094,19 @@
           "description": "Set to override the tolerations that will be added to the pods of the Auth module."
         },
         "ingresses": {
+          "additionalProperties": false,
           "type": "object",
           "description": "Override the definition of the Auth module ingresses.",
-          "additionalProperties": {
-            "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
+          "properties": {
+            "gangplank": {
+              "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
+            },
+            "dex": {
+              "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
+            },
+            "pomerium": {
+              "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
+            }
           }
         }
       }

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -3080,6 +3080,9 @@
             },
             "dex": {
               "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
+            },
+            "pomerium": {
+              "$ref": "#/$defs/Spec.Distribution.Modules.Auth.Overrides.Ingress"
             }
           }
         }

--- a/tests/e2e/kfddistribution/schema.sh
+++ b/tests/e2e/kfddistribution/schema.sh
@@ -374,3 +374,45 @@ test_schema() {
     test_schema "private" "ekscluster-kfd-v1alpha2" "013-no" expect
     test_schema "public" "ekscluster-kfd-v1alpha2" "013-no" expect
 }
+
+@test "014 - ok (pomerium override accepted)" {
+    info
+
+    test_schema "private" "ekscluster-kfd-v1alpha2" "014-ok" expect_ok
+    test_schema "public" "ekscluster-kfd-v1alpha2" "014-ok" expect_ok
+}
+
+@test "014 - no (pomerium override missing ingressClass)" {
+    info
+
+    expect() {
+        expect_no "${1}"
+
+        assert_error_contains "/spec/distribution/modules/auth/overrides/ingresses/pomerium" "missing property" || return $?
+        assert_error_contains "/spec/distribution/modules/auth/overrides/ingresses/pomerium" "'ingressClass'" || return $?
+    }
+
+    test_schema "private" "ekscluster-kfd-v1alpha2" "014-no" expect
+    test_schema "public" "ekscluster-kfd-v1alpha2" "014-no" expect
+}
+
+@test "015 - ok (dex + gangplank + pomerium overrides)" {
+    info
+
+    test_schema "private" "ekscluster-kfd-v1alpha2" "015-ok" expect_ok
+    test_schema "public" "ekscluster-kfd-v1alpha2" "015-ok" expect_ok
+}
+
+@test "015 - no (unknown key under ingresses overrides)" {
+    info
+
+    expect() {
+        expect_no "${1}"
+
+        assert_error_contains "/spec/distribution/modules/auth/overrides/ingresses" "additional propert" || return $?
+        assert_error_contains "/spec/distribution/modules/auth/overrides/ingresses" "'pomeriun'" || return $?
+    }
+
+    test_schema "private" "ekscluster-kfd-v1alpha2" "015-no" expect
+    test_schema "public" "ekscluster-kfd-v1alpha2" "015-no" expect
+}

--- a/tests/e2e/onpremises/schema.sh
+++ b/tests/e2e/onpremises/schema.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+load ./helper
+
+expect_ok() {
+    [ "${1}" -eq 0 ]
+}
+
+expect_no() {
+    [ "${1}" -eq 1 ]
+}
+
+# Helper function to check if error output contains both path and message
+# This makes tests resilient to jv version format changes
+assert_error_contains() {
+    local path="$1"
+    local message="$2"
+
+    # Check for path (flexible to different formats: "at '/path'" or "[I#/path]")
+    if [[ "${output}" != *"${path}"* ]]; then
+        echo "Expected path '${path}' not found in output" >&3
+        return 2
+    fi
+
+    # Check for error message
+    if [[ "${output}" != *"${message}"* ]]; then
+        echo "Expected message '${message}' not found in output" >&3
+        return 3
+    fi
+}
+
+# Preflight check: verify jv version and error format
+preflight_check() {
+    echo "Running preflight checks..." >&3
+
+    # Check if jv is available
+    if ! command -v jv >/dev/null 2>&1; then
+        echo "ERROR: jv command not found" >&3
+        echo "Make sure mise tools are installed and activated" >&3
+        return 1
+    fi
+
+    # Show which jv is being used
+    local JV_PATH
+    JV_PATH=$(command -v jv)
+    echo "Using jv from: ${JV_PATH}" >&3
+
+    # Create a test to verify error format
+    local TMPDIR_TEST
+    TMPDIR_TEST=$(mktemp -d -t "fury-jv-preflight-XXXXXXXXXX")
+
+    # Create minimal invalid JSON to test error format
+    echo '{"type": "string"}' > "${TMPDIR_TEST}/test-schema.json"
+    echo '123' > "${TMPDIR_TEST}/test-instance.json"
+
+    local TEST_OUTPUT
+    TEST_OUTPUT=$(jv "${TMPDIR_TEST}/test-schema.json" "${TMPDIR_TEST}/test-instance.json" 2>&1 || true)
+
+    rm -rf "${TMPDIR_TEST}"
+
+    # Check if error format matches v0.7.0 expectations
+    if [[ "${TEST_OUTPUT}" == *"got"*"want"* ]]; then
+        echo "✓ jv error format verified (v0.7.0)" >&3
+        return 0
+    elif [[ "${TEST_OUTPUT}" == *"expected"*"but got"* ]]; then
+        echo "ERROR: jv is using different error format (older v0.4.0)" >&3
+        echo "Expected: 'got X, want Y' (v0.7.0 format)" >&3
+        echo "Got: 'expected X, but got Y' (v0.4.0 format)" >&3
+        echo "Remove old jv binary and use mise-installed version" >&3
+        return 1
+    else
+        echo "WARNING: Could not verify jv error format" >&3
+        echo "Test output: ${TEST_OUTPUT}" >&3
+        return 0  # Don't fail, let tests proceed
+    fi
+}
+
+# Setup function called by bats before all tests
+setup_file() {
+    # Run preflight check once before all tests
+    if ! preflight_check; then
+        exit 1
+    fi
+}
+
+test_schema() {
+    local KIND=${1}
+    local APIVER=${2}
+    local EXAMPLE=${3}
+    local verify_expectation=${4}
+    local validate_status=""
+    local validate_output=""
+    local verify_expectation_status=""
+
+    TMPDIR=$(mktemp -d -t "fury-distribution-test-XXXXXXXXXX")
+
+    mkdir -p "${TMPDIR}/tests/schemas/${KIND}/${APIVER}"
+
+    yq "tests/schemas/${KIND}/${APIVER}/${EXAMPLE}.yaml" -o json  > "${TMPDIR}/tests/schemas/${KIND}/${APIVER}/${EXAMPLE}.json"
+
+    validate() {
+        jv "schemas/${KIND}/${APIVER}.json" "${TMPDIR}/tests/schemas/${KIND}/${APIVER}/${EXAMPLE}.json" 2>&1
+    }
+
+    run validate
+    validate_status="${status}"
+    validate_output="${output}"
+
+    run "${verify_expectation}" "${validate_status}"
+    verify_expectation_status="${status}"
+
+    rm -rf "${TMPDIR}"
+
+    if [ "${verify_expectation_status}" -ne 0 ]; then
+        echo "${validate_output}" >&3
+
+        return 1
+    fi
+
+    return 0
+}
+
+@test "001 - ok (pomerium override accepted)" {
+    info
+
+    test_schema "public" "onpremises-kfd-v1alpha2" "001-ok" expect_ok
+}
+
+@test "002 - ok (dex + gangplank + pomerium overrides)" {
+    info
+
+    test_schema "public" "onpremises-kfd-v1alpha2" "002-ok" expect_ok
+}
+
+@test "003 - no (pomerium override missing ingressClass)" {
+    info
+
+    expect() {
+        expect_no "${1}"
+
+        assert_error_contains "/spec/distribution/modules/auth/overrides/ingresses/pomerium" "missing property" || return $?
+        assert_error_contains "/spec/distribution/modules/auth/overrides/ingresses/pomerium" "'ingressClass'" || return $?
+    }
+
+    test_schema "public" "onpremises-kfd-v1alpha2" "003-no" expect
+}
+
+@test "004 - no (unknown key under ingresses overrides)" {
+    info
+
+    expect() {
+        expect_no "${1}"
+
+        assert_error_contains "/spec/distribution/modules/auth/overrides/ingresses" "additional propert" || return $?
+        assert_error_contains "/spec/distribution/modules/auth/overrides/ingresses" "'pomeriun'" || return $?
+    }
+
+    test_schema "public" "onpremises-kfd-v1alpha2" "004-no" expect
+}

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/014-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/014-no.yaml
@@ -1,0 +1,129 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given an EKSCluster config
+# And "spec.distribution.modules.auth.overrides.ingresses.pomerium" is specified
+# And the Pomerium override is missing "ingressClass"
+# When I validate the config against the schema
+# Then a validation error is returned for the Pomerium override
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: furyctl-dev-aws-al
+spec:
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.0.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.0.182.0/24
+            - 10.0.172.0/24
+            - 10.0.162.0/24
+          public:
+            - 10.0.20.0/24
+            - 10.0.30.0/24
+            - 10.0.40.0/24
+    vpn:
+      ssh:
+        allowedFromCidrs:
+          - 0.0.0.0/0
+        githubUsersName:
+          - jnardiello
+        publicKeys:
+          - ssh-ed25519 SomethingSomething engineering@sighup.io
+      vpnClientsSubnetCidr: 192.168.200.0/24
+  kubernetes:
+    apiServer:
+      privateAccess: true
+      privateAccessCidrs: ["0.0.0.0/0"]
+      publicAccessCidrs: []
+      publicAccess: false
+    nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
+    nodePoolsLaunchKind: both
+    nodePoolGlobalAmiType: "alinux2023"
+    nodePools:
+      - ami:
+          id: ami-01234567890123456
+          owner: "123456789012"
+        type: self-managed
+        instance:
+          type: t3.large
+        name: worker-eks
+        size:
+          max: 3
+          min: 2
+  distribution:
+    modules:
+      auth:
+        dex:
+          connectors: []
+        pomerium:
+          policy: "test"
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        provider:
+          type: sso
+        baseDomain: furyctl-demo.sighup.io
+        overrides:
+          ingresses:
+            pomerium:
+              host: pomerium.furyctl-demo.sighup.io
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: example-velero
+            iamRoleArn: arn:aws:iam::123456789012:role/example-velero
+            region: eu-west-1
+      ingress:
+        baseDomain: furyctl-demo.sighup.io
+        dns:
+          private:
+            create: true
+            name: internal.furyctl-demo.sighup.io
+            vpcId: ""
+          public:
+            create: true
+            name: furyctl-demo.sighup.io
+        nginx:
+          type: single
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: email@test.it
+            type: http01
+            route53:
+              region: eu-west-1
+              hostedZoneId: Z1234567890
+              iamRoleArn: arn:aws:iam::123456789012:role/cert-manager
+        externalDns:
+          privateIamRoleArn: arn:aws:iam::123456789012:role/external-dns-private
+          publicIamRoleArn: arn:aws:iam::123456789012:role/external-dns-public
+      logging:
+        type: opensearch
+        opensearch:
+          type: single
+      policy:
+        type: gatekeeper
+        gatekeeper:
+          additionalExcludedNamespaces: []
+          installDefaultPolicies: true
+          enforcementAction: deny
+  distributionVersion: v1.24.1
+  region: eu-west-1
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: furyctl-test-eks
+          keyPrefix: furyctl-test
+          region: eu-west-1

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/014-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/014-ok.yaml
@@ -1,0 +1,130 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given an EKSCluster config
+# And "spec.distribution.modules.auth.overrides.ingresses.pomerium" is specified
+# And both "host" and "ingressClass" are provided
+# When I validate the config against the schema
+# Then no errors are returned
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: furyctl-dev-aws-al
+spec:
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.0.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.0.182.0/24
+            - 10.0.172.0/24
+            - 10.0.162.0/24
+          public:
+            - 10.0.20.0/24
+            - 10.0.30.0/24
+            - 10.0.40.0/24
+    vpn:
+      ssh:
+        allowedFromCidrs:
+          - 0.0.0.0/0
+        githubUsersName:
+          - jnardiello
+        publicKeys:
+          - ssh-ed25519 SomethingSomething engineering@sighup.io
+      vpnClientsSubnetCidr: 192.168.200.0/24
+  kubernetes:
+    apiServer:
+      privateAccess: true
+      privateAccessCidrs: ["0.0.0.0/0"]
+      publicAccessCidrs: []
+      publicAccess: false
+    nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
+    nodePoolsLaunchKind: both
+    nodePoolGlobalAmiType: "alinux2023"
+    nodePools:
+      - ami:
+          id: ami-01234567890123456
+          owner: "123456789012"
+        type: self-managed
+        instance:
+          type: t3.large
+        name: worker-eks
+        size:
+          max: 3
+          min: 2
+  distribution:
+    modules:
+      auth:
+        dex:
+          connectors: []
+        pomerium:
+          policy: "test"
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        provider:
+          type: sso
+        baseDomain: furyctl-demo.sighup.io
+        overrides:
+          ingresses:
+            pomerium:
+              host: pomerium.furyctl-demo.sighup.io
+              ingressClass: external
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: example-velero
+            iamRoleArn: arn:aws:iam::123456789012:role/example-velero
+            region: eu-west-1
+      ingress:
+        baseDomain: furyctl-demo.sighup.io
+        dns:
+          private:
+            create: true
+            name: internal.furyctl-demo.sighup.io
+            vpcId: ""
+          public:
+            create: true
+            name: furyctl-demo.sighup.io
+        nginx:
+          type: single
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: email@test.it
+            type: http01
+            route53:
+              region: eu-west-1
+              hostedZoneId: Z1234567890
+              iamRoleArn: arn:aws:iam::123456789012:role/cert-manager
+        externalDns:
+          privateIamRoleArn: arn:aws:iam::123456789012:role/external-dns-private
+          publicIamRoleArn: arn:aws:iam::123456789012:role/external-dns-public
+      logging:
+        type: opensearch
+        opensearch:
+          type: single
+      policy:
+        type: gatekeeper
+        gatekeeper:
+          additionalExcludedNamespaces: []
+          installDefaultPolicies: true
+          enforcementAction: deny
+  distributionVersion: v1.24.1
+  region: eu-west-1
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: furyctl-test-eks
+          keyPrefix: furyctl-test
+          region: eu-west-1

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/015-no.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/015-no.yaml
@@ -1,0 +1,129 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given an EKSCluster config
+# And "spec.distribution.modules.auth.overrides.ingresses" contains an unknown key
+# When I validate the config against the schema
+# Then a validation error is returned for the unknown property
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: furyctl-dev-aws-al
+spec:
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.0.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.0.182.0/24
+            - 10.0.172.0/24
+            - 10.0.162.0/24
+          public:
+            - 10.0.20.0/24
+            - 10.0.30.0/24
+            - 10.0.40.0/24
+    vpn:
+      ssh:
+        allowedFromCidrs:
+          - 0.0.0.0/0
+        githubUsersName:
+          - jnardiello
+        publicKeys:
+          - ssh-ed25519 SomethingSomething engineering@sighup.io
+      vpnClientsSubnetCidr: 192.168.200.0/24
+  kubernetes:
+    apiServer:
+      privateAccess: true
+      privateAccessCidrs: ["0.0.0.0/0"]
+      publicAccessCidrs: []
+      publicAccess: false
+    nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
+    nodePoolsLaunchKind: both
+    nodePoolGlobalAmiType: "alinux2023"
+    nodePools:
+      - ami:
+          id: ami-01234567890123456
+          owner: "123456789012"
+        type: self-managed
+        instance:
+          type: t3.large
+        name: worker-eks
+        size:
+          max: 3
+          min: 2
+  distribution:
+    modules:
+      auth:
+        dex:
+          connectors: []
+        pomerium:
+          policy: "test"
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        provider:
+          type: sso
+        baseDomain: furyctl-demo.sighup.io
+        overrides:
+          ingresses:
+            pomeriun:
+              host: pomerium.furyctl-demo.sighup.io
+              ingressClass: external
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: example-velero
+            iamRoleArn: arn:aws:iam::123456789012:role/example-velero
+            region: eu-west-1
+      ingress:
+        baseDomain: furyctl-demo.sighup.io
+        dns:
+          private:
+            create: true
+            name: internal.furyctl-demo.sighup.io
+            vpcId: ""
+          public:
+            create: true
+            name: furyctl-demo.sighup.io
+        nginx:
+          type: single
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: email@test.it
+            type: http01
+            route53:
+              region: eu-west-1
+              hostedZoneId: Z1234567890
+              iamRoleArn: arn:aws:iam::123456789012:role/cert-manager
+        externalDns:
+          privateIamRoleArn: arn:aws:iam::123456789012:role/external-dns-private
+          publicIamRoleArn: arn:aws:iam::123456789012:role/external-dns-public
+      logging:
+        type: opensearch
+        opensearch:
+          type: single
+      policy:
+        type: gatekeeper
+        gatekeeper:
+          additionalExcludedNamespaces: []
+          installDefaultPolicies: true
+          enforcementAction: deny
+  distributionVersion: v1.24.1
+  region: eu-west-1
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: furyctl-test-eks
+          keyPrefix: furyctl-test
+          region: eu-west-1

--- a/tests/schemas/private/ekscluster-kfd-v1alpha2/015-ok.yaml
+++ b/tests/schemas/private/ekscluster-kfd-v1alpha2/015-ok.yaml
@@ -1,0 +1,136 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given an EKSCluster config
+# And "spec.distribution.modules.auth.overrides.ingresses" specifies
+#     dex, gangplank, and pomerium with host and ingressClass
+# When I validate the config against the schema
+# Then no errors are returned
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: furyctl-dev-aws-al
+spec:
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.0.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.0.182.0/24
+            - 10.0.172.0/24
+            - 10.0.162.0/24
+          public:
+            - 10.0.20.0/24
+            - 10.0.30.0/24
+            - 10.0.40.0/24
+    vpn:
+      ssh:
+        allowedFromCidrs:
+          - 0.0.0.0/0
+        githubUsersName:
+          - jnardiello
+        publicKeys:
+          - ssh-ed25519 SomethingSomething engineering@sighup.io
+      vpnClientsSubnetCidr: 192.168.200.0/24
+  kubernetes:
+    apiServer:
+      privateAccess: true
+      privateAccessCidrs: ["0.0.0.0/0"]
+      publicAccessCidrs: []
+      publicAccess: false
+    nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
+    nodePoolsLaunchKind: both
+    nodePoolGlobalAmiType: "alinux2023"
+    nodePools:
+      - ami:
+          id: ami-01234567890123456
+          owner: "123456789012"
+        type: self-managed
+        instance:
+          type: t3.large
+        name: worker-eks
+        size:
+          max: 3
+          min: 2
+  distribution:
+    modules:
+      auth:
+        dex:
+          connectors: []
+        pomerium:
+          policy: "test"
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        provider:
+          type: sso
+        baseDomain: furyctl-demo.sighup.io
+        overrides:
+          ingresses:
+            dex:
+              host: login.furyctl-demo.sighup.io
+              ingressClass: external
+            gangplank:
+              host: access.furyctl-demo.sighup.io
+              ingressClass: external
+            pomerium:
+              host: pomerium.furyctl-demo.sighup.io
+              ingressClass: external
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: example-velero
+            iamRoleArn: arn:aws:iam::123456789012:role/example-velero
+            region: eu-west-1
+      ingress:
+        baseDomain: furyctl-demo.sighup.io
+        dns:
+          private:
+            create: true
+            name: internal.furyctl-demo.sighup.io
+            vpcId: ""
+          public:
+            create: true
+            name: furyctl-demo.sighup.io
+        nginx:
+          type: single
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: email@test.it
+            type: http01
+            route53:
+              region: eu-west-1
+              hostedZoneId: Z1234567890
+              iamRoleArn: arn:aws:iam::123456789012:role/cert-manager
+        externalDns:
+          privateIamRoleArn: arn:aws:iam::123456789012:role/external-dns-private
+          publicIamRoleArn: arn:aws:iam::123456789012:role/external-dns-public
+      logging:
+        type: opensearch
+        opensearch:
+          type: single
+      policy:
+        type: gatekeeper
+        gatekeeper:
+          additionalExcludedNamespaces: []
+          installDefaultPolicies: true
+          enforcementAction: deny
+  distributionVersion: v1.24.1
+  region: eu-west-1
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: furyctl-test-eks
+          keyPrefix: furyctl-test
+          region: eu-west-1

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/014-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/014-no.yaml
@@ -1,0 +1,120 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given an EKSCluster config
+# And "spec.distribution.modules.auth.overrides.ingresses.pomerium" is specified
+# And the Pomerium override is missing "ingressClass"
+# When I validate the config against the schema
+# Then a validation error is returned for the Pomerium override
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: furyctl-dev-aws-al
+spec:
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.0.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.0.182.0/24
+            - 10.0.172.0/24
+            - 10.0.162.0/24
+          public:
+            - 10.0.20.0/24
+            - 10.0.30.0/24
+            - 10.0.40.0/24
+    vpn:
+      ssh:
+        allowedFromCidrs:
+          - 0.0.0.0/0
+        githubUsersName:
+          - jnardiello
+        publicKeys:
+          - ssh-ed25519 SomethingSomething engineering@sighup.io
+      vpnClientsSubnetCidr: 192.168.200.0/24
+  kubernetes:
+    apiServer:
+      privateAccess: true
+      privateAccessCidrs: ["0.0.0.0/0"]
+      publicAccessCidrs: []
+      publicAccess: false
+    nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
+    nodePoolsLaunchKind: both
+    nodePoolGlobalAmiType: "alinux2023"
+    nodePools:
+      - ami:
+          id: ami-01234567890123456
+          owner: "123456789012"
+        type: self-managed
+        instance:
+          type: t3.large
+        name: worker-eks
+        size:
+          max: 3
+          min: 2
+  distribution:
+    modules:
+      auth:
+        baseDomain: furyctl-demo.sighup.io
+        dex:
+          connectors: []
+        pomerium:
+          policy: "test"
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        provider:
+          type: sso
+        overrides:
+          ingresses:
+            pomerium:
+              host: pomerium.furyctl-demo.sighup.io
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: example-velero
+            region: eu-west-1
+      ingress:
+        baseDomain: furyctl-demo.sighup.io
+        dns:
+          private:
+            create: true
+            name: internal.furyctl-demo.sighup.io
+          public:
+            create: true
+            name: furyctl-demo.sighup.io
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: example@sighup.io
+            type: http01
+        nginx:
+          type: single
+      logging:
+        type: opensearch
+        opensearch:
+          type: single
+      policy:
+        type: gatekeeper
+        gatekeeper:
+          additionalExcludedNamespaces: []
+          installDefaultPolicies: true
+          enforcementAction: deny
+  distributionVersion: v1.24.1
+  region: eu-west-1
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: furyctl-test-eks
+          keyPrefix: furyctl-test
+          region: eu-west-1

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/014-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/014-ok.yaml
@@ -1,0 +1,121 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given an EKSCluster config
+# And "spec.distribution.modules.auth.overrides.ingresses.pomerium" is specified
+# And both "host" and "ingressClass" are provided
+# When I validate the config against the schema
+# Then no errors are returned
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: furyctl-dev-aws-al
+spec:
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.0.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.0.182.0/24
+            - 10.0.172.0/24
+            - 10.0.162.0/24
+          public:
+            - 10.0.20.0/24
+            - 10.0.30.0/24
+            - 10.0.40.0/24
+    vpn:
+      ssh:
+        allowedFromCidrs:
+          - 0.0.0.0/0
+        githubUsersName:
+          - jnardiello
+        publicKeys:
+          - ssh-ed25519 SomethingSomething engineering@sighup.io
+      vpnClientsSubnetCidr: 192.168.200.0/24
+  kubernetes:
+    apiServer:
+      privateAccess: true
+      privateAccessCidrs: ["0.0.0.0/0"]
+      publicAccessCidrs: []
+      publicAccess: false
+    nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
+    nodePoolsLaunchKind: both
+    nodePoolGlobalAmiType: "alinux2023"
+    nodePools:
+      - ami:
+          id: ami-01234567890123456
+          owner: "123456789012"
+        type: self-managed
+        instance:
+          type: t3.large
+        name: worker-eks
+        size:
+          max: 3
+          min: 2
+  distribution:
+    modules:
+      auth:
+        baseDomain: furyctl-demo.sighup.io
+        dex:
+          connectors: []
+        pomerium:
+          policy: "test"
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        provider:
+          type: sso
+        overrides:
+          ingresses:
+            pomerium:
+              host: pomerium.furyctl-demo.sighup.io
+              ingressClass: external
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: example-velero
+            region: eu-west-1
+      ingress:
+        baseDomain: furyctl-demo.sighup.io
+        dns:
+          private:
+            create: true
+            name: internal.furyctl-demo.sighup.io
+          public:
+            create: true
+            name: furyctl-demo.sighup.io
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: example@sighup.io
+            type: http01
+        nginx:
+          type: single
+      logging:
+        type: opensearch
+        opensearch:
+          type: single
+      policy:
+        type: gatekeeper
+        gatekeeper:
+          additionalExcludedNamespaces: []
+          installDefaultPolicies: true
+          enforcementAction: deny
+  distributionVersion: v1.24.1
+  region: eu-west-1
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: furyctl-test-eks
+          keyPrefix: furyctl-test
+          region: eu-west-1

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/015-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/015-no.yaml
@@ -1,0 +1,120 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given an EKSCluster config
+# And "spec.distribution.modules.auth.overrides.ingresses" contains an unknown key
+# When I validate the config against the schema
+# Then a validation error is returned for the unknown property
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: furyctl-dev-aws-al
+spec:
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.0.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.0.182.0/24
+            - 10.0.172.0/24
+            - 10.0.162.0/24
+          public:
+            - 10.0.20.0/24
+            - 10.0.30.0/24
+            - 10.0.40.0/24
+    vpn:
+      ssh:
+        allowedFromCidrs:
+          - 0.0.0.0/0
+        githubUsersName:
+          - jnardiello
+        publicKeys:
+          - ssh-ed25519 SomethingSomething engineering@sighup.io
+      vpnClientsSubnetCidr: 192.168.200.0/24
+  kubernetes:
+    apiServer:
+      privateAccess: true
+      privateAccessCidrs: ["0.0.0.0/0"]
+      publicAccessCidrs: []
+      publicAccess: false
+    nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
+    nodePoolsLaunchKind: both
+    nodePoolGlobalAmiType: "alinux2023"
+    nodePools:
+      - ami:
+          id: ami-01234567890123456
+          owner: "123456789012"
+        type: self-managed
+        instance:
+          type: t3.large
+        name: worker-eks
+        size:
+          max: 3
+          min: 2
+  distribution:
+    modules:
+      auth:
+        baseDomain: furyctl-demo.sighup.io
+        dex:
+          connectors: []
+        pomerium:
+          policy: "test"
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        provider:
+          type: sso
+        overrides:
+          ingresses:
+            pomeriun:
+              host: pomerium.furyctl-demo.sighup.io
+              ingressClass: external
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: example-velero
+            region: eu-west-1
+      ingress:
+        baseDomain: furyctl-demo.sighup.io
+        dns:
+          private:
+            create: true
+            name: internal.furyctl-demo.sighup.io
+          public:
+            create: true
+            name: furyctl-demo.sighup.io
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: example@sighup.io
+            type: http01
+        nginx:
+          type: single
+      logging:
+        type: opensearch
+        opensearch:
+          type: single
+      policy:
+        type: gatekeeper
+        gatekeeper:
+          additionalExcludedNamespaces: []
+          installDefaultPolicies: true
+          enforcementAction: deny
+  distributionVersion: v1.24.1
+  region: eu-west-1
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: furyctl-test-eks
+          keyPrefix: furyctl-test
+          region: eu-west-1

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/015-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/015-ok.yaml
@@ -1,0 +1,127 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given an EKSCluster config
+# And "spec.distribution.modules.auth.overrides.ingresses" specifies
+#     dex, gangplank, and pomerium with host and ingressClass
+# When I validate the config against the schema
+# Then no errors are returned
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: furyctl-dev-aws-al
+spec:
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.0.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.0.182.0/24
+            - 10.0.172.0/24
+            - 10.0.162.0/24
+          public:
+            - 10.0.20.0/24
+            - 10.0.30.0/24
+            - 10.0.40.0/24
+    vpn:
+      ssh:
+        allowedFromCidrs:
+          - 0.0.0.0/0
+        githubUsersName:
+          - jnardiello
+        publicKeys:
+          - ssh-ed25519 SomethingSomething engineering@sighup.io
+      vpnClientsSubnetCidr: 192.168.200.0/24
+  kubernetes:
+    apiServer:
+      privateAccess: true
+      privateAccessCidrs: ["0.0.0.0/0"]
+      publicAccessCidrs: []
+      publicAccess: false
+    nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
+    nodePoolsLaunchKind: both
+    nodePoolGlobalAmiType: "alinux2023"
+    nodePools:
+      - ami:
+          id: ami-01234567890123456
+          owner: "123456789012"
+        type: self-managed
+        instance:
+          type: t3.large
+        name: worker-eks
+        size:
+          max: 3
+          min: 2
+  distribution:
+    modules:
+      auth:
+        baseDomain: furyctl-demo.sighup.io
+        dex:
+          connectors: []
+        pomerium:
+          policy: "test"
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        provider:
+          type: sso
+        overrides:
+          ingresses:
+            dex:
+              host: login.furyctl-demo.sighup.io
+              ingressClass: external
+            gangplank:
+              host: access.furyctl-demo.sighup.io
+              ingressClass: external
+            pomerium:
+              host: pomerium.furyctl-demo.sighup.io
+              ingressClass: external
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: example-velero
+            region: eu-west-1
+      ingress:
+        baseDomain: furyctl-demo.sighup.io
+        dns:
+          private:
+            create: true
+            name: internal.furyctl-demo.sighup.io
+          public:
+            create: true
+            name: furyctl-demo.sighup.io
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: example@sighup.io
+            type: http01
+        nginx:
+          type: single
+      logging:
+        type: opensearch
+        opensearch:
+          type: single
+      policy:
+        type: gatekeeper
+        gatekeeper:
+          additionalExcludedNamespaces: []
+          installDefaultPolicies: true
+          enforcementAction: deny
+  distributionVersion: v1.24.1
+  region: eu-west-1
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: furyctl-test-eks
+          keyPrefix: furyctl-test
+          region: eu-west-1

--- a/tests/schemas/public/onpremises-kfd-v1alpha2/001-ok.yaml
+++ b/tests/schemas/public/onpremises-kfd-v1alpha2/001-ok.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given a valid OnPremises config
+# And "spec.distribution.modules.auth.overrides.ingresses.pomerium" is specified
+# And the Pomerium override contains "host" and "ingressClass"
+# When I validate the config against the schema
+# Then no errors are returned
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: OnPremises
+metadata:
+  name: onpremises-test-pomerium-override
+spec:
+  distributionVersion: v1.34.0
+  distribution:
+    modules:
+      auth:
+        provider:
+          type: sso
+        baseDomain: example.test
+        dex:
+          connectors: []
+        pomerium:
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        overrides:
+          ingresses:
+            pomerium:
+              host: pomerium.example.test
+              ingressClass: nginx
+      dr:
+        type: none
+      ingress:
+        baseDomain: example.test
+        nginx:
+          type: single
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-example
+            email: example@example.test
+            type: http01
+      logging:
+        type: none
+      policy:
+        type: none

--- a/tests/schemas/public/onpremises-kfd-v1alpha2/002-ok.yaml
+++ b/tests/schemas/public/onpremises-kfd-v1alpha2/002-ok.yaml
@@ -1,0 +1,59 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given a valid OnPremises config
+# And "spec.distribution.modules.auth.overrides.ingresses" contains dex, gangplank, and pomerium
+# And each override contains "host" and "ingressClass"
+# When I validate the config against the schema
+# Then no errors are returned
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: OnPremises
+metadata:
+  name: onpremises-test-pomerium-override
+spec:
+  distributionVersion: v1.34.0
+  distribution:
+    modules:
+      auth:
+        provider:
+          type: sso
+        baseDomain: example.test
+        dex:
+          connectors: []
+        pomerium:
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        overrides:
+          ingresses:
+            dex:
+              host: dex.example.test
+              ingressClass: nginx
+            gangplank:
+              host: gangplank.example.test
+              ingressClass: nginx
+            pomerium:
+              host: pomerium.example.test
+              ingressClass: nginx
+      dr:
+        type: none
+      ingress:
+        baseDomain: example.test
+        nginx:
+          type: single
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-example
+            email: example@example.test
+            type: http01
+      logging:
+        type: none
+      policy:
+        type: none

--- a/tests/schemas/public/onpremises-kfd-v1alpha2/003-no.yaml
+++ b/tests/schemas/public/onpremises-kfd-v1alpha2/003-no.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given an OnPremises config
+# And "spec.distribution.modules.auth.overrides.ingresses.pomerium" is specified
+# And the Pomerium override is missing "ingressClass"
+# When I validate the config against the schema
+# Then a validation error is returned for the Pomerium override
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: OnPremises
+metadata:
+  name: onpremises-test-pomerium-override
+spec:
+  distributionVersion: v1.34.0
+  distribution:
+    modules:
+      auth:
+        provider:
+          type: sso
+        baseDomain: example.test
+        dex:
+          connectors: []
+        pomerium:
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        overrides:
+          ingresses:
+            pomerium:
+              host: pomerium.example.test
+      dr:
+        type: none
+      ingress:
+        baseDomain: example.test
+        nginx:
+          type: single
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-example
+            email: example@example.test
+            type: http01
+      logging:
+        type: none
+      policy:
+        type: none

--- a/tests/schemas/public/onpremises-kfd-v1alpha2/004-no.yaml
+++ b/tests/schemas/public/onpremises-kfd-v1alpha2/004-no.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given an OnPremises config
+# And "spec.distribution.modules.auth.overrides.ingresses" contains an unknown key
+# When I validate the config against the schema
+# Then a validation error is returned for the unknown property
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: OnPremises
+metadata:
+  name: onpremises-test-unknown-ingress-override
+spec:
+  distributionVersion: v1.34.0
+  distribution:
+    modules:
+      auth:
+        provider:
+          type: sso
+        baseDomain: example.test
+        dex:
+          connectors: []
+        pomerium:
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        overrides:
+          ingresses:
+            pomeriun:
+              host: pomerium.example.test
+              ingressClass: external
+      dr:
+        type: none
+      ingress:
+        baseDomain: example.test
+        nginx:
+          type: single
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-example
+            email: example@example.test
+            type: http01
+      logging:
+        type: none
+      policy:
+        type: none


### PR DESCRIPTION
### Summary 💡

Add `pomerium` as a valid key under `spec.distribution.modules.auth.overrides.ingresses`, alongside `dex` and `gangplank`. Applied to all three installers (onpremises, kfddistribution, ekscluster) so users can override `host` and `ingressClass` for the Pomerium ingress, matching what the templates already render.

Closes:

Relates:

### Description 📝

- `schemas/public/{onpremises,kfddistribution,ekscluster}-kfd-v1alpha2.json` + `schemas/private/ekscluster-kfd-v1alpha2.json`: `ingresses` becomes a closed enum `{gangplank, dex, pomerium}`, all sharing the same `Spec.Distribution.Modules.Auth.Overrides.Ingress` `$ref`.
- Generated Go models + docs regenerated for the three installers.
- Templates already consume `overrides.ingresses.pomerium.host` (`_helpers.tpl`, `auth/patches/pomerium-ingress.yml.tpl`, `auth/resources/pomerium-config.env.tpl`, `auth/secrets/dex.yml.tpl`); no template change required.

### Breaking Changes 💔

**kfddistribution + ekscluster**: previously these schemas defined `ingresses` as an open map (`additionalProperties: $ref Ingress`). They are now restricted to `{dex, gangplank, pomerium}`.

- **Schema impact**: configs using unknown keys (e.g. typos) under `auth.overrides.ingresses` now fail validation. In practice only the three known keys are consumed by templates, so real-world impact is limited.
- **Go API impact**: `pkg/apis/{ekscluster,kfddistribution}/v1alpha2/...SpecDistributionModulesAuthOverridesIngresses` changes from `map[string]Ingress` to a struct with `Dex/Gangplank/Pomerium *Ingress` fields. Downstream Go consumers iterating or indexing as a map will not compile and need to migrate to field access.

**onpremises**: purely additive — schema gains the `pomerium` key, Go struct gains the `Pomerium` field. No existing config breaks.

### Tests performed 🧪

- [x] `mise run license-check` clean
- [x] `mise run lint-go` clean (97 linters, 0 issues)
- [x] `mise run dump-private-schema` produces no diff against the committed private schema
- [x] `mise run generate-docs` regenerates the three docs/schemas with `dex`/`gangplank`/`pomerium` subsections
- [x] `bats tests/e2e/onpremises/schema.sh` — 4/4 (001-ok pomerium, 002-ok three ingresses, 003-no missing ingressClass, 004-no unknown key)
- [x] `bats tests/e2e/kfddistribution/schema.sh` — 28/28 (added 014-ok, 014-no, 015-ok, 015-no covering the same matrix on ekscluster)
- [x] `go build ./... && go test ./...` clean
- [x] `furyctl create config` for all three installers — output validates against the new schemas with `jv`
- [x] Manual sample config with `auth.overrides.ingresses.pomerium` validates against all three public schemas

### Future work 🔧

- Audit furyctl (downstream consumer of `pkg/apis/...`) for any `Ingresses[key]` / `range *.Ingresses` usage that would break the kfd/eks Go API change, and bump in coordination.
- Mirror the onpremises/eks fixtures under `tests/schemas/public/kfddistribution-kfd-v1alpha2/` if a dedicated kfddistribution validation bats suite is added later (currently the kfddistribution e2e schema bats reuses ekscluster fixtures).