### PR TITLE
fix(templates/monitoring): AlertmanagerConfigs conditional deploy

### DIFF
--- a/docs/releases/v1.35.0.md
+++ b/docs/releases/v1.35.0.md
@@ -25,6 +25,7 @@ This version adds support for Kubernetes 1.35 and updates modules.
 
 - [[[#515](https://github.com/sighupio/distribution/issues/515)]] **Don't try to delete Kyverno Policies when CRDs are not present**: the distribution pre-apply script tried to delete the default Kyverno policies even when the CRDs were not present in the cluster. Now the script checks for the CRDs before attempting to delete them.
 - [[#532](https://github.com/sighupio/distribution/pull/532)] **Fix worker nodes not receiving custom registry in OnPremises clusters**: `kubernetes_image_registry` was placed under `master.vars` instead of `all.vars` in the generated `hosts.yaml`, causing worker nodes to fall back to the default `registry.sighup.io/fury/on-premises` registry for the pause container (`sandbox_image`).
+- [[#537](https://github.com/sighupio/distribution/pull/537)] **Fix `PrometheusOperatorRejectedResources` false positive**: Deploy the AlertmanagerConfigs included with the monitoring module only when URLs are set for the webhooks they use, otherwise a `PrometheusOperatorRejectedResources` alert would be triggered because of missing Secrets causing alert noise.
 
 ## Breaking changes 💔
 

--- a/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
@@ -103,7 +103,33 @@ patches:
     {{- end }}
   {{- end }}
 {{- end }}
-{{- if not .spec.distribution.modules.monitoring.alertmanager.installDefaultRules }}
+{{- if .spec.distribution.modules.monitoring.alertmanager.installDefaultRules }}
+{{- if eq .spec.distribution.modules.monitoring.alertmanager.deadManSwitchWebhookUrl "" }}
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: deadmanswitch
+{{- end }}
+{{- if eq .spec.distribution.modules.monitoring.alertmanager.slackWebhookUrl "" }}
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: infra
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: k8s
+{{- end }}
+{{- else }}
 {{- if .spec.distribution.modules.monitoring.alertmanager.deadManSwitchWebhookUrl }}
   - patch: |-
       $patch: delete

--- a/tests/templates/ekscluster/00-disabled/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/ekscluster/00-disabled/baseline/manifests/monitoring/kustomization.yaml
@@ -27,6 +27,27 @@ patches:
       metadata:
         namespace: monitoring
         name: x509-certificate-exporter-data-plane
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: deadmanswitch
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: infra
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: k8s
 
 configMapGenerator:
 

--- a/tests/templates/ekscluster/01-full-nginx/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/ekscluster/01-full-nginx/baseline/manifests/monitoring/kustomization.yaml
@@ -36,6 +36,27 @@ patches:
   - path: patches/alertmanager-operated.yml
   - path: patches/prometheus-operated.yml
   - path: patches/minio.yml
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: deadmanswitch
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: infra
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: k8s
 
 configMapGenerator:
   - name: mimir-distributed-config

--- a/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/monitoring/kustomization.yaml
@@ -34,6 +34,27 @@ patches:
         name: x509-certificate-exporter-data-plane
   - path: patches/alertmanager-operated.yml
   - path: patches/prometheus-operated.yml
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: deadmanswitch
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: infra
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: k8s
 
 configMapGenerator:
 

--- a/tests/templates/kfddistribution/00-disabled/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/kfddistribution/00-disabled/baseline/manifests/monitoring/kustomization.yaml
@@ -20,6 +20,27 @@ resources:
 
 patches:
   - path: patches/infra-nodes.yml
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: deadmanswitch
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: infra
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: k8s
 
 configMapGenerator:
 

--- a/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/monitoring/kustomization.yaml
@@ -29,6 +29,27 @@ patches:
   - path: patches/alertmanager-operated.yml
   - path: patches/prometheus-operated.yml
   - path: patches/minio.yml
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: deadmanswitch
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: infra
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: k8s
 
 configMapGenerator:
   - name: mimir-distributed-config

--- a/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/monitoring/kustomization.yaml
@@ -27,6 +27,27 @@ patches:
   - path: patches/infra-nodes.yml
   - path: patches/alertmanager-operated.yml
   - path: patches/prometheus-operated.yml
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: deadmanswitch
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: infra
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: k8s
 
 configMapGenerator:
 

--- a/tests/templates/onpremises/00-disabled/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/onpremises/00-disabled/baseline/manifests/monitoring/kustomization.yaml
@@ -20,6 +20,27 @@ resources:
 
 patches:
   - path: patches/infra-nodes.yml
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: deadmanswitch
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: infra
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: k8s
 
 configMapGenerator:
 

--- a/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/monitoring/kustomization.yaml
@@ -29,6 +29,27 @@ patches:
   - path: patches/alertmanager-operated.yml
   - path: patches/prometheus-operated.yml
   - path: patches/minio.yml
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: deadmanswitch
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: infra
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: k8s
 
 configMapGenerator:
   - name: mimir-distributed-config

--- a/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/monitoring/kustomization.yaml
@@ -27,6 +27,27 @@ patches:
   - path: patches/infra-nodes.yml
   - path: patches/alertmanager-operated.yml
   - path: patches/prometheus-operated.yml
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: deadmanswitch
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: infra
+  - patch: |-
+      $patch: delete
+      apiVersion: monitoring.coreos.com/v1alpha1
+      kind: AlertmanagerConfig
+      metadata:
+        namespace: monitoring
+        name: k8s
 
 configMapGenerator:
 


### PR DESCRIPTION
### Summary 💡

Deploy the AlertmanagerConfigs included with the monitoring module only if needed.

Fixes #536

Related:
- https://github.com/sighupio/distribution/issues/315

### Description 📝

Deploy the AlertmanagerConfigs included with the monitoring module for Slack and DeadmanSwith webhooks only when the URLs for those services are set.

If the URLs are _not_ set in the configuration file, the secrets with the URL are not created, resulting in a configuration error on Prometheus Operator that triggers a `PrometheusOperatorRejectedResources` alert.

Added logic to deploy the AlertmanagerConfigs CRs only when the URLs are set, to avoid false postivies.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] setting the webhook URL - no alert
- [x] unsetting the webhook URL: alertmanagerConfig is not deployed
- [x] setting `installDefaultRules: false` -> alertmanagerConfigs are not deployed even if webhooks URLs are set, `furyctl apply` works without errors
- [x] setting `installDefaultRules: true` explicitly and the webhook URLs works

### Future work 🔧

With this change the `installDefaultRules` field does not make much sense any more. We could deprecate it, also its name and description do not match well with what it actually does.

I suggest deprecating the field, if the URLs are not set (default state) now the AlertmanagerConfig CR will not be created, having the same effect as setting `installDefaultRules` to `false`.