### PR TITLE
feat: add schema validation and tests for apiServer access properties in ekscluster

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,15 @@
+# SIGHUP Distribution Release vTBD
+
+Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
+
+## New features 🌟
+
+- [[#553](https://github.com/sighupio/distribution/pull/553)] EKSCluster: added schema validation to require at least one of `privateAccess` or `publicAccess` to be `true` in the Kubernetes API server configuration.
+
+## Bug fixes 🐞
+
+TBD
+
+## Breaking Changes 💔
+
+TBD

--- a/schemas/public/ekscluster-kfd-v1alpha2.json
+++ b/schemas/public/ekscluster-kfd-v1alpha2.json
@@ -642,6 +642,22 @@
       "required": [
         "privateAccess",
         "publicAccess"
+      ],
+      "anyOf": [
+        {
+          "properties": {
+            "privateAccess": {
+              "const": true
+            }
+          }
+        },
+        {
+          "properties": {
+            "publicAccess": {
+              "const": true
+            }
+          }
+        }
       ]
     },
     "Spec.Kubernetes.NodePoolsCommon": {

--- a/tests/e2e/kfddistribution/schema.sh
+++ b/tests/e2e/kfddistribution/schema.sh
@@ -388,3 +388,21 @@ test_schema() {
 
     test_schema "public" "ekscluster-kfd-v1alpha2" "015-no" expect
 }
+
+@test "016 - ok (at least one of privateAccess/publicAccess is true)" {
+    info
+
+    test_schema "public" "ekscluster-kfd-v1alpha2" "016-ok" expect_ok
+}
+
+@test "016 - no (both privateAccess and publicAccess are false)" {
+    info
+
+    expect() {
+        expect_no "${1}"
+
+        assert_error_contains "/spec/kubernetes/apiServer" "anyOf" || return $?
+    }
+
+    test_schema "public" "ekscluster-kfd-v1alpha2" "016-no" expect
+}

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/016-no.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/016-no.yaml
@@ -1,0 +1,115 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given "spec.kubernetes.apiServer.privateAccess" is false
+# And "spec.kubernetes.apiServer.publicAccess" is false
+# When I validate the config against the schema
+# Then an error "anyOf" is returned (at least one of privateAccess/publicAccess must be true)
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: furyctl-dev-aws-al
+spec:
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.0.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.0.182.0/24
+            - 10.0.172.0/24
+            - 10.0.162.0/24
+          public:
+            - 10.0.20.0/24
+            - 10.0.30.0/24
+            - 10.0.40.0/24
+    vpn:
+      ssh:
+        allowedFromCidrs:
+          - 0.0.0.0/0
+        githubUsersName:
+          - jnardiello
+        publicKeys:
+          - ssh-ed25519 SomethingSomething engineering@sighup.io
+      vpnClientsSubnetCidr: 192.168.200.0/24
+  kubernetes:
+    apiServer:
+      privateAccess: false
+      privateAccessCidrs: ["0.0.0.0/0"]
+      publicAccessCidrs: []
+      publicAccess: false
+    nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
+    nodePoolsLaunchKind: both
+    nodePoolGlobalAmiType: "alinux2023"
+    nodePools:
+      - ami:
+          id: ami-01234567890123456
+          owner: "123456789012"
+        type: self-managed
+        instance:
+          type: t3.large
+        name: worker-eks
+        size:
+          max: 3
+          min: 2
+  distribution:
+    modules:
+      auth:
+        baseDomain: furyctl-demo.sighup.io
+        dex:
+          connectors: []
+        pomerium:
+          policy: "test"
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        provider:
+          type: sso
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: example-velero
+            region: eu-west-1
+      ingress:
+        baseDomain: furyctl-demo.sighup.io
+        dns:
+          private:
+            create: true
+            name: internal.furyctl-demo.sighup.io
+          public:
+            create: true
+            name: furyctl-demo.sighup.io
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: example@sighup.io
+            type: http01
+        nginx:
+          type: single
+      logging:
+        type: opensearch
+        opensearch:
+          type: single
+      policy:
+        type: gatekeeper
+        gatekeeper:
+          additionalExcludedNamespaces: []
+          installDefaultPolicies: true
+          enforcementAction: deny
+  distributionVersion: v1.24.1
+  region: eu-west-1
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: furyctl-test-eks
+          keyPrefix: furyctl-test
+          region: eu-west-1

--- a/tests/schemas/public/ekscluster-kfd-v1alpha2/016-ok.yaml
+++ b/tests/schemas/public/ekscluster-kfd-v1alpha2/016-ok.yaml
@@ -1,0 +1,115 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Tests the following cases:
+
+# Given "spec.kubernetes.apiServer.privateAccess" is false
+# And "spec.kubernetes.apiServer.publicAccess" is true
+# When I validate the config against the schema
+# Then no errors are returned (at least one of privateAccess/publicAccess is true)
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: EKSCluster
+metadata:
+  name: furyctl-dev-aws-al
+spec:
+  infrastructure:
+    vpc:
+      network:
+        cidr: 10.0.0.0/16
+        subnetsCidrs:
+          private:
+            - 10.0.182.0/24
+            - 10.0.172.0/24
+            - 10.0.162.0/24
+          public:
+            - 10.0.20.0/24
+            - 10.0.30.0/24
+            - 10.0.40.0/24
+    vpn:
+      ssh:
+        allowedFromCidrs:
+          - 0.0.0.0/0
+        githubUsersName:
+          - jnardiello
+        publicKeys:
+          - ssh-ed25519 SomethingSomething engineering@sighup.io
+      vpnClientsSubnetCidr: 192.168.200.0/24
+  kubernetes:
+    apiServer:
+      privateAccess: false
+      privateAccessCidrs: ["0.0.0.0/0"]
+      publicAccessCidrs: ["0.0.0.0/0"]
+      publicAccess: true
+    nodeAllowedSshPublicKey: ssh-ed25519 SomethingSomething engineering@sighup.io
+    nodePoolsLaunchKind: both
+    nodePoolGlobalAmiType: "alinux2023"
+    nodePools:
+      - ami:
+          id: ami-01234567890123456
+          owner: "123456789012"
+        type: self-managed
+        instance:
+          type: t3.large
+        name: worker-eks
+        size:
+          max: 3
+          min: 2
+  distribution:
+    modules:
+      auth:
+        baseDomain: furyctl-demo.sighup.io
+        dex:
+          connectors: []
+        pomerium:
+          policy: "test"
+          secrets:
+            COOKIE_SECRET: "test"
+            IDP_CLIENT_SECRET: "test"
+            SHARED_SECRET: "test"
+            SIGNING_KEY: "test"
+        provider:
+          type: sso
+      dr:
+        type: eks
+        velero:
+          eks:
+            bucketName: example-velero
+            region: eu-west-1
+      ingress:
+        baseDomain: furyctl-demo.sighup.io
+        dns:
+          private:
+            create: true
+            name: internal.furyctl-demo.sighup.io
+          public:
+            create: true
+            name: furyctl-demo.sighup.io
+        certManager:
+          clusterIssuer:
+            name: letsencrypt-fury
+            email: example@sighup.io
+            type: http01
+        nginx:
+          type: single
+      logging:
+        type: opensearch
+        opensearch:
+          type: single
+      policy:
+        type: gatekeeper
+        gatekeeper:
+          additionalExcludedNamespaces: []
+          installDefaultPolicies: true
+          enforcementAction: deny
+  distributionVersion: v1.24.1
+  region: eu-west-1
+  toolsConfiguration:
+    terraform:
+      state:
+        s3:
+          bucketName: furyctl-test-eks
+          keyPrefix: furyctl-test
+          region: eu-west-1


### PR DESCRIPTION
### Summary 💡

You can configure an EKSCluster with both private and public connectivity values ​​set to false.
This causes the EKSCluster creation on AWS to fail with a mid-installation error.
This PR adds schema validation and tests for apiServer access properties in EKSCluster


### Description 📝

The validation blocks the creation process if both privateAccess and publicAccess are false for apiServer.
```
furyctl validate config
INFO Downloading distribution...                  
ERRO error while validating against schema: jsonschema: '/spec/kubernetes/apiServer/privateAccess' does not validate with file:///var/folders/95/x7yhynm917xgmy89srftsv3w0000gn/T/furyctl-1001434894/data/schemas/public/ekscluster-kfd-v1alpha2.json#/properties/spec/$ref/properties/kubernetes/$ref/properties/apiServer/$ref/anyOf/0/properties/privateAccess/const: value must be true 
ERRO configuration file validation failed 
``` 

The error itself isn't very clear, but it's caused by version 5.3.1 of the jsonschema dependency of furyctl.
Upgrading the version to 6.0.2 makes the error clearer.
```
furyctl validate config
INFO Downloading distribution...                  
ERRO error while validating against schema: jsonschema validation failed with 'file:///var/folders/95/x7yhynm917xgmy89srftsv3w0000gn/T/furyctl-3813329265/data/schemas/public/ekscluster-kfd-v1alpha2.json#'
- at '/spec/kubernetes/apiServer': 'anyOf' failed
  - at '/spec/kubernetes/apiServer/privateAccess': value must be true
  - at '/spec/kubernetes/apiServer/publicAccess': value must be true 
ERRO configuration file validation failed   
```

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- Test privateAccess=false and publicAccess=false -> validation error ✅
- Test privateAccess=true and publicAccess=false -> validation OK ✅
- Test privateAccess=false and publicAccess=true -> validation OK ✅
- Test privateAccess=true and publicAccess=true -> validation OK ✅

### Future work 🔧

Update jsonschema dependency to 6.0.2 .

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green