### PR TITLE
feat(distribution): add `customResources`

### DIFF
--- a/defaults/ekscluster-kfd-v1alpha2.yaml
+++ b/defaults/ekscluster-kfd-v1alpha2.yaml
@@ -3,6 +3,7 @@
 # license that can be found in the LICENSE file.
 
 data:
+  customResources: []
   customPatches:
     configMapGenerator: []
     secretGenerator: []

--- a/defaults/immutable-kfd-v1alpha2.yaml
+++ b/defaults/immutable-kfd-v1alpha2.yaml
@@ -3,6 +3,7 @@
 # license that can be found in the LICENSE file.
 
 data:
+  customResources: []
   customPatches:
     configMapGenerator: []
     secretGenerator: []

--- a/defaults/kfddistribution-kfd-v1alpha2.yaml
+++ b/defaults/kfddistribution-kfd-v1alpha2.yaml
@@ -3,6 +3,7 @@
 # license that can be found in the LICENSE file.
 
 data:
+  customResources: []
   customPatches:
     configMapGenerator: []
     secretGenerator: []

--- a/defaults/onpremises-kfd-v1alpha2.yaml
+++ b/defaults/onpremises-kfd-v1alpha2.yaml
@@ -3,6 +3,7 @@
 # license that can be found in the LICENSE file.
 
 data:
+  customResources: []
   customPatches:
     configMapGenerator: []
     secretGenerator: []

--- a/docs/releases/v1.35.0.md
+++ b/docs/releases/v1.35.0.md
@@ -22,6 +22,7 @@ This version adds support for Kubernetes 1.35 and updates modules.
 - [[#530](https://github.com/sighupio/distribution/pull/530)] Add support for a per-host `dnsZone` override in `furyctl.yaml` for `masters`, `etcd`, `nodes`, and `loadBalancers` host entries. When set on a host, the local value takes precedence over the global `spec.kubernetes.dnsZone` when computing `kubernetes_hostname` and `etcd_initial_cluster`. This makes it possible to assign different FQDNs to hosts in different DNS zones.
 - [[#505](https://github.com/sighupio/distribution/pull/505)] Support NFTables mode for kube-proxy.
 - [[#539](https://github.com/sighupio/distribution/pull/539)] Pin `ansible` (with its `python` + `uv` build toolchain and the galaxy collections) under `tools.common` in `kfd.yaml`, so `furyctl` installs a self-contained, versioned Ansible via the bundled mise for the `OnPremises` and `Immutable` kinds instead of requiring it on the host. Optional and backward compatible: distributions without the block keep using the host Ansible.
+- [[#543](https://github.com/sighupio/distribution/pull/543)] New `customResources` distribution field: add a new `customResources` field under the distribution phase configuration that allows the deployment of custom resources together with the distribution phase. This allows to solve some cyclic dependencies that could arise using Kustomize Plugins (like the storage). Plugins remain the preferred way to deploy additional resources.
 
 ## Bug Fixes 🐛
 

--- a/schemas/public/ekscluster-kfd-v1alpha2.json
+++ b/schemas/public/ekscluster-kfd-v1alpha2.json
@@ -1146,6 +1146,9 @@
         },
         "customPatches": {
           "$ref": "../public/spec-distribution-custompatches.json"
+        },
+        "customResources": {
+          "$ref": "../public/spec-distribution-customresources.json"
         }
       },
       "required": [

--- a/schemas/public/immutable-kfd-v1alpha2.json
+++ b/schemas/public/immutable-kfd-v1alpha2.json
@@ -1736,6 +1736,9 @@
         },
         "customPatches": {
           "$ref": "../public/spec-distribution-custompatches.json"
+        },
+        "customResources": {
+          "$ref": "../public/spec-distribution-customresources.json"
         }
       },
       "required": [

--- a/schemas/public/kfddistribution-kfd-v1alpha2.json
+++ b/schemas/public/kfddistribution-kfd-v1alpha2.json
@@ -83,6 +83,9 @@
         },
         "customPatches": {
           "$ref": "../public/spec-distribution-custompatches.json"
+        },
+        "customResources": {
+          "$ref": "../public/spec-distribution-customresources.json"
         }
       },
       "required": [

--- a/schemas/public/onpremises-kfd-v1alpha2.json
+++ b/schemas/public/onpremises-kfd-v1alpha2.json
@@ -935,6 +935,9 @@
         },
         "customPatches": {
           "$ref": "../public/spec-distribution-custompatches.json"
+        },
+        "customResources": {
+          "$ref": "../public/spec-distribution-customresources.json"
         }
       },
       "required": [

--- a/schemas/public/spec-distribution-customresources.json
+++ b/schemas/public/spec-distribution-customresources.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "string"
+  },
+  "description": "Add custom resources to the distribution phase. Each entry should point to a resource file, a kustomize base, or a remote resource (e.g. a git repository or URL). `customResources` should be used when you _need_ the resources to be applyed in the distribution phase together with the rest of the modules; prefer using Plugins instead when possible."
+}

--- a/templates/distribution/manifests/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/kustomization.yaml.tpl
@@ -36,6 +36,10 @@ resources:
   - tracing
 {{- end }}
 
+{{- if .spec.distribution.customResources }}
+  {{ .spec.distribution.customResources | toYaml | indent 2 | trim -}}
+{{- end }}
+
 {{- if .spec.distribution.customPatches.patchesStrategicMerge }}
 patchesStrategicMerge:
   {{ .spec.distribution.customPatches.patchesStrategicMerge | toYaml | indent 2 | trim -}}


### PR DESCRIPTION
### Summary 💡

Adds a `customResources` field to the distribution phase that allows to deploy additional custom resources together with the distribution phase.

Relates:
- https://github.com/sighupio/furyctl/pull/685

### Description 📝

Adds a `customResources` field to the distribution phase that allows to deploy additional custom resources together with the distribution phase.

Plugins should still be preferred, this new field can be useful though for resources that have cyclic dependencies with the distribution, for example the storage or CNI configuration like enabling GAPI.

Resources follow Kustomize's definition and are passed as-is to kustomize, so they can be all the resources kinds supported by kustomize (local files and folder, remote git repos, remote http resources, etc.)


`customResources` is a first-class sibling of `customPatches` under `spec.distribution` (resources aren't patches, so they don't belong nested under `customPatches`). It is a flat array of strings, mirroring kustomize's own top-level `resources:` list:

```yaml
spec:
  distribution:
    customResources:
      - ./gapi-calico                          # local base, relative to furyctl.yaml
      - ../../plugins/kustomize/localstorage   # local base outside the project (warns)
      - github.com/org/repo//modules/x?ref=v1  # remote ref
```

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested adding custom resources: local files, local kustomize folders, remote files, remote git repos
- [x] Tested apply still works not setting the new field


### Future work 🔧

We could now check if there's a default storage class being defined inside all the manifests and don't skip the deployment of stateful workload. Removing the need of a second apply of the distribution phase.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR is has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

