### PR TITLE
fix(distribution/preapply): kyverno migration

### DIFF
--- a/docs/releases/v1.35.0.md
+++ b/docs/releases/v1.35.0.md
@@ -22,6 +22,8 @@ This version adds support for Kubernetes 1.35 and updates modules.
 
 ## Bug Fixes 🐛
 
+- [[[#515](https://github.com/sighupio/distribution/issues/515)]] **Don't try to delete Kyverno Policies when CRDs are not present**: the distribution pre-apply script tried to delete the default Kyverno policies even when the CRDs were not present in the cluster. Now the script checks for the CRDs before attempting to delete them.
+
 ## Breaking changes 💔
 
 - [[#519](https://github.com/sighupio/distribution/pull/519)] For the `EKSCluster` and `KFDDistribution` kinds, `spec.distribution.modules.auth.overrides.ingresses` now only accepts the `gangplank`, `dex` and `pomerium` keys. Previously any key was accepted; configurations using other keys will now fail schema validation.

--- a/templates/distribution/scripts/pre-apply.sh.tpl
+++ b/templates/distribution/scripts/pre-apply.sh.tpl
@@ -250,8 +250,12 @@ deleteGatekeeperDefaultPolicies
 {{- if index .reducers "distributionModulesPolicyKyvernoInstallDefaultPolicies" }}
 
 deleteKyvernoDefaultPolicies() {
-  $kustomizebin build $vendorPath/modules/opa/katalog/kyverno/policies | $kubectlbin delete --ignore-not-found --wait --timeout=600s -f -
-  echo "Kyverno default policies resources deleted"
+  if $kubectlbin get crd clusterpolicies.kyverno.io > /dev/null 2>&1; then
+    $kustomizebin build $vendorPath/modules/opa/katalog/kyverno/policies | $kubectlbin delete --ignore-not-found --wait --timeout=600s -f -
+    echo "Kyverno default policies resources deleted"
+  else
+    echo "Kyverno CRDs not found, skipping deleteKyvernoDefaultPolicies"
+  fi
 }
 
 # from enabled


### PR DESCRIPTION
### Summary 💡

Check if CRds are present before attempting to delete Kyverno default policies.

Fixes #515

### Description 📝

Applies the suggested fix in the linked issue.

Thanks @paranoiasystem for the report and the fix :tada:

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Replicated the scenario described in the issue, applied the suggested fix and check that it worked as expected.
- [x] Tested several cases migrating from policy none to kyverno and viceversa with default polciies enabled and disabled.
- [x] Tested changing default policies from enabled to disabled and viceversa.

### Future work 🔧

We could probably remove this from the pre-apply script, `kapp` would have taken care of deleting the objects anyway.
