### PR TITLE
feat(kfd): group provider tools under eks (back-compatible)

### DIFF
--- a/kfd.yaml
+++ b/kfd.yaml
@@ -38,14 +38,10 @@ furyctlSchemas:
       kind: OnPremises
 tools:
   common:
-    furyagent:
-      version: 0.4.0
     kubectl:
       version: 1.34.4
     kustomize:
       version: 5.6.0
-    opentofu:
-      version: 1.10.0
     yq:
       version: 4.34.1
     helm:
@@ -57,3 +53,7 @@ tools:
   eks:
     awscli:
       version: ">= 2.8.12"
+    opentofu:
+      version: 1.10.0
+    furyagent:
+      version: 0.4.0

--- a/pkg/apis/config/model.go
+++ b/pkg/apis/config/model.go
@@ -65,19 +65,25 @@ type KFDTools struct {
 }
 
 type KFDToolsCommon struct {
-	Furyagent KFDTool `yaml:"furyagent" validate:"required"`
 	Kubectl   KFDTool `yaml:"kubectl"   validate:"required"`
 	Kustomize KFDTool `yaml:"kustomize" validate:"required"`
-	Terraform KFDTool `yaml:"terraform"`
-	OpenTofu  KFDTool `yaml:"opentofu"  validate:"required"`
 	Yq        KFDTool `yaml:"yq"        validate:"required"`
 	Kapp      KFDTool `yaml:"kapp"`
 	Helm      KFDTool `yaml:"helm"`
 	Helmfile  KFDTool `yaml:"helmfile"`
+	// Terraform, OpenTofu and Furyagent are kept here for backward compatibility with
+	// distributions < 1.34.2 that pinned them under tools.common. Newer distributions pin
+	// opentofu/furyagent under the provider section (tools.eks); consumers resolve the
+	// provider value first and fall back to these. Hence they are optional.
+	Terraform KFDTool `yaml:"terraform"`
+	OpenTofu  KFDTool `yaml:"opentofu"`
+	Furyagent KFDTool `yaml:"furyagent"`
 }
 
 type KFDToolsEks struct {
-	Awscli KFDTool `yaml:"awscli" validate:"required"`
+	Awscli    KFDTool `yaml:"awscli" validate:"required"`
+	OpenTofu  KFDTool `yaml:"opentofu"`
+	Furyagent KFDTool `yaml:"furyagent"`
 }
 
 type KFDTool struct {


### PR DESCRIPTION
### Summary 💡

Groups the kfd.yaml `tools` per provider: `opentofu` and `furyagent` are now pinned under
`tools.eks` (they are EKS-only). The change is **backward compatible** — the model still accepts
the previous layout (these tools, and the legacy `terraform`, under `tools.common`), so older
distributions keep working with a furyctl that reads the new location first.

Related furyctl PR: sighupio/furyctl#672
Pre-release tag for furyctl to consume: `v1.34.2-rc.3`

### Description 📝

- `kfd.yaml`: `opentofu` and `furyagent` moved under `tools.eks` (next to `awscli`); `tools.common`
  keeps the truly common tools (kubectl, kustomize, yq, helm, helmfile, kapp).
- `pkg/apis/config/model.go`: `KFDToolsEks` gains optional `opentofu`/`furyagent`. `KFDToolsCommon`
  **keeps** `opentofu`/`furyagent`/`terraform` as **optional** (no longer `required`) for backward
  compatibility with distributions < 1.34.2. `model.go` is hand-written, no regeneration.

### Breaking Changes 💔

None. The model is additive: new distributions pin under `tools.eks`, older ones keep `tools.common`,
and furyctl resolves provider-first with a common fallback (see related PR). Requires the
`v1.34.2-rc.3` pre-release for furyctl.

### Tests performed 🧪

- [x] `go build ./...`
- [x] furyctl (split-tools) consumes `v1.34.2-rc.3`: EKS reads tools from `tools.eks`; OnPremises
      gets only the common tools (new layout) and still resolves opentofu/furyagent from `tools.common`
      on older distributions (cold-cache e2e against v1.34.1)
- [ ] bump furyctl with an rc version to make CI green again (after the PR from furyctl is approved)
