### PR TITLE
fix(templates): add secret basic-auth in calico-system

### DIFF
--- a/templates/distribution/manifests/auth/secrets/basic-auth.yml.tpl
+++ b/templates/distribution/manifests/auth/secrets/basic-auth.yml.tpl
@@ -113,6 +113,22 @@ stringData:
 {{- end }}
 {{- end }}
 
+{{ if eq .spec.distribution.modules.networking.type "calico" }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: basic-auth
+  namespace: calico-system
+type: Opaque
+stringData:
+{{- if $useHAProxyFormat }}
+  {{ $username }}: '{{ $hashOnly }}'
+{{- else }}
+  auth: {{ $htpasswdFull }}
+{{- end }}
+{{- end }}
+
 {{ if eq .spec.distribution.modules.networking.type "cilium" }}
 ---
 apiVersion: v1


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.

By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterward.

Opening a PR in draft lets other team members know you're working on this change, and gives you a 
place to track your work in progress.

When opening PRs in Draft, **don't assign reviewers until the PR is ready for review**.

Once you are comfortable with the status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

This PR is a follow-up to https://github.com/sighupio/distribution/pull/504, which is necessary to define the secret required for basic-auth authentication type for the calico-system namespace.


<!-- If this PR is related to changes produced in other repos, like a Module, please link them below. -->
Relates: https://github.com/sighupio/distribution/pull/504


### Description 📝

See above.

### Breaking Changes 💔

<!--
If this PR introduces Breaking Changes, please include all the relevant information:
- What is changing
- What should the process for updating be
- Include examples if you can
-->

### Tests performed 🧪

- [x] Tested the change with SD version v1.35.0

### Future work 🔧

None.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

