### PR TITLE
fix: align distribution patches with module packages configuration

### DIFF
--- a/templates/distribution/manifests/logging/patches/loki-config.yaml.tpl
+++ b/templates/distribution/manifests/logging/patches/loki-config.yaml.tpl
@@ -1,7 +1,6 @@
 # Copyright (c) 2025-present SIGHUP s.r.l. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-#
 
 analytics:
   reporting_enabled: false
@@ -19,7 +18,7 @@ bloom_gateway:
     addresses: dnssrvnoa+_grpc._tcp.loki-distributed-bloom-gateway-headless.logging.svc.cluster.local
   enabled: false
 common:
-  compactor_address: 'http://loki-distributed-compactor:3100'
+  compactor_grpc_address: 'loki-distributed-compactor.logging.svc.cluster.local:9095'
   path_prefix: /var/loki
   replication_factor: 1
   storage:
@@ -42,11 +41,11 @@ common:
 {{- end }}
 frontend:
   compress_responses: true
-  log_queries_longer_than: 5s 
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  log_queries_longer_than: 5s
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
   tail_proxy_url: http://loki-distributed-querier.logging.svc.cluster.local:3100
 frontend_worker:
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
 index_gateway:
   mode: simple
 ingester:
@@ -60,7 +59,6 @@ ingester:
         store: memberlist
       replication_factor: 1
   wal:
-    dir: /var/loki/wal
     flush_on_shutdown: true
 limits_config:
   allow_structured_metadata: true
@@ -73,8 +71,15 @@ limits_config:
   max_label_names_per_series: 30
   retention_period: {{ .spec.distribution.modules.logging.loki.retentionTime }}
 memberlist:
+  abort_if_cluster_join_fails: true
+  advertise_port: 7946
+  bind_port: 7946
   join_members:
-  - loki-distributed-memberlist
+  - loki-distributed-memberlist.logging.svc.cluster.local
+  max_join_backoff: 1m
+  max_join_retries: 10
+  min_join_backoff: 1s
+  rejoin_interval: 90s
 pattern_ingester:
   enabled: true
 querier:
@@ -99,7 +104,7 @@ schema_config:
     schema: v11
     store: boltdb-shipper
 {{- if and (index .spec.distribution.modules.logging "loki") (index .spec.distribution.modules.logging.loki "tsdbStartDate") }}
-  - from: "{{ .spec.distribution.modules.logging.loki.tsdbStartDate }}" 
+  - from: "{{ .spec.distribution.modules.logging.loki.tsdbStartDate }}"
     index:
       period: 24h
       prefix: index_
@@ -108,10 +113,18 @@ schema_config:
     store: tsdb
 {{- end }}
 server:
+  graceful_shutdown_timeout: 5s
   grpc_listen_port: 9095
+  grpc_server_max_concurrent_streams: 1000
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  grpc_server_min_time_between_pings: 10s
+  grpc_server_ping_without_stream_allowed: true
   http_listen_port: 3100
-  http_server_read_timeout: 600s
-  http_server_write_timeout: 600s
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 10m0s
+  http_server_write_timeout: 10m0s
+  log_level: info
 storage_config:
   bloom_shipper:
     working_directory: /var/loki/data/bloomshipper
@@ -133,6 +146,7 @@ storage_config:
     resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+  use_thanos_objstore: false
 compactor:
   working_directory: /var/loki/compactor
   retention_enabled: {{ ne .spec.distribution.modules.logging.loki.retentionTime "0s" }}

--- a/templates/distribution/manifests/tracing/patches/tempo.yaml.tpl
+++ b/templates/distribution/manifests/tracing/patches/tempo.yaml.tpl
@@ -91,7 +91,7 @@ query_frontend:
 server:
     grpc_server_max_recv_msg_size: 4194304
     grpc_server_max_send_msg_size: 4194304
-    http_listen_port: 3100
+    http_listen_port: 3200
     http_server_read_timeout: 30s
     http_server_write_timeout: 30s
     log_format: logfmt

--- a/tests/templates/ekscluster/00-disabled/baseline/manifests/logging/patches/loki-config.yaml
+++ b/tests/templates/ekscluster/00-disabled/baseline/manifests/logging/patches/loki-config.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2025-present SIGHUP s.r.l. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-#
 
 analytics:
   reporting_enabled: false
@@ -19,7 +18,7 @@ bloom_gateway:
     addresses: dnssrvnoa+_grpc._tcp.loki-distributed-bloom-gateway-headless.logging.svc.cluster.local
   enabled: false
 common:
-  compactor_address: 'http://loki-distributed-compactor:3100'
+  compactor_grpc_address: 'loki-distributed-compactor.logging.svc.cluster.local:9095'
   path_prefix: /var/loki
   replication_factor: 1
   storage:
@@ -32,11 +31,11 @@ common:
       s3forcepathstyle: true
 frontend:
   compress_responses: true
-  log_queries_longer_than: 5s 
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  log_queries_longer_than: 5s
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
   tail_proxy_url: http://loki-distributed-querier.logging.svc.cluster.local:3100
 frontend_worker:
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
 index_gateway:
   mode: simple
 ingester:
@@ -50,7 +49,6 @@ ingester:
         store: memberlist
       replication_factor: 1
   wal:
-    dir: /var/loki/wal
     flush_on_shutdown: true
 limits_config:
   allow_structured_metadata: true
@@ -63,8 +61,15 @@ limits_config:
   max_label_names_per_series: 30
   retention_period: 720h
 memberlist:
+  abort_if_cluster_join_fails: true
+  advertise_port: 7946
+  bind_port: 7946
   join_members:
-  - loki-distributed-memberlist
+  - loki-distributed-memberlist.logging.svc.cluster.local
+  max_join_backoff: 1m
+  max_join_retries: 10
+  min_join_backoff: 1s
+  rejoin_interval: 90s
 pattern_ingester:
   enabled: true
 querier:
@@ -88,7 +93,7 @@ schema_config:
     object_store: s3
     schema: v11
     store: boltdb-shipper
-  - from: "2025-05-15" 
+  - from: "2025-05-15"
     index:
       period: 24h
       prefix: index_
@@ -96,10 +101,18 @@ schema_config:
     schema: v13
     store: tsdb
 server:
+  graceful_shutdown_timeout: 5s
   grpc_listen_port: 9095
+  grpc_server_max_concurrent_streams: 1000
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  grpc_server_min_time_between_pings: 10s
+  grpc_server_ping_without_stream_allowed: true
   http_listen_port: 3100
-  http_server_read_timeout: 600s
-  http_server_write_timeout: 600s
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 10m0s
+  http_server_write_timeout: 10m0s
+  log_level: info
 storage_config:
   bloom_shipper:
     working_directory: /var/loki/data/bloomshipper
@@ -121,6 +134,7 @@ storage_config:
     resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+  use_thanos_objstore: false
 compactor:
   working_directory: /var/loki/compactor
   retention_enabled: true

--- a/tests/templates/ekscluster/00-disabled/baseline/manifests/tracing/patches/tempo.yaml
+++ b/tests/templates/ekscluster/00-disabled/baseline/manifests/tracing/patches/tempo.yaml
@@ -91,7 +91,7 @@ query_frontend:
 server:
     grpc_server_max_recv_msg_size: 4194304
     grpc_server_max_send_msg_size: 4194304
-    http_listen_port: 3100
+    http_listen_port: 3200
     http_server_read_timeout: 30s
     http_server_write_timeout: 30s
     log_format: logfmt

--- a/tests/templates/ekscluster/01-full-nginx/baseline/manifests/logging/patches/loki-config.yaml
+++ b/tests/templates/ekscluster/01-full-nginx/baseline/manifests/logging/patches/loki-config.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2025-present SIGHUP s.r.l. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-#
 
 analytics:
   reporting_enabled: false
@@ -19,7 +18,7 @@ bloom_gateway:
     addresses: dnssrvnoa+_grpc._tcp.loki-distributed-bloom-gateway-headless.logging.svc.cluster.local
   enabled: false
 common:
-  compactor_address: 'http://loki-distributed-compactor:3100'
+  compactor_grpc_address: 'loki-distributed-compactor.logging.svc.cluster.local:9095'
   path_prefix: /var/loki
   replication_factor: 1
   storage:
@@ -32,11 +31,11 @@ common:
       s3forcepathstyle: true
 frontend:
   compress_responses: true
-  log_queries_longer_than: 5s 
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  log_queries_longer_than: 5s
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
   tail_proxy_url: http://loki-distributed-querier.logging.svc.cluster.local:3100
 frontend_worker:
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
 index_gateway:
   mode: simple
 ingester:
@@ -50,7 +49,6 @@ ingester:
         store: memberlist
       replication_factor: 1
   wal:
-    dir: /var/loki/wal
     flush_on_shutdown: true
 limits_config:
   allow_structured_metadata: true
@@ -63,8 +61,15 @@ limits_config:
   max_label_names_per_series: 30
   retention_period: 720h
 memberlist:
+  abort_if_cluster_join_fails: true
+  advertise_port: 7946
+  bind_port: 7946
   join_members:
-  - loki-distributed-memberlist
+  - loki-distributed-memberlist.logging.svc.cluster.local
+  max_join_backoff: 1m
+  max_join_retries: 10
+  min_join_backoff: 1s
+  rejoin_interval: 90s
 pattern_ingester:
   enabled: true
 querier:
@@ -88,7 +93,7 @@ schema_config:
     object_store: s3
     schema: v11
     store: boltdb-shipper
-  - from: "2025-05-15" 
+  - from: "2025-05-15"
     index:
       period: 24h
       prefix: index_
@@ -96,10 +101,18 @@ schema_config:
     schema: v13
     store: tsdb
 server:
+  graceful_shutdown_timeout: 5s
   grpc_listen_port: 9095
+  grpc_server_max_concurrent_streams: 1000
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  grpc_server_min_time_between_pings: 10s
+  grpc_server_ping_without_stream_allowed: true
   http_listen_port: 3100
-  http_server_read_timeout: 600s
-  http_server_write_timeout: 600s
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 10m0s
+  http_server_write_timeout: 10m0s
+  log_level: info
 storage_config:
   bloom_shipper:
     working_directory: /var/loki/data/bloomshipper
@@ -121,6 +134,7 @@ storage_config:
     resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+  use_thanos_objstore: false
 compactor:
   working_directory: /var/loki/compactor
   retention_enabled: true

--- a/tests/templates/ekscluster/01-full-nginx/baseline/manifests/tracing/patches/tempo.yaml
+++ b/tests/templates/ekscluster/01-full-nginx/baseline/manifests/tracing/patches/tempo.yaml
@@ -91,7 +91,7 @@ query_frontend:
 server:
     grpc_server_max_recv_msg_size: 4194304
     grpc_server_max_send_msg_size: 4194304
-    http_listen_port: 3100
+    http_listen_port: 3200
     http_server_read_timeout: 30s
     http_server_write_timeout: 30s
     log_format: logfmt

--- a/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/logging/patches/loki-config.yaml
+++ b/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/logging/patches/loki-config.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2025-present SIGHUP s.r.l. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-#
 
 analytics:
   reporting_enabled: false
@@ -19,7 +18,7 @@ bloom_gateway:
     addresses: dnssrvnoa+_grpc._tcp.loki-distributed-bloom-gateway-headless.logging.svc.cluster.local
   enabled: false
 common:
-  compactor_address: 'http://loki-distributed-compactor:3100'
+  compactor_grpc_address: 'loki-distributed-compactor.logging.svc.cluster.local:9095'
   path_prefix: /var/loki
   replication_factor: 1
   storage:
@@ -32,11 +31,11 @@ common:
       s3forcepathstyle: true
 frontend:
   compress_responses: true
-  log_queries_longer_than: 5s 
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  log_queries_longer_than: 5s
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
   tail_proxy_url: http://loki-distributed-querier.logging.svc.cluster.local:3100
 frontend_worker:
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
 index_gateway:
   mode: simple
 ingester:
@@ -50,7 +49,6 @@ ingester:
         store: memberlist
       replication_factor: 1
   wal:
-    dir: /var/loki/wal
     flush_on_shutdown: true
 limits_config:
   allow_structured_metadata: true
@@ -63,8 +61,15 @@ limits_config:
   max_label_names_per_series: 30
   retention_period: 720h
 memberlist:
+  abort_if_cluster_join_fails: true
+  advertise_port: 7946
+  bind_port: 7946
   join_members:
-  - loki-distributed-memberlist
+  - loki-distributed-memberlist.logging.svc.cluster.local
+  max_join_backoff: 1m
+  max_join_retries: 10
+  min_join_backoff: 1s
+  rejoin_interval: 90s
 pattern_ingester:
   enabled: true
 querier:
@@ -88,7 +93,7 @@ schema_config:
     object_store: s3
     schema: v11
     store: boltdb-shipper
-  - from: "2025-05-15" 
+  - from: "2025-05-15"
     index:
       period: 24h
       prefix: index_
@@ -96,10 +101,18 @@ schema_config:
     schema: v13
     store: tsdb
 server:
+  graceful_shutdown_timeout: 5s
   grpc_listen_port: 9095
+  grpc_server_max_concurrent_streams: 1000
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  grpc_server_min_time_between_pings: 10s
+  grpc_server_ping_without_stream_allowed: true
   http_listen_port: 3100
-  http_server_read_timeout: 600s
-  http_server_write_timeout: 600s
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 10m0s
+  http_server_write_timeout: 10m0s
+  log_level: info
 storage_config:
   bloom_shipper:
     working_directory: /var/loki/data/bloomshipper
@@ -121,6 +134,7 @@ storage_config:
     resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+  use_thanos_objstore: false
 compactor:
   working_directory: /var/loki/compactor
   retention_enabled: true

--- a/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/tracing/patches/tempo.yaml
+++ b/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/tracing/patches/tempo.yaml
@@ -91,7 +91,7 @@ query_frontend:
 server:
     grpc_server_max_recv_msg_size: 4194304
     grpc_server_max_send_msg_size: 4194304
-    http_listen_port: 3100
+    http_listen_port: 3200
     http_server_read_timeout: 30s
     http_server_write_timeout: 30s
     log_format: logfmt

--- a/tests/templates/kfddistribution/00-disabled/baseline/manifests/logging/patches/loki-config.yaml
+++ b/tests/templates/kfddistribution/00-disabled/baseline/manifests/logging/patches/loki-config.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2025-present SIGHUP s.r.l. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-#
 
 analytics:
   reporting_enabled: false
@@ -19,7 +18,7 @@ bloom_gateway:
     addresses: dnssrvnoa+_grpc._tcp.loki-distributed-bloom-gateway-headless.logging.svc.cluster.local
   enabled: false
 common:
-  compactor_address: 'http://loki-distributed-compactor:3100'
+  compactor_grpc_address: 'loki-distributed-compactor.logging.svc.cluster.local:9095'
   path_prefix: /var/loki
   replication_factor: 1
   storage:
@@ -32,11 +31,11 @@ common:
       s3forcepathstyle: true
 frontend:
   compress_responses: true
-  log_queries_longer_than: 5s 
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  log_queries_longer_than: 5s
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
   tail_proxy_url: http://loki-distributed-querier.logging.svc.cluster.local:3100
 frontend_worker:
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
 index_gateway:
   mode: simple
 ingester:
@@ -50,7 +49,6 @@ ingester:
         store: memberlist
       replication_factor: 1
   wal:
-    dir: /var/loki/wal
     flush_on_shutdown: true
 limits_config:
   allow_structured_metadata: true
@@ -63,8 +61,15 @@ limits_config:
   max_label_names_per_series: 30
   retention_period: 720h
 memberlist:
+  abort_if_cluster_join_fails: true
+  advertise_port: 7946
+  bind_port: 7946
   join_members:
-  - loki-distributed-memberlist
+  - loki-distributed-memberlist.logging.svc.cluster.local
+  max_join_backoff: 1m
+  max_join_retries: 10
+  min_join_backoff: 1s
+  rejoin_interval: 90s
 pattern_ingester:
   enabled: true
 querier:
@@ -88,7 +93,7 @@ schema_config:
     object_store: s3
     schema: v11
     store: boltdb-shipper
-  - from: "2025-05-15" 
+  - from: "2025-05-15"
     index:
       period: 24h
       prefix: index_
@@ -96,10 +101,18 @@ schema_config:
     schema: v13
     store: tsdb
 server:
+  graceful_shutdown_timeout: 5s
   grpc_listen_port: 9095
+  grpc_server_max_concurrent_streams: 1000
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  grpc_server_min_time_between_pings: 10s
+  grpc_server_ping_without_stream_allowed: true
   http_listen_port: 3100
-  http_server_read_timeout: 600s
-  http_server_write_timeout: 600s
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 10m0s
+  http_server_write_timeout: 10m0s
+  log_level: info
 storage_config:
   bloom_shipper:
     working_directory: /var/loki/data/bloomshipper
@@ -121,6 +134,7 @@ storage_config:
     resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+  use_thanos_objstore: false
 compactor:
   working_directory: /var/loki/compactor
   retention_enabled: true

--- a/tests/templates/kfddistribution/00-disabled/baseline/manifests/tracing/patches/tempo.yaml
+++ b/tests/templates/kfddistribution/00-disabled/baseline/manifests/tracing/patches/tempo.yaml
@@ -91,7 +91,7 @@ query_frontend:
 server:
     grpc_server_max_recv_msg_size: 4194304
     grpc_server_max_send_msg_size: 4194304
-    http_listen_port: 3100
+    http_listen_port: 3200
     http_server_read_timeout: 30s
     http_server_write_timeout: 30s
     log_format: logfmt

--- a/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/logging/patches/loki-config.yaml
+++ b/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/logging/patches/loki-config.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2025-present SIGHUP s.r.l. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-#
 
 analytics:
   reporting_enabled: false
@@ -19,7 +18,7 @@ bloom_gateway:
     addresses: dnssrvnoa+_grpc._tcp.loki-distributed-bloom-gateway-headless.logging.svc.cluster.local
   enabled: false
 common:
-  compactor_address: 'http://loki-distributed-compactor:3100'
+  compactor_grpc_address: 'loki-distributed-compactor.logging.svc.cluster.local:9095'
   path_prefix: /var/loki
   replication_factor: 1
   storage:
@@ -32,11 +31,11 @@ common:
       s3forcepathstyle: true
 frontend:
   compress_responses: true
-  log_queries_longer_than: 5s 
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  log_queries_longer_than: 5s
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
   tail_proxy_url: http://loki-distributed-querier.logging.svc.cluster.local:3100
 frontend_worker:
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
 index_gateway:
   mode: simple
 ingester:
@@ -50,7 +49,6 @@ ingester:
         store: memberlist
       replication_factor: 1
   wal:
-    dir: /var/loki/wal
     flush_on_shutdown: true
 limits_config:
   allow_structured_metadata: true
@@ -63,8 +61,15 @@ limits_config:
   max_label_names_per_series: 30
   retention_period: 720h
 memberlist:
+  abort_if_cluster_join_fails: true
+  advertise_port: 7946
+  bind_port: 7946
   join_members:
-  - loki-distributed-memberlist
+  - loki-distributed-memberlist.logging.svc.cluster.local
+  max_join_backoff: 1m
+  max_join_retries: 10
+  min_join_backoff: 1s
+  rejoin_interval: 90s
 pattern_ingester:
   enabled: true
 querier:
@@ -88,7 +93,7 @@ schema_config:
     object_store: s3
     schema: v11
     store: boltdb-shipper
-  - from: "2025-05-15" 
+  - from: "2025-05-15"
     index:
       period: 24h
       prefix: index_
@@ -96,10 +101,18 @@ schema_config:
     schema: v13
     store: tsdb
 server:
+  graceful_shutdown_timeout: 5s
   grpc_listen_port: 9095
+  grpc_server_max_concurrent_streams: 1000
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  grpc_server_min_time_between_pings: 10s
+  grpc_server_ping_without_stream_allowed: true
   http_listen_port: 3100
-  http_server_read_timeout: 600s
-  http_server_write_timeout: 600s
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 10m0s
+  http_server_write_timeout: 10m0s
+  log_level: info
 storage_config:
   bloom_shipper:
     working_directory: /var/loki/data/bloomshipper
@@ -121,6 +134,7 @@ storage_config:
     resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+  use_thanos_objstore: false
 compactor:
   working_directory: /var/loki/compactor
   retention_enabled: true

--- a/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/tracing/patches/tempo.yaml
+++ b/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/tracing/patches/tempo.yaml
@@ -91,7 +91,7 @@ query_frontend:
 server:
     grpc_server_max_recv_msg_size: 4194304
     grpc_server_max_send_msg_size: 4194304
-    http_listen_port: 3100
+    http_listen_port: 3200
     http_server_read_timeout: 30s
     http_server_write_timeout: 30s
     log_format: logfmt

--- a/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/logging/patches/loki-config.yaml
+++ b/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/logging/patches/loki-config.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2025-present SIGHUP s.r.l. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-#
 
 analytics:
   reporting_enabled: false
@@ -19,7 +18,7 @@ bloom_gateway:
     addresses: dnssrvnoa+_grpc._tcp.loki-distributed-bloom-gateway-headless.logging.svc.cluster.local
   enabled: false
 common:
-  compactor_address: 'http://loki-distributed-compactor:3100'
+  compactor_grpc_address: 'loki-distributed-compactor.logging.svc.cluster.local:9095'
   path_prefix: /var/loki
   replication_factor: 1
   storage:
@@ -32,11 +31,11 @@ common:
       s3forcepathstyle: true
 frontend:
   compress_responses: true
-  log_queries_longer_than: 5s 
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  log_queries_longer_than: 5s
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
   tail_proxy_url: http://loki-distributed-querier.logging.svc.cluster.local:3100
 frontend_worker:
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
 index_gateway:
   mode: simple
 ingester:
@@ -50,7 +49,6 @@ ingester:
         store: memberlist
       replication_factor: 1
   wal:
-    dir: /var/loki/wal
     flush_on_shutdown: true
 limits_config:
   allow_structured_metadata: true
@@ -63,8 +61,15 @@ limits_config:
   max_label_names_per_series: 30
   retention_period: 720h
 memberlist:
+  abort_if_cluster_join_fails: true
+  advertise_port: 7946
+  bind_port: 7946
   join_members:
-  - loki-distributed-memberlist
+  - loki-distributed-memberlist.logging.svc.cluster.local
+  max_join_backoff: 1m
+  max_join_retries: 10
+  min_join_backoff: 1s
+  rejoin_interval: 90s
 pattern_ingester:
   enabled: true
 querier:
@@ -88,7 +93,7 @@ schema_config:
     object_store: s3
     schema: v11
     store: boltdb-shipper
-  - from: "2025-05-15" 
+  - from: "2025-05-15"
     index:
       period: 24h
       prefix: index_
@@ -96,10 +101,18 @@ schema_config:
     schema: v13
     store: tsdb
 server:
+  graceful_shutdown_timeout: 5s
   grpc_listen_port: 9095
+  grpc_server_max_concurrent_streams: 1000
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  grpc_server_min_time_between_pings: 10s
+  grpc_server_ping_without_stream_allowed: true
   http_listen_port: 3100
-  http_server_read_timeout: 600s
-  http_server_write_timeout: 600s
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 10m0s
+  http_server_write_timeout: 10m0s
+  log_level: info
 storage_config:
   bloom_shipper:
     working_directory: /var/loki/data/bloomshipper
@@ -121,6 +134,7 @@ storage_config:
     resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+  use_thanos_objstore: false
 compactor:
   working_directory: /var/loki/compactor
   retention_enabled: true

--- a/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/tracing/patches/tempo.yaml
+++ b/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/tracing/patches/tempo.yaml
@@ -91,7 +91,7 @@ query_frontend:
 server:
     grpc_server_max_recv_msg_size: 4194304
     grpc_server_max_send_msg_size: 4194304
-    http_listen_port: 3100
+    http_listen_port: 3200
     http_server_read_timeout: 30s
     http_server_write_timeout: 30s
     log_format: logfmt

--- a/tests/templates/onpremises/00-disabled/baseline/manifests/logging/patches/loki-config.yaml
+++ b/tests/templates/onpremises/00-disabled/baseline/manifests/logging/patches/loki-config.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2025-present SIGHUP s.r.l. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-#
 
 analytics:
   reporting_enabled: false
@@ -19,7 +18,7 @@ bloom_gateway:
     addresses: dnssrvnoa+_grpc._tcp.loki-distributed-bloom-gateway-headless.logging.svc.cluster.local
   enabled: false
 common:
-  compactor_address: 'http://loki-distributed-compactor:3100'
+  compactor_grpc_address: 'loki-distributed-compactor.logging.svc.cluster.local:9095'
   path_prefix: /var/loki
   replication_factor: 1
   storage:
@@ -32,11 +31,11 @@ common:
       s3forcepathstyle: true
 frontend:
   compress_responses: true
-  log_queries_longer_than: 5s 
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  log_queries_longer_than: 5s
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
   tail_proxy_url: http://loki-distributed-querier.logging.svc.cluster.local:3100
 frontend_worker:
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
 index_gateway:
   mode: simple
 ingester:
@@ -50,7 +49,6 @@ ingester:
         store: memberlist
       replication_factor: 1
   wal:
-    dir: /var/loki/wal
     flush_on_shutdown: true
 limits_config:
   allow_structured_metadata: true
@@ -63,8 +61,15 @@ limits_config:
   max_label_names_per_series: 30
   retention_period: 720h
 memberlist:
+  abort_if_cluster_join_fails: true
+  advertise_port: 7946
+  bind_port: 7946
   join_members:
-  - loki-distributed-memberlist
+  - loki-distributed-memberlist.logging.svc.cluster.local
+  max_join_backoff: 1m
+  max_join_retries: 10
+  min_join_backoff: 1s
+  rejoin_interval: 90s
 pattern_ingester:
   enabled: true
 querier:
@@ -88,7 +93,7 @@ schema_config:
     object_store: s3
     schema: v11
     store: boltdb-shipper
-  - from: "2025-05-15" 
+  - from: "2025-05-15"
     index:
       period: 24h
       prefix: index_
@@ -96,10 +101,18 @@ schema_config:
     schema: v13
     store: tsdb
 server:
+  graceful_shutdown_timeout: 5s
   grpc_listen_port: 9095
+  grpc_server_max_concurrent_streams: 1000
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  grpc_server_min_time_between_pings: 10s
+  grpc_server_ping_without_stream_allowed: true
   http_listen_port: 3100
-  http_server_read_timeout: 600s
-  http_server_write_timeout: 600s
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 10m0s
+  http_server_write_timeout: 10m0s
+  log_level: info
 storage_config:
   bloom_shipper:
     working_directory: /var/loki/data/bloomshipper
@@ -121,6 +134,7 @@ storage_config:
     resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+  use_thanos_objstore: false
 compactor:
   working_directory: /var/loki/compactor
   retention_enabled: true

--- a/tests/templates/onpremises/00-disabled/baseline/manifests/tracing/patches/tempo.yaml
+++ b/tests/templates/onpremises/00-disabled/baseline/manifests/tracing/patches/tempo.yaml
@@ -91,7 +91,7 @@ query_frontend:
 server:
     grpc_server_max_recv_msg_size: 4194304
     grpc_server_max_send_msg_size: 4194304
-    http_listen_port: 3100
+    http_listen_port: 3200
     http_server_read_timeout: 30s
     http_server_write_timeout: 30s
     log_format: logfmt

--- a/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/logging/patches/loki-config.yaml
+++ b/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/logging/patches/loki-config.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2025-present SIGHUP s.r.l. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-#
 
 analytics:
   reporting_enabled: false
@@ -19,7 +18,7 @@ bloom_gateway:
     addresses: dnssrvnoa+_grpc._tcp.loki-distributed-bloom-gateway-headless.logging.svc.cluster.local
   enabled: false
 common:
-  compactor_address: 'http://loki-distributed-compactor:3100'
+  compactor_grpc_address: 'loki-distributed-compactor.logging.svc.cluster.local:9095'
   path_prefix: /var/loki
   replication_factor: 1
   storage:
@@ -32,11 +31,11 @@ common:
       s3forcepathstyle: true
 frontend:
   compress_responses: true
-  log_queries_longer_than: 5s 
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  log_queries_longer_than: 5s
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
   tail_proxy_url: http://loki-distributed-querier.logging.svc.cluster.local:3100
 frontend_worker:
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
 index_gateway:
   mode: simple
 ingester:
@@ -50,7 +49,6 @@ ingester:
         store: memberlist
       replication_factor: 1
   wal:
-    dir: /var/loki/wal
     flush_on_shutdown: true
 limits_config:
   allow_structured_metadata: true
@@ -63,8 +61,15 @@ limits_config:
   max_label_names_per_series: 30
   retention_period: 720h
 memberlist:
+  abort_if_cluster_join_fails: true
+  advertise_port: 7946
+  bind_port: 7946
   join_members:
-  - loki-distributed-memberlist
+  - loki-distributed-memberlist.logging.svc.cluster.local
+  max_join_backoff: 1m
+  max_join_retries: 10
+  min_join_backoff: 1s
+  rejoin_interval: 90s
 pattern_ingester:
   enabled: true
 querier:
@@ -88,7 +93,7 @@ schema_config:
     object_store: s3
     schema: v11
     store: boltdb-shipper
-  - from: "2025-05-15" 
+  - from: "2025-05-15"
     index:
       period: 24h
       prefix: index_
@@ -96,10 +101,18 @@ schema_config:
     schema: v13
     store: tsdb
 server:
+  graceful_shutdown_timeout: 5s
   grpc_listen_port: 9095
+  grpc_server_max_concurrent_streams: 1000
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  grpc_server_min_time_between_pings: 10s
+  grpc_server_ping_without_stream_allowed: true
   http_listen_port: 3100
-  http_server_read_timeout: 600s
-  http_server_write_timeout: 600s
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 10m0s
+  http_server_write_timeout: 10m0s
+  log_level: info
 storage_config:
   bloom_shipper:
     working_directory: /var/loki/data/bloomshipper
@@ -121,6 +134,7 @@ storage_config:
     resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+  use_thanos_objstore: false
 compactor:
   working_directory: /var/loki/compactor
   retention_enabled: true

--- a/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/tracing/patches/tempo.yaml
+++ b/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/tracing/patches/tempo.yaml
@@ -91,7 +91,7 @@ query_frontend:
 server:
     grpc_server_max_recv_msg_size: 4194304
     grpc_server_max_send_msg_size: 4194304
-    http_listen_port: 3100
+    http_listen_port: 3200
     http_server_read_timeout: 30s
     http_server_write_timeout: 30s
     log_format: logfmt

--- a/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/logging/patches/loki-config.yaml
+++ b/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/logging/patches/loki-config.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2025-present SIGHUP s.r.l. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-#
 
 analytics:
   reporting_enabled: false
@@ -19,7 +18,7 @@ bloom_gateway:
     addresses: dnssrvnoa+_grpc._tcp.loki-distributed-bloom-gateway-headless.logging.svc.cluster.local
   enabled: false
 common:
-  compactor_address: 'http://loki-distributed-compactor:3100'
+  compactor_grpc_address: 'loki-distributed-compactor.logging.svc.cluster.local:9095'
   path_prefix: /var/loki
   replication_factor: 1
   storage:
@@ -32,11 +31,11 @@ common:
       s3forcepathstyle: true
 frontend:
   compress_responses: true
-  log_queries_longer_than: 5s 
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  log_queries_longer_than: 5s
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
   tail_proxy_url: http://loki-distributed-querier.logging.svc.cluster.local:3100
 frontend_worker:
-  scheduler_address: loki-distributed-query-scheduler.logging.svc.cluster.local:9095
+  scheduler_address: loki-distributed-query-scheduler-headless.logging.svc.cluster.local:9095
 index_gateway:
   mode: simple
 ingester:
@@ -50,7 +49,6 @@ ingester:
         store: memberlist
       replication_factor: 1
   wal:
-    dir: /var/loki/wal
     flush_on_shutdown: true
 limits_config:
   allow_structured_metadata: true
@@ -63,8 +61,15 @@ limits_config:
   max_label_names_per_series: 30
   retention_period: 720h
 memberlist:
+  abort_if_cluster_join_fails: true
+  advertise_port: 7946
+  bind_port: 7946
   join_members:
-  - loki-distributed-memberlist
+  - loki-distributed-memberlist.logging.svc.cluster.local
+  max_join_backoff: 1m
+  max_join_retries: 10
+  min_join_backoff: 1s
+  rejoin_interval: 90s
 pattern_ingester:
   enabled: true
 querier:
@@ -88,7 +93,7 @@ schema_config:
     object_store: s3
     schema: v11
     store: boltdb-shipper
-  - from: "2025-05-15" 
+  - from: "2025-05-15"
     index:
       period: 24h
       prefix: index_
@@ -96,10 +101,18 @@ schema_config:
     schema: v13
     store: tsdb
 server:
+  graceful_shutdown_timeout: 5s
   grpc_listen_port: 9095
+  grpc_server_max_concurrent_streams: 1000
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  grpc_server_min_time_between_pings: 10s
+  grpc_server_ping_without_stream_allowed: true
   http_listen_port: 3100
-  http_server_read_timeout: 600s
-  http_server_write_timeout: 600s
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 10m0s
+  http_server_write_timeout: 10m0s
+  log_level: info
 storage_config:
   bloom_shipper:
     working_directory: /var/loki/data/bloomshipper
@@ -121,6 +134,7 @@ storage_config:
     resync_interval: 5s
     index_gateway_client:
       server_address: dns+loki-distributed-index-gateway-headless.logging.svc.cluster.local:9095
+  use_thanos_objstore: false
 compactor:
   working_directory: /var/loki/compactor
   retention_enabled: true

--- a/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/tracing/patches/tempo.yaml
+++ b/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/tracing/patches/tempo.yaml
@@ -91,7 +91,7 @@ query_frontend:
 server:
     grpc_server_max_recv_msg_size: 4194304
     grpc_server_max_send_msg_size: 4194304
-    http_listen_port: 3100
+    http_listen_port: 3200
     http_server_read_timeout: 30s
     http_server_write_timeout: 30s
     log_format: logfmt


### PR DESCRIPTION
### Summary 💡

Align distro patches with the module packages' configuration.

### Description 📝

Align distro patches with the module packages' configuration.
Aligned template tests.
PR with the configuration changes:
- Loki configuration: https://github.com/sighupio/module-logging/pull/208
- Tempo configuration: https://github.com/sighupio/module-tracing/pull/20

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- I tested in a local K8S that pods become ready.
- https://ci.sighup.io/sighupio/distribution/4928

### Future work 🔧

Not planned.

### Self-assessment checklist 🏁

- [x] My PR is has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent) <- **Not necessary**
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green