### PR TITLE
feat(monitoring): use PrometheusAgent 3.10.0

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -5,6 +5,7 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 ## New features 🌟
 
 - [[#553](https://github.com/sighupio/distribution/pull/553)] EKSCluster: added schema validation to require at least one of `privateAccess` or `publicAccess` to be `true` in the Kubernetes API server configuration.
+- [[#554](https://github.com/sighupio/distribution/pull/554)] Monitoring: bump PrometheusAgent version to 3.10.0
 
 ## Bug fixes 🐞
 

--- a/templates/distribution/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml.tpl
@@ -9,7 +9,7 @@ metadata:
   namespace: monitoring
 spec:
   # image should be the same as the one used in prometheus-operated
-  image: registry.sighup.io/fury/prometheus/prometheus:v3.5.0
+  image: registry.sighup.io/fury/prometheus/prometheus:v3.10.0
   # version: 2.46.0
   replicas: 2
   externalLabels:

--- a/templates/distribution/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml.tpl
@@ -30,6 +30,7 @@ spec:
   probeSelector: {}
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
+  serviceDiscoveryRole: EndpointSlice
   scrapeConfigSelector: {}
 
   {{- $prometheusAgentArgs := dict "module" "monitoring" "package" "prometheusAgent" "spec" .spec }}

--- a/templates/distribution/manifests/monitoring/resources/prometheus-agent/rbac.yaml
+++ b/templates/distribution/manifests/monitoring/resources/prometheus-agent/rbac.yaml
@@ -29,6 +29,14 @@ rules:
       - configmaps
     verbs: ["get"]
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses

--- a/tests/templates/ekscluster/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/ekscluster/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -21,6 +21,7 @@ spec:
   probeSelector: {}
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
+  serviceDiscoveryRole: EndpointSlice
   scrapeConfigSelector: {}
   tolerations:
     - effect: NoSchedule

--- a/tests/templates/ekscluster/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/ekscluster/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: monitoring
 spec:
   # image should be the same as the one used in prometheus-operated
-  image: registry.sighup.io/fury/prometheus/prometheus:v3.5.0
+  image: registry.sighup.io/fury/prometheus/prometheus:v3.10.0
   # version: 2.46.0
   replicas: 2
   externalLabels:

--- a/tests/templates/ekscluster/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
+++ b/tests/templates/ekscluster/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
@@ -29,6 +29,14 @@ rules:
       - configmaps
     verbs: ["get"]
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses

--- a/tests/templates/ekscluster/01-full-nginx/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/ekscluster/01-full-nginx/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -21,6 +21,7 @@ spec:
   probeSelector: {}
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
+  serviceDiscoveryRole: EndpointSlice
   scrapeConfigSelector: {}
   tolerations:
     - effect: NoSchedule

--- a/tests/templates/ekscluster/01-full-nginx/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/ekscluster/01-full-nginx/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: monitoring
 spec:
   # image should be the same as the one used in prometheus-operated
-  image: registry.sighup.io/fury/prometheus/prometheus:v3.5.0
+  image: registry.sighup.io/fury/prometheus/prometheus:v3.10.0
   # version: 2.46.0
   replicas: 2
   externalLabels:

--- a/tests/templates/ekscluster/01-full-nginx/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
+++ b/tests/templates/ekscluster/01-full-nginx/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
@@ -29,6 +29,14 @@ rules:
       - configmaps
     verbs: ["get"]
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses

--- a/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: monitoring
 spec:
   # image should be the same as the one used in prometheus-operated
-  image: registry.sighup.io/fury/prometheus/prometheus:v3.5.0
+  image: registry.sighup.io/fury/prometheus/prometheus:v3.10.0
   # version: 2.46.0
   replicas: 2
   externalLabels:

--- a/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -21,6 +21,7 @@ spec:
   probeSelector: {}
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
+  serviceDiscoveryRole: EndpointSlice
   scrapeConfigSelector: {}
   tolerations:
     null

--- a/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
+++ b/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
@@ -29,6 +29,14 @@ rules:
       - configmaps
     verbs: ["get"]
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses

--- a/tests/templates/kfddistribution/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/kfddistribution/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: monitoring
 spec:
   # image should be the same as the one used in prometheus-operated
-  image: registry.sighup.io/fury/prometheus/prometheus:v3.5.0
+  image: registry.sighup.io/fury/prometheus/prometheus:v3.10.0
   # version: 2.46.0
   replicas: 2
   externalLabels:

--- a/tests/templates/kfddistribution/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/kfddistribution/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -21,6 +21,7 @@ spec:
   probeSelector: {}
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
+  serviceDiscoveryRole: EndpointSlice
   scrapeConfigSelector: {}
   tolerations:
     null

--- a/tests/templates/kfddistribution/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
+++ b/tests/templates/kfddistribution/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
@@ -29,6 +29,14 @@ rules:
       - configmaps
     verbs: ["get"]
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses

--- a/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: monitoring
 spec:
   # image should be the same as the one used in prometheus-operated
-  image: registry.sighup.io/fury/prometheus/prometheus:v3.5.0
+  image: registry.sighup.io/fury/prometheus/prometheus:v3.10.0
   # version: 2.46.0
   replicas: 2
   externalLabels:

--- a/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -21,6 +21,7 @@ spec:
   probeSelector: {}
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
+  serviceDiscoveryRole: EndpointSlice
   scrapeConfigSelector: {}
   tolerations:
     null

--- a/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
+++ b/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
@@ -29,6 +29,14 @@ rules:
       - configmaps
     verbs: ["get"]
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses

--- a/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: monitoring
 spec:
   # image should be the same as the one used in prometheus-operated
-  image: registry.sighup.io/fury/prometheus/prometheus:v3.5.0
+  image: registry.sighup.io/fury/prometheus/prometheus:v3.10.0
   # version: 2.46.0
   replicas: 2
   externalLabels:

--- a/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -21,6 +21,7 @@ spec:
   probeSelector: {}
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
+  serviceDiscoveryRole: EndpointSlice
   scrapeConfigSelector: {}
   tolerations:
     null

--- a/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
+++ b/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
@@ -29,6 +29,14 @@ rules:
       - configmaps
     verbs: ["get"]
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses

--- a/tests/templates/onpremises/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/onpremises/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: monitoring
 spec:
   # image should be the same as the one used in prometheus-operated
-  image: registry.sighup.io/fury/prometheus/prometheus:v3.5.0
+  image: registry.sighup.io/fury/prometheus/prometheus:v3.10.0
   # version: 2.46.0
   replicas: 2
   externalLabels:

--- a/tests/templates/onpremises/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/onpremises/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -21,6 +21,7 @@ spec:
   probeSelector: {}
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
+  serviceDiscoveryRole: EndpointSlice
   scrapeConfigSelector: {}
   tolerations:
     null

--- a/tests/templates/onpremises/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
+++ b/tests/templates/onpremises/00-disabled/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
@@ -29,6 +29,14 @@ rules:
       - configmaps
     verbs: ["get"]
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses

--- a/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -21,6 +21,7 @@ spec:
   probeSelector: {}
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
+  serviceDiscoveryRole: EndpointSlice
   scrapeConfigSelector: {}
   tolerations:
     - effect: NoSchedule

--- a/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: monitoring
 spec:
   # image should be the same as the one used in prometheus-operated
-  image: registry.sighup.io/fury/prometheus/prometheus:v3.5.0
+  image: registry.sighup.io/fury/prometheus/prometheus:v3.10.0
   # version: 2.46.0
   replicas: 2
   externalLabels:

--- a/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
+++ b/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
@@ -29,6 +29,14 @@ rules:
       - configmaps
     verbs: ["get"]
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses

--- a/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: monitoring
 spec:
   # image should be the same as the one used in prometheus-operated
-  image: registry.sighup.io/fury/prometheus/prometheus:v3.5.0
+  image: registry.sighup.io/fury/prometheus/prometheus:v3.10.0
   # version: 2.46.0
   replicas: 2
   externalLabels:

--- a/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
+++ b/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml
@@ -21,6 +21,7 @@ spec:
   probeSelector: {}
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
+  serviceDiscoveryRole: EndpointSlice
   scrapeConfigSelector: {}
   tolerations:
     null

--- a/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
+++ b/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/monitoring/resources/prometheus-agent/rbac.yaml
@@ -29,6 +29,14 @@ rules:
       - configmaps
     verbs: ["get"]
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses


### PR DESCRIPTION
### Summary 💡

Bump Prometheus Agent version to 3.10.0, aligning it with prometheus operated's version.

Relates:
- https://github.com/sighupio/module-monitoring/pull/251
- #555 

### Description 📝

See summary

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested distribution v1.35.0 with `monitoring.type=prometheusAgent` and there are no errors.

### Future work 🔧

See if it would be better to have the prometheusAgent resources in the monitoring module so we don't forget to bump this image when we upgrade.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

