### PR TITLE
fix(on-premises): move kubernetes_image_registry to all.vars

### DIFF
--- a/docs/releases/v1.35.0.md
+++ b/docs/releases/v1.35.0.md
@@ -23,6 +23,7 @@ This version adds support for Kubernetes 1.35 and updates modules.
 ## Bug Fixes 🐛
 
 - [[[#515](https://github.com/sighupio/distribution/issues/515)]] **Don't try to delete Kyverno Policies when CRDs are not present**: the distribution pre-apply script tried to delete the default Kyverno policies even when the CRDs were not present in the cluster. Now the script checks for the CRDs before attempting to delete them.
+- [[#532](https://github.com/sighupio/distribution/pull/532)] **Fix worker nodes not receiving custom registry in OnPremises clusters**: `kubernetes_image_registry` was placed under `master.vars` instead of `all.vars` in the generated `hosts.yaml`, causing worker nodes to fall back to the default `registry.sighup.io/fury/on-premises` registry for the pause container (`sandbox_image`).
 
 ## Breaking changes 💔
 

--- a/templates/kubernetes/onpremises/hosts.yaml.tpl
+++ b/templates/kubernetes/onpremises/hosts.yaml.tpl
@@ -130,10 +130,6 @@ all:
         {{- end }}
 
         {{- if index .spec.kubernetes "advanced" }}
-        {{- if and (index .spec.kubernetes.advanced "registry") (ne .spec.kubernetes.advanced.registry "") }}
-        kubernetes_image_registry: "{{ .spec.kubernetes.advanced.registry }}"
-        {{- end }}
-
         {{- if index .spec.kubernetes.advanced "eventRateLimits" }}
         eventratelimits:
           {{- range .spec.kubernetes.advanced.eventRateLimits }}
@@ -255,6 +251,9 @@ all:
     no_proxy: "{{ .spec.kubernetes.proxy.noProxy }}"
     {{- end }}
     {{- if (index .spec.kubernetes "advanced") }}
+    {{- if and (index .spec.kubernetes.advanced "registry") (ne .spec.kubernetes.advanced.registry "") }}
+    kubernetes_image_registry: "{{ .spec.kubernetes.advanced.registry }}"
+    {{- end }}
     {{- if (index .spec.kubernetes.advanced "containerd") }}
     {{- if (index .spec.kubernetes.advanced.containerd "registryConfigs") }}
     containerd_registry_configs:


### PR DESCRIPTION
### Summary 💡

When spec.kubernetes.advanced.registry is set in furyctl.yaml, the generated hosts.yaml was placing kubernetes_image_registry under master.vars only. Worker nodes never received the variable, causing the containerd role to fall back to the hardcoded registry.sighup.io/fury/on-premises when computing sandbox_image for the pause container.

Closes: https://github.com/sighupio/distribution/issues/523

###  Description 📝

See the issue.

###  Breaking Changes 💔

None.

###  Tests performed 🧪

- [x] Generated hosts.yaml and verified kubernetes_image_registry appears under all.vars

###  Future work 🔧

None.