### PR TITLE
feat(kfd): pin ansible and its build toolchain for the mise-managed install

### DIFF
--- a/docs/releases/v1.35.0.md
+++ b/docs/releases/v1.35.0.md
@@ -21,6 +21,7 @@ This version adds support for Kubernetes 1.35 and updates modules.
 - [[#527](https://github.com/sighupio/distribution/pull/527)] The distribution is now a **data-only repository**: it no longer ships the generated Go types. It provides the public JSON schemas, defaults, templates, rules and `kfd.yaml`. `furyctl` now owns its config types (see furyctl#674), so integrators that previously imported the generated Go library should migrate accordingly.
 - [[#530](https://github.com/sighupio/distribution/pull/530)] Add support for a per-host `dnsZone` override in `furyctl.yaml` for `masters`, `etcd`, `nodes`, and `loadBalancers` host entries. When set on a host, the local value takes precedence over the global `spec.kubernetes.dnsZone` when computing `kubernetes_hostname` and `etcd_initial_cluster`. This makes it possible to assign different FQDNs to hosts in different DNS zones.
 - [[#505](https://github.com/sighupio/distribution/pull/505)] Support NFTables mode for kube-proxy.
+- [[#539](https://github.com/sighupio/distribution/pull/539)] Pin `ansible` (with its `python` + `uv` build toolchain and the galaxy collections) under `tools.common` in `kfd.yaml`, so `furyctl` installs a self-contained, versioned Ansible via the bundled mise for the `OnPremises` and `Immutable` kinds instead of requiring it on the host. Optional and backward compatible: distributions without the block keep using the host Ansible.
 
 ## Bug Fixes 🐛
 

--- a/kfd.yaml
+++ b/kfd.yaml
@@ -57,3 +57,23 @@ tools:
       version: 1.10.0
     furyagent:
       version: 0.4.0
+  onpremises:
+    ansible:
+      version: 2.21.0
+      python: "3.12"
+      uv: "0.9"
+      collections:
+        - name: ansible.posix
+          version: 2.2.0
+        - name: community.general
+          version: 13.0.1
+  immutable:
+    ansible:
+      version: 2.21.0
+      python: "3.12"
+      uv: "0.9"
+      collections:
+        - name: ansible.posix
+          version: 2.2.0
+        - name: community.general
+          version: 13.0.1


### PR DESCRIPTION
### Summary 💡

Adds `ansible` under the `onpremises` and `immutable` provider tool sections so `furyctl` installs a self-contained, versioned Ansible (+ galaxy collections) via the bundled mise, instead of requiring it on the host. Each section also pins the build toolchain (`python` + `uv`) mise uses to build the venv.

Closes:

Relates: https://github.com/sighupio/furyctl/pull/681

### Description 📝

Ansible is only used by the `OnPremises` and `Immutable` kinds, so it is pinned per provider (mirroring how `tools.eks` groups the EKS-only tools) rather than under `tools.common`. Each provider section pins ansible-core, its build toolchain and the galaxy collections — the block is repeated under both `onpremises` and `immutable`:

```yaml
tools:
  onpremises:
    ansible:
      version: 2.21.0
      python: "3.12"
      uv: "0.9"
      collections:
        - { name: ansible.posix, version: 2.2.0 }
        - { name: community.general, version: 13.0.1 }
  immutable:
    ansible: # same block as onpremises
```

`python` and `uv` live inside `ansible` on purpose: the right versions depend on the ansible version (ansible-core 2.21 needs python ≥ 3.11), so the distribution that picks ansible must pick its toolchain too. Both are optional — furyctl falls back to its defaults when a distro pins only `version` + `collections`. Full mechanism in the furyctl PR.

### Breaking Changes 💔

None — the sections are optional; distros without them keep using the host Ansible.

### Tests performed 🧪

- [x] On-prem e2e on Vagrant (furyctl run inside a Linux container): `apply` creates a v1.35.5 cluster, playbooks run by the mise-installed Ansible 2.21.0 + collections from `tools.onpremises`
- [x] Self-contained install verified on a clean Linux container (no host python/uv/pipx)
- [x] EKSCluster/KFDDistribution don't pull ansible; distros without the sections fall back to host Ansible (verified against a real v1.34.1)

### Future work 🔧

- Pin the same block on other distribution lines as they adopt the mise-managed Ansible.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green
