### PR TITLE
feat(immutable): retry node status report

### DIFF
--- a/templates/infrastructure/immutable/butane/_helpers.tpl
+++ b/templates/infrastructure/immutable/butane/_helpers.tpl
@@ -295,7 +295,7 @@ passwd:
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/curl --retry 2 -X POST '{{ .ipxeServerURL }}/status?node={{ .node.hostname }}&status=booted'
+        ExecStart=/usr/bin/curl --retry 2 --retry-connrefused --connect-timeout 5 --max-time 15 --retry-max-time 40 -X POST '{{ .ipxeServerURL }}/status?node={{ .node.hostname }}&status=booted'
         RemainAfterExit=yes
 
 

--- a/templates/infrastructure/immutable/butane/_helpers.tpl
+++ b/templates/infrastructure/immutable/butane/_helpers.tpl
@@ -295,9 +295,9 @@ passwd:
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/curl -X POST '{{ .ipxeServerURL }}/status?node={{ .node.hostname }}&status=booted'
+        ExecStart=/usr/bin/curl --retry 2 -X POST '{{ .ipxeServerURL }}/status?node={{ .node.hostname }}&status=booted'
         RemainAfterExit=yes
-        
+
 
         [Install]
         WantedBy=multi-user.target

--- a/templates/infrastructure/immutable/butane/install-flatcar.bu.tpl
+++ b/templates/infrastructure/immutable/butane/install-flatcar.bu.tpl
@@ -49,7 +49,7 @@ systemd:
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/curl -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=installation-blocked'
+        ExecStart=/usr/bin/curl --retry 2 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=installation-blocked'
         RemainAfterExit=yes
 
         [Install]
@@ -67,20 +67,20 @@ systemd:
         [Service]
         Type=oneshot
         {{- if .ipxeServerPreInstallCommands }}
-        ExecStartPre=/usr/bin/curl -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=running%%20pre-install%%20commands'
+        ExecStartPre=/usr/bin/curl --retry 2 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=running%%20pre-install%%20commands'
         {{- range .ipxeServerPreInstallCommands }}
         ExecStartPre={{ . }}
         {{- end }}
         {{- end }}
-        ExecStartPre=/usr/bin/curl -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=installing'
+        ExecStartPre=/usr/bin/curl --retry 2 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=installing'
         ExecStart=/usr/bin/flatcar-install -d {{ .installDisk }} -i /opt/ignition/config.ign -b {{ .ipxeServerURL }}/assets/flatcar/{{ .arch }}
         {{- if .ipxeServerPostInstallCommands }}
-        ExecStartPost=/usr/bin/curl -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=running%%20post-install%%20commands'
+        ExecStartPost=/usr/bin/curl --retry 2 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=running%%20post-install%%20commands'
         {{- range .ipxeServerPostInstallCommands }}
         ExecStartPost={{ . }}
         {{- end }}
         {{- end }}
-        ExecStartPost=/usr/bin/curl -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=rebooting'
+        ExecStartPost=/usr/bin/curl --retry 2 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=rebooting'
         ExecStartPost=/usr/bin/systemctl --no-block reboot
         RemainAfterExit=yes
 

--- a/templates/infrastructure/immutable/butane/install-flatcar.bu.tpl
+++ b/templates/infrastructure/immutable/butane/install-flatcar.bu.tpl
@@ -49,7 +49,7 @@ systemd:
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/curl --retry 2 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=installation-blocked'
+        ExecStart=/usr/bin/curl --retry 2 --retry-connrefused --connect-timeout 5 --max-time 15 --retry-max-time 40 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=installation-blocked'
         RemainAfterExit=yes
 
         [Install]
@@ -67,20 +67,20 @@ systemd:
         [Service]
         Type=oneshot
         {{- if .ipxeServerPreInstallCommands }}
-        ExecStartPre=/usr/bin/curl --retry 2 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=running%%20pre-install%%20commands'
+        ExecStartPre=/usr/bin/curl --retry 2 --retry-connrefused --connect-timeout 5 --max-time 15 --retry-max-time 40 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=running%%20pre-install%%20commands'
         {{- range .ipxeServerPreInstallCommands }}
         ExecStartPre={{ . }}
         {{- end }}
         {{- end }}
-        ExecStartPre=/usr/bin/curl --retry 2 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=installing'
+        ExecStartPre=/usr/bin/curl --retry 2 --retry-connrefused --connect-timeout 5 --max-time 15 --retry-max-time 40 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=installing'
         ExecStart=/usr/bin/flatcar-install -d {{ .installDisk }} -i /opt/ignition/config.ign -b {{ .ipxeServerURL }}/assets/flatcar/{{ .arch }}
         {{- if .ipxeServerPostInstallCommands }}
-        ExecStartPost=/usr/bin/curl --retry 2 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=running%%20post-install%%20commands'
+        ExecStartPost=/usr/bin/curl --retry 2 --retry-connrefused --connect-timeout 5 --max-time 15 --retry-max-time 40 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=running%%20post-install%%20commands'
         {{- range .ipxeServerPostInstallCommands }}
         ExecStartPost={{ . }}
         {{- end }}
         {{- end }}
-        ExecStartPost=/usr/bin/curl --retry 2 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=rebooting'
+        ExecStartPost=/usr/bin/curl --retry 2 --retry-connrefused --connect-timeout 5 --max-time 15 --retry-max-time 40 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=rebooting'
         ExecStartPost=/usr/bin/systemctl --no-block reboot
         RemainAfterExit=yes
 


### PR DESCRIPTION
### Summary 💡

Add retries to the node status report commands, so in case of flaky networks we don't block the bootstrapping because of curl failing to post the status update.

### Description 📝

In case of flaky networks, the status update POST may fail and block the systemd unit. This PR adds 2 retries (3 attempts in total) to the curl command so it does not immediately fail.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Succesful node bootstrapping 

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
~~- [] I've updated the `docs/releases/unreleased.md` file (or equivalent)~~ Not relevant to release notes.
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [X] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

