### PR TITLE
fix(network-policies): update Calico's policies to allow access to the Whisker UI

### DIFF
--- a/templates/distribution/manifests/networking/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/networking/kustomization.yaml.tpl
@@ -36,7 +36,9 @@ resources:
     {{- end }}
 {{- end }}
 
-{{ if and (eq .spec.distribution.common.networkPoliciesEnabled true) (eq .spec.distribution.modules.networking.type "calico") $hasAnyIngress }}
+{{/* The Calico policies only grant the ingress controller access to the Whisker UI; they are not
+     SD network policies, so they don't depend on networkPoliciesEnabled field. */}}
+{{ if and (eq .spec.distribution.modules.networking.type "calico") $hasAnyIngress }}
   - policies
 {{- end }}
 

--- a/tests/templates/ekscluster/00-disabled/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/ekscluster/00-disabled/baseline/manifests/networking/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 
 
 
+
 patches:
   - path: patches/tigera/infra-nodes-and-mask.yaml
 

--- a/tests/templates/ekscluster/01-full-nginx/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/ekscluster/01-full-nginx/baseline/manifests/networking/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 
 
 
+
 patches:
   - path: patches/tigera/infra-nodes-and-mask.yaml
 

--- a/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/networking/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 
 
 
+
 patches:
   - path: patches/tigera/infra-nodes-and-mask.yaml
 

--- a/tests/templates/kfddistribution/00-disabled/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/kfddistribution/00-disabled/baseline/manifests/networking/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
 
 
 
+
 patches:
 

--- a/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/networking/kustomization.yaml
@@ -12,6 +12,8 @@ resources:
 
 
 
+  - policies
+
 patches:
   - path: patches/tigera/infra-nodes-and-mask.yaml
   - target:

--- a/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/networking/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 
 
 
+
 patches:
   - path: patches/cilium/infra-nodes.yaml
   - target:

--- a/tests/templates/onpremises/00-disabled/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/onpremises/00-disabled/baseline/manifests/networking/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 
 
 
+
 patches:
   - path: patches/tigera/infra-nodes-and-mask.yaml
   - target:

--- a/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/networking/kustomization.yaml
@@ -12,6 +12,8 @@ resources:
 
 
 
+  - policies
+
 patches:
   - path: patches/tigera/infra-nodes-and-mask.yaml
   - target:

--- a/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/networking/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 
 
 
+
 patches:
   - path: patches/cilium/infra-nodes.yaml
   - target:


### PR DESCRIPTION
### Summary 💡

Grants the ingress controller (nginx/haproxy) or Pomerium network access to the Calico Whisker UI regardless of the `networkPoliciesEnabled` setting, fixing a 503 on the Whisker ingress out of the box.

Relates: https://github.com/sighupio/distribution/pull/504

### Description 📝

The Tigera operator always denies all ingress traffic to the Whisker pod via Network Policy. With the `networkPoliciesEnabled` field at its default (false), the enabling policy that opens port 8081 to the ingress controller was never applied, so Whisker's Ingress had no reachable backend and returned 503.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested the change with SD version v1.35.0 with and without network policies.

### Future work 🔧

None.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

