### PR TITLE
fix(immutable): set node booted after sshd

### DIFF
--- a/templates/infrastructure/immutable/butane/_helpers.tpl
+++ b/templates/infrastructure/immutable/butane/_helpers.tpl
@@ -271,6 +271,7 @@ passwd:
         Description=Report node status to furyctl
         Requires=network-online.target
         After=network-online.target
+        After=sshd.service
         ConditionFirstBoot=yes
 
         [Service]


### PR DESCRIPTION
### Summary 💡

Make the report node as booted systemd unit depend on SSHD.

### Description 📝

Report node as booted after sshd has started, so furyctl (via Ansible) can reach the nodes.

If we do it after the network is online we could fall in the case where the SSH daemon is not started yet and furyctl tried to connect to it, failing the apply procedure.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested successful Immutable kind cluster creation

### Future work 🔧

None

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
~~- [] I've updated the `docs/releases/unreleased.md` file (or equivalent)~~ N.A.
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

