### PR TITLE
fix(logging): update NetworkPolicies for the new dedicated job pod identities

### DIFF
--- a/docs/network-policies/modules/logging/opensearch.md
+++ b/docs/network-policies/modules/logging/opensearch.md
@@ -12,7 +12,8 @@ graph TD
         bucket[MinIO Bucket Setup<br/>app: minio-logging-buckets-setup]
         op[Logging Operator<br/>app.kubernetes.io/name: logging-operator]
         et[Event Tailer<br/>app.kubernetes.io/name: event-tailer]
-        job[OpenSearch Jobs]
+        ispj[Index Patterns Job<br/>app.kubernetes.io/name: opensearch-dashboards-patterns-job]
+        ismj[ISM Policy Job<br/>app.kubernetes.io/name: opensearch-ism-policy-job]
     end
 
     %% External and K8s Core Components
@@ -33,8 +34,8 @@ graph TD
     fd -->|"egress: all"| os
     osd -->|"9200/TCP"| os
     pom -->|"5601/TCP"| osd
-    job -->|"5601/TCP"| osd
-    job -->|"9200/TCP"| os
+    ispj -->|"5601/TCP"| osd
+    ismj -->|"9200/TCP"| os
     prom -->|"2020/TCP"| fb
     prom -->|"24231/TCP"| fd
     prom -->|"9108/TCP"| os

--- a/docs/releases/v1.35.0.md
+++ b/docs/releases/v1.35.0.md
@@ -63,7 +63,6 @@ This version adds support for Kubernetes 1.35 and updates modules.
 - [[#532](https://github.com/sighupio/distribution/pull/532)] Fix worker nodes not receiving custom registry in OnPremises clusters: `kubernetes_image_registry` was placed under `master.vars` instead of `all.vars` in the generated `hosts.yaml`, causing worker nodes to fall back to the default `registry.sighup.io/fury/on-premises` registry for the pause container (`sandbox_image`).
 - [[#537](https://github.com/sighupio/distribution/pull/537)] Fix `PrometheusOperatorRejectedResources` false positive: Deploy the AlertmanagerConfigs included with the monitoring module only when URLs are set for the webhooks they use, otherwise a `PrometheusOperatorRejectedResources` alert would be triggered because of missing Secrets causing alert noise.
 - [[#549](https://github.com/sighupio/distribution/pull/549)] Fix Gatekeeper Policy Manager NetworkPolicy blocking ingress traffic when auth provider is not SSO.
-- [[#550](https://github.com/sighupio/distribution/pull/550)] Fix logging module's index-patterns and ISM policy jobs NetworkPolicies to match the new pod labels introduced in `module-logging`.
 
 ## Breaking changes 💔
 

--- a/docs/releases/v1.35.0.md
+++ b/docs/releases/v1.35.0.md
@@ -63,6 +63,7 @@ This version adds support for Kubernetes 1.35 and updates modules.
 - [[#532](https://github.com/sighupio/distribution/pull/532)] Fix worker nodes not receiving custom registry in OnPremises clusters: `kubernetes_image_registry` was placed under `master.vars` instead of `all.vars` in the generated `hosts.yaml`, causing worker nodes to fall back to the default `registry.sighup.io/fury/on-premises` registry for the pause container (`sandbox_image`).
 - [[#537](https://github.com/sighupio/distribution/pull/537)] Fix `PrometheusOperatorRejectedResources` false positive: Deploy the AlertmanagerConfigs included with the monitoring module only when URLs are set for the webhooks they use, otherwise a `PrometheusOperatorRejectedResources` alert would be triggered because of missing Secrets causing alert noise.
 - [[#549](https://github.com/sighupio/distribution/pull/549)] Fix Gatekeeper Policy Manager NetworkPolicy blocking ingress traffic when auth provider is not SSO.
+- [[#550](https://github.com/sighupio/distribution/pull/550)] Fix logging module's index-patterns and ISM policy jobs NetworkPolicies to match the new pod labels introduced in `module-logging`.
 
 ## Breaking changes 💔
 

--- a/templates/distribution/manifests/logging/policies/opensearch-dashboards.yaml.tpl
+++ b/templates/distribution/manifests/logging/policies/opensearch-dashboards.yaml.tpl
@@ -47,8 +47,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch-dashboards
-              app.kubernetes.io/instance: opensearch-dashboards
+              app.kubernetes.io/name: opensearch-dashboards-patterns-job
+              app.kubernetes.io/instance: opensearch-dashboards-patterns-job
       ports:
         - port: 5601
           protocol: TCP
@@ -208,8 +208,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch-dashboards
-      app.kubernetes.io/instance: opensearch-dashboards
+      app.kubernetes.io/name: opensearch-dashboards-patterns-job
+      app.kubernetes.io/instance: opensearch-dashboards-patterns-job
   egress:
     - to:
         - podSelector:

--- a/templates/distribution/manifests/logging/policies/opensearch.yaml.tpl
+++ b/templates/distribution/manifests/logging/policies/opensearch.yaml.tpl
@@ -137,8 +137,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch
-              app.kubernetes.io/instance: opensearch
+              app.kubernetes.io/name: opensearch-ism-policy-job
+              app.kubernetes.io/instance: opensearch-ism-policy-job
       ports:
         - port: 9200
           protocol: TCP
@@ -156,8 +156,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch
-      app.kubernetes.io/instance: opensearch
+      app.kubernetes.io/name: opensearch-ism-policy-job
+      app.kubernetes.io/instance: opensearch-ism-policy-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/ekscluster/00-disabled/baseline/manifests/logging/policies/opensearch-dashboards.yaml
+++ b/tests/templates/ekscluster/00-disabled/baseline/manifests/logging/policies/opensearch-dashboards.yaml
@@ -47,8 +47,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch-dashboards
-              app.kubernetes.io/instance: opensearch-dashboards
+              app.kubernetes.io/name: opensearch-dashboards-patterns-job
+              app.kubernetes.io/instance: opensearch-dashboards-patterns-job
       ports:
         - port: 5601
           protocol: TCP
@@ -92,8 +92,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch-dashboards
-      app.kubernetes.io/instance: opensearch-dashboards
+      app.kubernetes.io/name: opensearch-dashboards-patterns-job
+      app.kubernetes.io/instance: opensearch-dashboards-patterns-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/ekscluster/00-disabled/baseline/manifests/logging/policies/opensearch.yaml
+++ b/tests/templates/ekscluster/00-disabled/baseline/manifests/logging/policies/opensearch.yaml
@@ -137,8 +137,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch
-              app.kubernetes.io/instance: opensearch
+              app.kubernetes.io/name: opensearch-ism-policy-job
+              app.kubernetes.io/instance: opensearch-ism-policy-job
       ports:
         - port: 9200
           protocol: TCP
@@ -156,8 +156,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch
-      app.kubernetes.io/instance: opensearch
+      app.kubernetes.io/name: opensearch-ism-policy-job
+      app.kubernetes.io/instance: opensearch-ism-policy-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/ekscluster/01-full-nginx/baseline/manifests/logging/policies/opensearch-dashboards.yaml
+++ b/tests/templates/ekscluster/01-full-nginx/baseline/manifests/logging/policies/opensearch-dashboards.yaml
@@ -47,8 +47,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch-dashboards
-              app.kubernetes.io/instance: opensearch-dashboards
+              app.kubernetes.io/name: opensearch-dashboards-patterns-job
+              app.kubernetes.io/instance: opensearch-dashboards-patterns-job
       ports:
         - port: 5601
           protocol: TCP
@@ -118,8 +118,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch-dashboards
-      app.kubernetes.io/instance: opensearch-dashboards
+      app.kubernetes.io/name: opensearch-dashboards-patterns-job
+      app.kubernetes.io/instance: opensearch-dashboards-patterns-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/ekscluster/01-full-nginx/baseline/manifests/logging/policies/opensearch.yaml
+++ b/tests/templates/ekscluster/01-full-nginx/baseline/manifests/logging/policies/opensearch.yaml
@@ -137,8 +137,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch
-              app.kubernetes.io/instance: opensearch
+              app.kubernetes.io/name: opensearch-ism-policy-job
+              app.kubernetes.io/instance: opensearch-ism-policy-job
       ports:
         - port: 9200
           protocol: TCP
@@ -156,8 +156,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch
-      app.kubernetes.io/instance: opensearch
+      app.kubernetes.io/name: opensearch-ism-policy-job
+      app.kubernetes.io/instance: opensearch-ism-policy-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/logging/policies/opensearch-dashboards.yaml
+++ b/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/logging/policies/opensearch-dashboards.yaml
@@ -47,8 +47,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch-dashboards
-              app.kubernetes.io/instance: opensearch-dashboards
+              app.kubernetes.io/name: opensearch-dashboards-patterns-job
+              app.kubernetes.io/instance: opensearch-dashboards-patterns-job
       ports:
         - port: 5601
           protocol: TCP
@@ -119,8 +119,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch-dashboards
-      app.kubernetes.io/instance: opensearch-dashboards
+      app.kubernetes.io/name: opensearch-dashboards-patterns-job
+      app.kubernetes.io/instance: opensearch-dashboards-patterns-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/logging/policies/opensearch.yaml
+++ b/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/logging/policies/opensearch.yaml
@@ -137,8 +137,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch
-              app.kubernetes.io/instance: opensearch
+              app.kubernetes.io/name: opensearch-ism-policy-job
+              app.kubernetes.io/instance: opensearch-ism-policy-job
       ports:
         - port: 9200
           protocol: TCP
@@ -156,8 +156,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch
-      app.kubernetes.io/instance: opensearch
+      app.kubernetes.io/name: opensearch-ism-policy-job
+      app.kubernetes.io/instance: opensearch-ism-policy-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/kfddistribution/00-disabled/baseline/manifests/logging/policies/opensearch-dashboards.yaml
+++ b/tests/templates/kfddistribution/00-disabled/baseline/manifests/logging/policies/opensearch-dashboards.yaml
@@ -47,8 +47,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch-dashboards
-              app.kubernetes.io/instance: opensearch-dashboards
+              app.kubernetes.io/name: opensearch-dashboards-patterns-job
+              app.kubernetes.io/instance: opensearch-dashboards-patterns-job
       ports:
         - port: 5601
           protocol: TCP
@@ -92,8 +92,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch-dashboards
-      app.kubernetes.io/instance: opensearch-dashboards
+      app.kubernetes.io/name: opensearch-dashboards-patterns-job
+      app.kubernetes.io/instance: opensearch-dashboards-patterns-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/kfddistribution/00-disabled/baseline/manifests/logging/policies/opensearch.yaml
+++ b/tests/templates/kfddistribution/00-disabled/baseline/manifests/logging/policies/opensearch.yaml
@@ -137,8 +137,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch
-              app.kubernetes.io/instance: opensearch
+              app.kubernetes.io/name: opensearch-ism-policy-job
+              app.kubernetes.io/instance: opensearch-ism-policy-job
       ports:
         - port: 9200
           protocol: TCP
@@ -156,8 +156,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch
-      app.kubernetes.io/instance: opensearch
+      app.kubernetes.io/name: opensearch-ism-policy-job
+      app.kubernetes.io/instance: opensearch-ism-policy-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/logging/policies/opensearch-dashboards.yaml
+++ b/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/logging/policies/opensearch-dashboards.yaml
@@ -47,8 +47,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch-dashboards
-              app.kubernetes.io/instance: opensearch-dashboards
+              app.kubernetes.io/name: opensearch-dashboards-patterns-job
+              app.kubernetes.io/instance: opensearch-dashboards-patterns-job
       ports:
         - port: 5601
           protocol: TCP
@@ -118,8 +118,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch-dashboards
-      app.kubernetes.io/instance: opensearch-dashboards
+      app.kubernetes.io/name: opensearch-dashboards-patterns-job
+      app.kubernetes.io/instance: opensearch-dashboards-patterns-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/logging/policies/opensearch.yaml
+++ b/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/logging/policies/opensearch.yaml
@@ -137,8 +137,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch
-              app.kubernetes.io/instance: opensearch
+              app.kubernetes.io/name: opensearch-ism-policy-job
+              app.kubernetes.io/instance: opensearch-ism-policy-job
       ports:
         - port: 9200
           protocol: TCP
@@ -156,8 +156,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch
-      app.kubernetes.io/instance: opensearch
+      app.kubernetes.io/name: opensearch-ism-policy-job
+      app.kubernetes.io/instance: opensearch-ism-policy-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/logging/policies/opensearch-dashboards.yaml
+++ b/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/logging/policies/opensearch-dashboards.yaml
@@ -47,8 +47,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch-dashboards
-              app.kubernetes.io/instance: opensearch-dashboards
+              app.kubernetes.io/name: opensearch-dashboards-patterns-job
+              app.kubernetes.io/instance: opensearch-dashboards-patterns-job
       ports:
         - port: 5601
           protocol: TCP
@@ -119,8 +119,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch-dashboards
-      app.kubernetes.io/instance: opensearch-dashboards
+      app.kubernetes.io/name: opensearch-dashboards-patterns-job
+      app.kubernetes.io/instance: opensearch-dashboards-patterns-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/logging/policies/opensearch.yaml
+++ b/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/logging/policies/opensearch.yaml
@@ -137,8 +137,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch
-              app.kubernetes.io/instance: opensearch
+              app.kubernetes.io/name: opensearch-ism-policy-job
+              app.kubernetes.io/instance: opensearch-ism-policy-job
       ports:
         - port: 9200
           protocol: TCP
@@ -156,8 +156,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch
-      app.kubernetes.io/instance: opensearch
+      app.kubernetes.io/name: opensearch-ism-policy-job
+      app.kubernetes.io/instance: opensearch-ism-policy-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/onpremises/00-disabled/baseline/manifests/logging/policies/opensearch-dashboards.yaml
+++ b/tests/templates/onpremises/00-disabled/baseline/manifests/logging/policies/opensearch-dashboards.yaml
@@ -47,8 +47,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch-dashboards
-              app.kubernetes.io/instance: opensearch-dashboards
+              app.kubernetes.io/name: opensearch-dashboards-patterns-job
+              app.kubernetes.io/instance: opensearch-dashboards-patterns-job
       ports:
         - port: 5601
           protocol: TCP
@@ -92,8 +92,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch-dashboards
-      app.kubernetes.io/instance: opensearch-dashboards
+      app.kubernetes.io/name: opensearch-dashboards-patterns-job
+      app.kubernetes.io/instance: opensearch-dashboards-patterns-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/onpremises/00-disabled/baseline/manifests/logging/policies/opensearch.yaml
+++ b/tests/templates/onpremises/00-disabled/baseline/manifests/logging/policies/opensearch.yaml
@@ -137,8 +137,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch
-              app.kubernetes.io/instance: opensearch
+              app.kubernetes.io/name: opensearch-ism-policy-job
+              app.kubernetes.io/instance: opensearch-ism-policy-job
       ports:
         - port: 9200
           protocol: TCP
@@ -156,8 +156,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch
-      app.kubernetes.io/instance: opensearch
+      app.kubernetes.io/name: opensearch-ism-policy-job
+      app.kubernetes.io/instance: opensearch-ism-policy-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/logging/policies/opensearch-dashboards.yaml
+++ b/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/logging/policies/opensearch-dashboards.yaml
@@ -47,8 +47,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch-dashboards
-              app.kubernetes.io/instance: opensearch-dashboards
+              app.kubernetes.io/name: opensearch-dashboards-patterns-job
+              app.kubernetes.io/instance: opensearch-dashboards-patterns-job
       ports:
         - port: 5601
           protocol: TCP
@@ -118,8 +118,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch-dashboards
-      app.kubernetes.io/instance: opensearch-dashboards
+      app.kubernetes.io/name: opensearch-dashboards-patterns-job
+      app.kubernetes.io/instance: opensearch-dashboards-patterns-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/logging/policies/opensearch.yaml
+++ b/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/logging/policies/opensearch.yaml
@@ -137,8 +137,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch
-              app.kubernetes.io/instance: opensearch
+              app.kubernetes.io/name: opensearch-ism-policy-job
+              app.kubernetes.io/instance: opensearch-ism-policy-job
       ports:
         - port: 9200
           protocol: TCP
@@ -156,8 +156,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch
-      app.kubernetes.io/instance: opensearch
+      app.kubernetes.io/name: opensearch-ism-policy-job
+      app.kubernetes.io/instance: opensearch-ism-policy-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/logging/policies/opensearch-dashboards.yaml
+++ b/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/logging/policies/opensearch-dashboards.yaml
@@ -47,8 +47,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch-dashboards
-              app.kubernetes.io/instance: opensearch-dashboards
+              app.kubernetes.io/name: opensearch-dashboards-patterns-job
+              app.kubernetes.io/instance: opensearch-dashboards-patterns-job
       ports:
         - port: 5601
           protocol: TCP
@@ -119,8 +119,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch-dashboards
-      app.kubernetes.io/instance: opensearch-dashboards
+      app.kubernetes.io/name: opensearch-dashboards-patterns-job
+      app.kubernetes.io/instance: opensearch-dashboards-patterns-job
   egress:
     - to:
         - podSelector:

--- a/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/logging/policies/opensearch.yaml
+++ b/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/logging/policies/opensearch.yaml
@@ -137,8 +137,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opensearch
-              app.kubernetes.io/instance: opensearch
+              app.kubernetes.io/name: opensearch-ism-policy-job
+              app.kubernetes.io/instance: opensearch-ism-policy-job
       ports:
         - port: 9200
           protocol: TCP
@@ -156,8 +156,8 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: opensearch
-      app.kubernetes.io/instance: opensearch
+      app.kubernetes.io/name: opensearch-ism-policy-job
+      app.kubernetes.io/instance: opensearch-ism-policy-job
   egress:
     - to:
         - podSelector:


### PR DESCRIPTION
### Summary 💡

Update the logging module's NetworkPolicies to match the new dedicated pod labels (`opensearch-dashboards-patterns-job`, `opensearch-ism-policy-job`) introduced upstream in sighupio/module-logging#222, which stop the index-patterns and ISM policy jobs from self-matching as endpoints of the Services they call.

Relates: sighupio/module-logging#222

### Description 📝

- `opensearch-dashboards.yaml.tpl`: `opensearch-dashboards-ingress-jobs` and `jobs-egress-opensearch-dashboards` now match `opensearch-dashboards-patterns-job`.
- `opensearch.yaml.tpl`: `opensearch-ingress-jobs` and `jobs-egress-opensearch` now match `opensearch-ism-policy-job`.
- Updated `docs/network-policies/modules/logging/opensearch.md` diagram and regenerated test baselines accordingly.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Network policies are applied using the `fix/index-pattern-initialization` branch of the module-logging

### Future work 🔧

None.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green
