### PR TITLE
feat(immutable): add upgrade playbooks, OS update config, and per-node messages

### DIFF
--- a/kfd.yaml
+++ b/kfd.yaml
@@ -22,7 +22,7 @@ kubernetes:
     installer: v1.34.4
   immutable:
     version: 1.34.8
-    installer: v1.34.8-rc.0
+    installer: feat/flatcar-os-update
 furyctlSchemas:
   eks:
     - apiVersion: kfd.sighup.io/v1alpha2

--- a/templates/infrastructure/immutable/butane/_helpers.tpl
+++ b/templates/infrastructure/immutable/butane/_helpers.tpl
@@ -48,6 +48,25 @@ passwd:
           Path=/
 {{- end }}
 
+{{- define "update-server-config" }}
+    # Point Flatcar update-engine to a custom Nebraska/Omaha update server.
+    # OS updates are NOT applied automatically: update-engine.service and
+    # locksmithd.service are masked (see "disable-os-updates" and the locksmithd
+    # mask in each node config) and REBOOT_STRATEGY=off disables auto-reboot.
+    # To run an update manually on a node:
+    #   sudo systemctl unmask update-engine.service
+    #   sudo systemctl start update-engine.service
+    #   sudo update_engine_client -check_for_update
+    - path: /etc/flatcar/update.conf
+      overwrite: true
+      mode: 0644
+      contents:
+        inline: |
+          SERVER=https://public.update.sighup-prod.sighup.io/v1/update/
+          GROUP=stable
+          REBOOT_STRATEGY=off
+{{- end }}
+
 {{- define "network" }}
 {{- range $name, $iface := .node.network.ethernets }}
     - path: /etc/systemd/network/10-{{ $name }}.network

--- a/templates/infrastructure/immutable/butane/controlplane.bu.tpl
+++ b/templates/infrastructure/immutable/butane/controlplane.bu.tpl
@@ -13,6 +13,7 @@ storage:
 {{ template "network" . }}
 {{ template "python" . }}
 {{ template "sysupdate-noop" . }}
+{{ template "update-server-config" . }}
 {{ template "sshd-pq-configuration" . }}
 {{ template "containerd-sysext-files" . }}
 {{ template "keepalived-sysext-files" . }}

--- a/templates/infrastructure/immutable/butane/etcd.bu.tpl
+++ b/templates/infrastructure/immutable/butane/etcd.bu.tpl
@@ -13,6 +13,7 @@ storage:
 {{ template "network" . }}
 {{ template "python" . }}
 {{ template "sysupdate-noop" . }}
+{{ template "update-server-config" . }}
 {{ template "sshd-pq-configuration" . }}
 {{ template "containerd-sysext-files" . }}
 {{ template "etcd-sysext-files" . }}

--- a/templates/infrastructure/immutable/butane/loadbalancer.bu.tpl
+++ b/templates/infrastructure/immutable/butane/loadbalancer.bu.tpl
@@ -13,6 +13,7 @@ storage:
 {{ template "network" . }}
 {{ template "python" . }}
 {{ template "sysupdate-noop" . }}
+{{ template "update-server-config" . }}
 {{ template "sshd-pq-configuration" . }}
 {{ template "containerd-sysext-files" . }}
 {{ template "keepalived-sysext-files" . }}

--- a/templates/infrastructure/immutable/butane/worker.bu.tpl
+++ b/templates/infrastructure/immutable/butane/worker.bu.tpl
@@ -13,6 +13,7 @@ storage:
 {{ template "network" . }}
 {{ template "python" . }}
 {{ template "sysupdate-noop" . }}
+{{ template "update-server-config" . }}
 {{ template "sshd-pq-configuration" . }}
 {{ template "containerd-sysext-files" . }}
 {{ template "kubernetes-sysext-files" . }}

--- a/templates/kubernetes/immutable/54.upgrade-etcd.yaml.tpl
+++ b/templates/kubernetes/immutable/54.upgrade-etcd.yaml.tpl
@@ -1,0 +1,19 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+{{- $etcdOnControlPlane := true }}
+{{- if gt ( .spec.kubernetes | digAny "etcd" "members" list | len ) 0 }}
+  {{- $etcdOnControlPlane = false }}
+{{- end }}
+---
+# etcd upgrade: align the etcd sysext + renew certificates (in-band, no drain/reboot).
+- name: Upgrade etcd
+  hosts: {{ if $etcdOnControlPlane }}control_plane{{ else }}etcd{{ end }}
+  serial: 1
+  become: true
+  vars:
+    etcd_upgrade: true
+  roles:
+    - etcd
+  tags:
+    - etcd

--- a/templates/kubernetes/immutable/55.upgrade-control-plane.yml.tpl
+++ b/templates/kubernetes/immutable/55.upgrade-control-plane.yml.tpl
@@ -1,0 +1,24 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+---
+# Control-plane upgrade, serial 1. No drain here (mirrors on-prem 55); the role drains only around its OS reboot.
+- name: Upgrade the control plane
+  hosts: control_plane
+  serial: 1
+  become: true
+  vars:
+    upgrade: true
+  roles:
+    - containerd
+    - kube-control-plane
+  post_tasks:
+    # Re-gather facts: the role rebooted the node, so play-start facts are stale.
+    - name: Refresh OS facts after the upgrade
+      ansible.builtin.setup:
+        gather_subset: min
+    - name: Report the upgraded version
+      ansible.builtin.debug:
+        msg: "{{ "{{ inventory_hostname }} upgraded to Kubernetes {{ kubernetes_version }} / Flatcar {{ ansible_facts['distribution_version'] | default('unknown') }}" }}"
+  tags:
+    - kubeadm-upgrade

--- a/templates/kubernetes/immutable/56.upgrade-worker-nodes.yml.tpl
+++ b/templates/kubernetes/immutable/56.upgrade-worker-nodes.yml.tpl
@@ -1,0 +1,49 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+---
+# Worker upgrade, serial 1: drain → roles (sysext + kubeadm upgrade node + OS reboot) → uncordon.
+- name: Upgrade the worker nodes
+  hosts: nodes
+  serial: 1
+  become: true
+  vars:
+    upgrade: true
+  pre_tasks:
+    - name: Cordon and drain the node
+      delegate_to: localhost
+      become: false
+      changed_when: true
+      ansible.builtin.shell: "{{ .paths.kubectl }} {{ "drain {{ inventory_hostname }} --grace-period=60 --timeout=360s --force --ignore-daemonsets --delete-emptydir-data --kubeconfig={{ kubernetes_kubeconfig_path }}admin.conf" }}"
+  roles:
+    - containerd
+    - kube-worker
+  post_tasks:
+    - name: Uncordon the node
+      delegate_to: localhost
+      become: false
+      changed_when: true
+      ansible.builtin.shell: "sleep 60 && {{ .paths.kubectl }} {{ "uncordon {{ inventory_hostname }} --kubeconfig={{ kubernetes_kubeconfig_path }}admin.conf" }}"
+{{- if ne .options.skipPodsRunningCheck true }}
+    # Health gate scoped to the just-upgraded node (--field-selector spec.nodeName): unscheduled, benign
+    # cluster-wide Pending pods have no nodeName and drop out, so a healthy node passes without --force,
+    # while pods on THIS node that did not recover still fail the gate. The header keeps the count >= 1.
+    - name: Wait for the upgraded node's pods to be running or completed
+      delegate_to: localhost
+      become: false
+      changed_when: false
+      ansible.builtin.shell: "{{ .paths.kubectl }} {{ "get pods -A -o wide --field-selector spec.nodeName={{ inventory_hostname }} --kubeconfig={{ kubernetes_kubeconfig_path }}admin.conf" }} | grep -cvE 'Running|Completed'"
+      register: num_pods_result
+      until: "num_pods_result.stdout | int < 2"
+      retries: {{ .options.podRunningTimeout | default 10 }}
+      delay: 30
+{{- end }}
+    # Re-gather facts: the role rebooted the node, so play-start facts are stale.
+    - name: Refresh OS facts after the upgrade
+      ansible.builtin.setup:
+        gather_subset: min
+    - name: Report the upgraded version
+      ansible.builtin.debug:
+        msg: "{{ "{{ inventory_hostname }} upgraded to Kubernetes {{ kubernetes_version }} / Flatcar {{ ansible_facts['distribution_version'] | default('unknown') }}" }}"
+  tags:
+    - kube-worker

--- a/templates/kubernetes/immutable/98.cluster-certificates-renewal.yml.tpl
+++ b/templates/kubernetes/immutable/98.cluster-certificates-renewal.yml.tpl
@@ -1,0 +1,100 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+---
+# Operator-invoked: renew ALL cluster certificates (kube + etcd) WITHOUT performing an upgrade.
+# Use this to refresh certificates before they expire on a cluster that is not being upgraded.
+# Run manually from the kubernetes workdir:  ansible-playbook 98.cluster-certificates-renewal.yml --become
+# serial: 1 preserves etcd quorum and control-plane HA — one node at a time. Assumes etcd co-located on
+# the control plane (the default immutable topology).
+- name: Renew cluster certificates (kube + etcd)
+  hosts: control_plane
+  become: true
+  serial: 1
+  vars:
+    etcd_certs_dir: /etc/etcd/pki
+  tasks:
+    - name: Set the backup timestamp
+      ansible.builtin.set_fact:
+        cert_backup_timestamp: "{{ "{{ lookup('pipe', 'date +%Y-%m-%d_%H-%M-%S') }}" }}"
+
+    - name: Ensure the certificate backup directories exist
+      ansible.builtin.file:
+        path: "{{ "{{ ansible_env.HOME }}/certs-backup/{{ cert_backup_timestamp }}/{{ item }}" }}"
+        state: directory
+        mode: "0750"
+      loop:
+        - etc-kubernetes-pki
+        - etc-etcd-pki
+
+    - name: Back up the current Kubernetes and etcd certificates
+      ansible.builtin.copy:
+        src: "{{ "{{ item.src }}" }}"
+        dest: "{{ "{{ ansible_env.HOME }}/certs-backup/{{ cert_backup_timestamp }}/{{ item.dest }}" }}"
+        remote_src: true
+        mode: preserve
+        directory_mode: "0750"
+      loop:
+        - src: /etc/kubernetes/pki/
+          dest: etc-kubernetes-pki
+        - src: /etc/etcd/pki/
+          dest: etc-etcd-pki
+
+    - name: Renew the Kubernetes control-plane certificates
+      ansible.builtin.command: "kubeadm certs renew {{ "{{ item }}" }}"
+      loop:
+        - super-admin.conf
+        - admin.conf
+        - apiserver
+        - apiserver-kubelet-client
+        - controller-manager.conf
+        - front-proxy-client
+        - scheduler.conf
+      changed_when: true
+
+    - name: Renew the etcd certificates
+      ansible.builtin.command: "kubeadm certs renew --cert-dir=/etc/etcd/pki --config=/etc/etcd/kubeadm-etcd.yml {{ "{{ item }}" }}"
+      loop:
+        - apiserver-etcd-client
+        - etcd-healthcheck-client
+        - etcd-peer
+        - etcd-server
+      changed_when: true
+
+    # Quorum-safe etcd restart (same guard + wait as the upgrade path): never stop a member while the
+    # cluster is degraded, and wait for this member to rejoin before serial:1 advances.
+    - name: Assert the etcd cluster is healthy before restarting this member
+      ansible.builtin.command: etcdctl endpoint health --cluster
+      environment:
+        ETCDCTL_CACERT: "{{ "{{ etcd_certs_dir }}" }}/etcd/ca.crt"
+        ETCDCTL_CERT: "{{ "{{ etcd_certs_dir }}" }}/apiserver-etcd-client.crt"
+        ETCDCTL_KEY: "{{ "{{ etcd_certs_dir }}" }}/apiserver-etcd-client.key"
+        ETCDCTL_DIAL_TIMEOUT: "3s"
+      register: cert_etcd_health_pre
+      changed_when: false
+
+    - name: Restart etcd to load the renewed certificates
+      ansible.builtin.systemd:
+        name: etcd
+        state: restarted
+
+    - name: Wait for this etcd member to rejoin and the cluster to regain quorum
+      ansible.builtin.command: etcdctl endpoint health --cluster
+      environment:
+        ETCDCTL_CACERT: "{{ "{{ etcd_certs_dir }}" }}/etcd/ca.crt"
+        ETCDCTL_CERT: "{{ "{{ etcd_certs_dir }}" }}/apiserver-etcd-client.crt"
+        ETCDCTL_KEY: "{{ "{{ etcd_certs_dir }}" }}/apiserver-etcd-client.key"
+        ETCDCTL_DIAL_TIMEOUT: "3s"
+      register: cert_etcd_health_post
+      changed_when: false
+      until: cert_etcd_health_post.rc == 0
+      retries: 12
+      delay: 5
+
+    # Restart this node's control-plane static pods so they load the renewed certs (delete -> kubelet
+    # recreates from the static manifests). serial:1 keeps the API up via the other control planes.
+    - name: Restart the control-plane static pods to load the renewed certificates
+      delegate_to: localhost
+      become: false
+      changed_when: true
+      ansible.builtin.shell: "{{ .paths.kubectl }} {{ "delete pod -n kube-system -l tier=control-plane --field-selector spec.nodeName={{ inventory_hostname }} --kubeconfig={{ kubernetes_kubeconfig_path }}admin.conf" }}"


### PR DESCRIPTION
### Summary 💡

Add the Immutable-cluster Kubernetes + Flatcar OS upgrade templates: numbered upgrade playbooks, the Flatcar update-engine configuration, and a standalone certificate-renewal playbook.

Closes:
Relates: sighupio/installer-immutable#6 (roles) + sighupio/furyctl#676 (upgrade orchestrator)

### Description 📝

- **Numbered upgrade playbooks** (`54.upgrade-etcd`, `55.upgrade-control-plane`, `56.upgrade-worker-nodes`), `serial: 1`, with a node-scoped post-worker health gate (`--field-selector spec.nodeName`) and a per-node `"upgraded to Kubernetes X / Flatcar Y"` confirmation message.
- **`98.cluster-certificates-renewal`**: operator-invoked kube + etcd cert renewal outside the upgrade chain, reusing the quorum-safe etcd restart.
- **Butane**: point Flatcar `update-engine` at the SIGHUP Nebraska update server via `/etc/flatcar/update.conf` (auto-updates masked, `REBOOT_STRATEGY=off`).
- **`kfd.yaml`**: point the immutable installer ref at the upgrade branch.

### Breaking Changes 💔

None. The templates are new; the `kfd.yaml` change only moves the immutable installer ref.

### Tests performed 🧪

- [x] Live upgrade 1.34.8 → 1.35.5 on a 6-node DEV cluster; per-node messages emitted, health gate passed without `--force`
- [x] `yamllint` + rendered `ansible-playbook --syntax-check` green
- [ ] `98` cert-renewal run on a live cluster

### Future work 🔧

- Align `98` with on-prem: local `crictl` restart instead of `kubectl delete pod`, plus kubelet certificate renewal and non-co-located etcd support.
