### PR TITLE
feat(on-prem): support dnsZone per host override

### DIFF
--- a/docs/releases/v1.35.0.md
+++ b/docs/releases/v1.35.0.md
@@ -18,6 +18,7 @@ This version adds support for Kubernetes 1.35 and updates modules.
 - [[#519](https://github.com/sighupio/distribution/pull/519)] Allow overriding the `pomerium` auth ingress through `spec.distribution.modules.auth.overrides.ingresses.pomerium`.
 - [[#526](https://github.com/sighupio/distribution/pull/526)] Group the `kfd.yaml` `tools` per provider: `opentofu` and `furyagent` are now pinned under `tools.eks` (they are EKS-only). The change is backward compatible — the previous layout (these tools, and the legacy `terraform`, under `tools.common`) is still accepted.
 - [[#527](https://github.com/sighupio/distribution/pull/527)] The distribution is now a **data-only repository**: it no longer ships the generated Go types. It provides the public JSON schemas, defaults, templates, rules and `kfd.yaml`. `furyctl` now owns its config types (see furyctl#674), so integrators that previously imported the generated Go library should migrate accordingly.
+- [[#530](https://github.com/sighupio/distribution/pull/530)] Add support for a per-host `dnsZone` override in `furyctl.yaml` for `masters`, `etcd`, `nodes`, and `loadBalancers` host entries. When set on a host, the local value takes precedence over the global `spec.kubernetes.dnsZone` when computing `kubernetes_hostname` and `etcd_initial_cluster`. This makes it possible to assign different FQDNs to hosts in different DNS zones.
 
 ## Bug Fixes 🐛
 

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -223,11 +223,15 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "A name to identify the host. This value will be concatenated to `.spec.kubernetes.dnsZone` to calculate the FQDN for the host as `<name>.<dnsZone>`."
+          "description": "A name to identify the host. This value will be concatenated to `.spec.kubernetes.dnsZone` (or the host-level `dnsZone` if set) to calculate the FQDN for the host as `<name>.<dnsZone>`."
         },
         "ip": {
           "type": "string",
           "description": "The IP address of the host."
+        },
+        "dnsZone": {
+          "type": "string",
+          "description": "Optional per-host DNS zone override. When set, takes precedence over `.spec.kubernetes.dnsZone` when computing the FQDN for this host."
         }
       },
       "required": [
@@ -346,11 +350,15 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "A name to identify the host. This value will be concatenated to `.spec.kubernetes.dnsZone` to calculate the FQDN for the host as `<name>.<dnsZone>`."
+          "description": "A name to identify the host. This value will be concatenated to `.spec.kubernetes.dnsZone` (or the host-level `dnsZone` if set) to calculate the FQDN for the host as `<name>.<dnsZone>`."
         },
         "ip": {
           "type": "string",
           "description": "The IP address of the host"
+        },
+        "dnsZone": {
+          "type": "string",
+          "description": "Optional per-host DNS zone override. When set, takes precedence over `.spec.kubernetes.dnsZone` when computing the FQDN for this host."
         }
       },
       "required": [
@@ -382,11 +390,15 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "A name to identify the etcd node. This value will be concatenated to `.spec.kubernetes.dnsZone` to calculate the FQDN for the host as `<name>.<dnsZone>`."
+          "description": "A name to identify the etcd node. This value will be concatenated to `.spec.kubernetes.dnsZone` (or the host-level `dnsZone` if set) to calculate the FQDN for the host as `<name>.<dnsZone>`."
         },
         "ip": {
           "type": "string",
           "description": "The IP address of the etcd node."
+        },
+        "dnsZone": {
+          "type": "string",
+          "description": "Optional per-host DNS zone override. When set, takes precedence over `.spec.kubernetes.dnsZone` when computing the FQDN for this etcd node."
         }
       },
       "required": [
@@ -452,11 +464,15 @@
       "additionalProperties": false,
       "properties": {
         "name": {
-          "description": "A name to identify the host. This value will be concatenated to `.spec.kubernetes.dnsZone` to calculate the FQDN for the host as `<name>.<dnsZone>`.",
+          "description": "A name to identify the host. This value will be concatenated to `.spec.kubernetes.dnsZone` (or the host-level `dnsZone` if set) to calculate the FQDN for the host as `<name>.<dnsZone>`.",
           "type": "string"
         },
         "ip": {
           "description": "The IP address of the host",
+          "type": "string"
+        },
+        "dnsZone": {
+          "description": "Optional per-host DNS zone override. When set, takes precedence over `.spec.kubernetes.dnsZone` when computing the FQDN for this host.",
           "type": "string"
         }
       },

--- a/templates/kubernetes/onpremises/haproxy.cfg.tpl
+++ b/templates/kubernetes/onpremises/haproxy.cfg.tpl
@@ -42,7 +42,7 @@ backend masters
     option httpchk GET /healthz
     balance roundrobin
     {{- range $h := .spec.kubernetes.masters.hosts }}
-    server {{ $h.name }}.{{ $dnsZone }} {{ $h.ip }}:6443 maxconn 256 check check-ssl ca-file /etc/ssl/certs/kubernetes.crt
+    server {{ $h.name }}.{{ default $dnsZone (index $h "dnsZone") }} {{ $h.ip }}:6443 maxconn 256 check check-ssl ca-file /etc/ssl/certs/kubernetes.crt
     {{- end }}
 
 {{- if index .spec.kubernetes.loadBalancers "additionalConfig" }}

--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -7,9 +7,10 @@ all:
     haproxy:
       hosts:
         {{- range $h := .spec.kubernetes.loadBalancers.hosts }}
+        {{- $hostDnsZone := default $dnsZone (index $h "dnsZone") }}
         {{ $h.name }}:
           ansible_host: "{{ $h.ip }}"
-          kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
+          kubernetes_hostname: "{{ $h.name }}.{{ $hostDnsZone }}"
         {{- end }}
       vars:
         keepalived_cluster: {{ .spec.kubernetes.loadBalancers.keepalived.enabled }}
@@ -25,14 +26,15 @@ all:
       hosts:
         {{- $etcdInitialCluster := list }}
         {{- range $h := .spec.kubernetes.masters.hosts }}
+        {{- $hostDnsZone := default $dnsZone (index $h "dnsZone") }}
         {{- if not (index $.spec.kubernetes "etcd") }}
-        {{- $etcdUri := print $h.name "=https://" $h.name "." $dnsZone ":2380" }}
+        {{- $etcdUri := print $h.name "=https://" $h.name "." $hostDnsZone ":2380" }}
         {{- $etcdInitialCluster = append $etcdInitialCluster $etcdUri }}
         {{- end }}
         {{ $h.name }}:
           ansible_host: "{{ $h.ip }}"
           kubernetes_apiserver_advertise_address: "{{ $h.ip }}"
-          kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
+          kubernetes_hostname: "{{ $h.name }}.{{ $hostDnsZone }}"
           {{- if index $.spec.kubernetes.masters "labels" }}
           kubernetes_node_labels:
             {{ $.spec.kubernetes.masters.labels | toYaml | indent 12 | trim }}
@@ -54,7 +56,7 @@ all:
         etcd:
           endpoints:
             {{- range $h := .spec.kubernetes.etcd.hosts }}
-            - "https://{{ $h.name }}.{{ $dnsZone }}:2379"
+            - "https://{{ $h.name }}.{{ default $dnsZone (index $h "dnsZone") }}:2379"
             {{- end }}
           caFile: "/etc/etcd/pki/etcd/ca.crt"
           keyFile: "/etc/etcd/pki/apiserver-etcd-client.key"
@@ -166,11 +168,12 @@ all:
       hosts:
         {{- if index $.spec.kubernetes "etcd" }}
         {{- range $h := .spec.kubernetes.etcd.hosts }}
-        {{- $etcdUri := print $h.name "=https://" $h.name "." $dnsZone ":2380" }}
+        {{- $hostDnsZone := default $dnsZone (index $h "dnsZone") }}
+        {{- $etcdUri := print $h.name "=https://" $h.name "." $hostDnsZone ":2380" }}
         {{- $etcdInitialCluster = append $etcdInitialCluster $etcdUri }}
         {{ $h.name }}:
           ansible_host: "{{ $h.ip }}"
-          kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
+          kubernetes_hostname: "{{ $h.name }}.{{ $hostDnsZone }}"
           etcd_client_address: "{{ $h.ip }}"
         {{- end }}
       vars:
@@ -178,9 +181,10 @@ all:
         etcd_initial_cluster: "{{ $etcdInitialCluster | join "," }}"
         {{- else }}
         {{- range $h := .spec.kubernetes.masters.hosts }}
+        {{- $hostDnsZone := default $dnsZone (index $h "dnsZone") }}
         {{ $h.name }}:
           ansible_host: "{{ $h.ip }}"
-          kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
+          kubernetes_hostname: "{{ $h.name }}.{{ $hostDnsZone }}"
         {{- end }}
       vars:
         dns_zone: "{{ $dnsZone }}"
@@ -191,9 +195,10 @@ all:
         {{ $n.name }}:
           hosts:
           {{- range $h := $n.hosts }}
+          {{- $hostDnsZone := default $dnsZone (index $h "dnsZone") }}
             {{ $h.name }}:
               ansible_host: "{{ $h.ip }}"
-              kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
+              kubernetes_hostname: "{{ $h.name }}.{{ $hostDnsZone }}"
           {{- end }}
           vars:
             kubernetes_role: "{{ $n.name }}"

--- a/templates/preflight/onpremises/hosts.yaml.tpl
+++ b/templates/preflight/onpremises/hosts.yaml.tpl
@@ -7,9 +7,10 @@ all:
     haproxy:
       hosts:
         {{- range $h := .spec.kubernetes.loadBalancers.hosts }}
+        {{- $hostDnsZone := default $dnsZone (index $h "dnsZone") }}
         {{ $h.name }}:
           ansible_host: "{{ $h.ip }}"
-          kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
+          kubernetes_hostname: "{{ $h.name }}.{{ $hostDnsZone }}"
         {{- end }}
       vars:
         keepalived_cluster: {{ .spec.kubernetes.loadBalancers.keepalived.enabled }}
@@ -22,14 +23,15 @@ all:
       hosts:
         {{- $etcdInitialCluster := list }}
         {{- range $h := .spec.kubernetes.masters.hosts }}
+        {{- $hostDnsZone := default $dnsZone (index $h "dnsZone") }}
         {{- if not (index $.spec.kubernetes "etcd") }}
-        {{- $etcdUri := print $h.name "=https://" $h.name "." $dnsZone ":2380" }}
+        {{- $etcdUri := print $h.name "=https://" $h.name "." $hostDnsZone ":2380" }}
         {{- $etcdInitialCluster = append $etcdInitialCluster $etcdUri }}
         {{- end }}
         {{ $h.name }}:
           ansible_host: "{{ $h.ip }}"
           kubernetes_apiserver_advertise_address: "{{ $h.ip }}"
-          kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
+          kubernetes_hostname: "{{ $h.name }}.{{ $hostDnsZone }}"
           {{- if index $.spec.kubernetes.masters "labels" }}
           kubernetes_node_labels:
             {{ $.spec.kubernetes.masters.labels | toYaml | indent 12 | trim }}
@@ -51,7 +53,7 @@ all:
         etcd:
           endpoints:
             {{- range $h := .spec.kubernetes.etcd.hosts }}
-            - "https://{{ $h.name }}.{{ $dnsZone }}:2379"
+            - "https://{{ $h.name }}.{{ default $dnsZone (index $h "dnsZone") }}:2379"
             {{- end }}
           caFile: "/etc/etcd/pki/etcd/ca.crt"
           keyFile: "/etc/etcd/pki/apiserver-etcd-client.key"
@@ -89,11 +91,12 @@ all:
       hosts:
         {{- if index $.spec.kubernetes "etcd" }}
         {{- range $h := .spec.kubernetes.etcd.hosts }}
-        {{- $etcdUri := print $h.name "=https://" $h.name "." $dnsZone ":2380" }}
+        {{- $hostDnsZone := default $dnsZone (index $h "dnsZone") }}
+        {{- $etcdUri := print $h.name "=https://" $h.name "." $hostDnsZone ":2380" }}
         {{- $etcdInitialCluster = append $etcdInitialCluster $etcdUri }}
         {{ $h.name }}:
           ansible_host: "{{ $h.ip }}"
-          kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
+          kubernetes_hostname: "{{ $h.name }}.{{ $hostDnsZone }}"
           etcd_client_address: "{{ $h.ip }}"
         {{- end }}
       vars:
@@ -101,9 +104,10 @@ all:
         etcd_initial_cluster: "{{ $etcdInitialCluster | join "," }}"
         {{- else }}
         {{- range $h := .spec.kubernetes.masters.hosts }}
+        {{- $hostDnsZone := default $dnsZone (index $h "dnsZone") }}
         {{ $h.name }}:
           ansible_host: "{{ $h.ip }}"
-          kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
+          kubernetes_hostname: "{{ $h.name }}.{{ $hostDnsZone }}"
         {{- end }}
       vars:
         dns_zone: "{{ $dnsZone }}"
@@ -114,9 +118,10 @@ all:
         {{ $n.name }}:
           hosts:
           {{- range $h := $n.hosts }}
+          {{- $hostDnsZone := default $dnsZone (index $h "dnsZone") }}
             {{ $h.name }}:
               ansible_host: "{{ $h.ip }}"
-              kubernetes_hostname: "{{ $h.name }}.{{ $dnsZone }}"
+              kubernetes_hostname: "{{ $h.name }}.{{ $hostDnsZone }}"
           {{- end }}
           vars:
             kubernetes_role: "{{ $n.name }}"

--- a/tests/e2e/onpremises/schema.sh
+++ b/tests/e2e/onpremises/schema.sh
@@ -160,3 +160,9 @@ test_schema() {
 
     test_schema "public" "onpremises-kfd-v1alpha2" "004-no" expect
 }
+
+@test "005 - ok (per-host dnsZone on masters, etcd, workers, and loadBalancers)" {
+    info
+
+    test_schema "public" "onpremises-kfd-v1alpha2" "005-ok" expect_ok
+}

--- a/tests/schemas/public/onpremises-kfd-v1alpha2/005-ok.yaml
+++ b/tests/schemas/public/onpremises-kfd-v1alpha2/005-ok.yaml
@@ -1,0 +1,77 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given a valid OnPremises config
+# And some host entries under masters, etcd, workers, and loadBalancers have a per-host "dnsZone" field
+# When I validate the config against the schema
+# Then no errors are returned
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: OnPremises
+metadata:
+  name: onpremises-test-per-host-dnszone
+spec:
+  distributionVersion: v1.35.0
+  kubernetes:
+    pkiFolder: /etc/pki
+    ssh:
+      username: user
+      keyPath: ~/.ssh/id_rsa
+    dnsZone: k8s.local
+    controlPlaneAddress: api.k8s.local
+    podCidr: 10.0.0.0/16
+    svcCidr: 10.1.0.0/16
+    loadBalancers:
+      enabled: true
+      hosts:
+        - name: lb-0
+          ip: 192.168.1.10
+          dnsZone: k8s.cloud
+      keepalived:
+        enabled: false
+      stats:
+        username: admin
+        password: admin
+    masters:
+      hosts:
+        - name: master-0
+          ip: 192.168.1.1
+        - name: master-1
+          ip: 192.168.1.2
+          dnsZone: k8s.cloud
+    etcd:
+      hosts:
+        - name: etcd-0
+          ip: 192.168.1.5
+        - name: etcd-1
+          ip: 192.168.1.6
+          dnsZone: k8s.cloud
+    nodes:
+      - name: workers
+        hosts:
+          - name: worker-0
+            ip: 192.168.1.20
+          - name: worker-1
+            ip: 192.168.1.21
+            dnsZone: k8s.cloud
+  distribution:
+    modules:
+      dr:
+        type: none
+      ingress:
+        baseDomain: example.local
+        nginx:
+          type: single
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-example
+            email: example@example.local
+            type: http01
+      logging:
+        type: none
+      policy:
+        type: none


### PR DESCRIPTION
### Summary 💡

Adds support for a per-host `dnsZone` override in `furyctl.yaml` for `masters`, `etcd`, `nodes`, and `loadBalancers` host entries. 

Closes: [#522](https://github.com/sighupio/distribution/issues/522)


### Description 📝

When deploying a cluster with both on-premises and cloud nodes, all hosts previously shared the single `spec.kubernetes.dnsZone` value. This made it impossible to assign different FQDNs to hosts belonging to different DNS zones (example: `controlplane.k8s.local` for on-prem nodes and `etcd01.k8s.cloud` for cloud nodes).

The new optional `dnsZone` field can be set on any host entry:

```yaml
spec:
  kubernetes:
    dnsZone: k8s.local
    masters:
      hosts:
        - name: master-0
          ip: 192.168.1.1
        - name: master-1
          ip: 192.168.1.2
          dnsZone: k8s.cloud   # overrides the global dnsZone for this host only
    etcd:
      hosts:
        - name: etcd-0
          ip: 192.168.1.5
          dnsZone: k8s.cloud
```

### Breaking Changes 💔

None. 

### Tests performed 🧪

-  [x] Tested a clean provisioning with a local distro-location pointing to this branch.

### Future work 🔧

None. 