### PR TITLE
fix: alertmanager configs patching

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -8,7 +8,7 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 
 ## Bug fixes 🐞
 
-TBD
+- [[#555](https://github.com/sighupio/distribution/pull/555)] Monitoring templates: don't try to patch the alertmanagerConfigs when they are not being deployed at all.
 
 ## Breaking Changes 💔
 

--- a/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
@@ -105,6 +105,7 @@ patches:
   {{- end }}
 {{- end }}
 {{- if .spec.distribution.modules.monitoring.alertmanager.installDefaultRules }}
+{{- if eq $monitoringType "prometheus" "mimir" }}
 {{- if eq .spec.distribution.modules.monitoring.alertmanager.deadManSwitchWebhookUrl "" }}
   - patch: |-
       $patch: delete
@@ -155,6 +156,7 @@ patches:
       metadata:
         namespace: monitoring
         name: k8s-slack-webhook
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if or (eq $monitoringType "prometheus") (eq $monitoringType "mimir") }}

--- a/tests/templates/ekscluster/00-disabled/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/ekscluster/00-disabled/baseline/manifests/monitoring/kustomization.yaml
@@ -27,27 +27,6 @@ patches:
       metadata:
         namespace: monitoring
         name: x509-certificate-exporter-data-plane
-  - patch: |-
-      $patch: delete
-      apiVersion: monitoring.coreos.com/v1alpha1
-      kind: AlertmanagerConfig
-      metadata:
-        namespace: monitoring
-        name: deadmanswitch
-  - patch: |-
-      $patch: delete
-      apiVersion: monitoring.coreos.com/v1alpha1
-      kind: AlertmanagerConfig
-      metadata:
-        namespace: monitoring
-        name: infra
-  - patch: |-
-      $patch: delete
-      apiVersion: monitoring.coreos.com/v1alpha1
-      kind: AlertmanagerConfig
-      metadata:
-        namespace: monitoring
-        name: k8s
 
 configMapGenerator:
 

--- a/tests/templates/kfddistribution/00-disabled/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/kfddistribution/00-disabled/baseline/manifests/monitoring/kustomization.yaml
@@ -20,27 +20,6 @@ resources:
 
 patches:
   - path: patches/infra-nodes.yml
-  - patch: |-
-      $patch: delete
-      apiVersion: monitoring.coreos.com/v1alpha1
-      kind: AlertmanagerConfig
-      metadata:
-        namespace: monitoring
-        name: deadmanswitch
-  - patch: |-
-      $patch: delete
-      apiVersion: monitoring.coreos.com/v1alpha1
-      kind: AlertmanagerConfig
-      metadata:
-        namespace: monitoring
-        name: infra
-  - patch: |-
-      $patch: delete
-      apiVersion: monitoring.coreos.com/v1alpha1
-      kind: AlertmanagerConfig
-      metadata:
-        namespace: monitoring
-        name: k8s
 
 configMapGenerator:
 

--- a/tests/templates/onpremises/00-disabled/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/onpremises/00-disabled/baseline/manifests/monitoring/kustomization.yaml
@@ -20,27 +20,6 @@ resources:
 
 patches:
   - path: patches/infra-nodes.yml
-  - patch: |-
-      $patch: delete
-      apiVersion: monitoring.coreos.com/v1alpha1
-      kind: AlertmanagerConfig
-      metadata:
-        namespace: monitoring
-        name: deadmanswitch
-  - patch: |-
-      $patch: delete
-      apiVersion: monitoring.coreos.com/v1alpha1
-      kind: AlertmanagerConfig
-      metadata:
-        namespace: monitoring
-        name: infra
-  - patch: |-
-      $patch: delete
-      apiVersion: monitoring.coreos.com/v1alpha1
-      kind: AlertmanagerConfig
-      metadata:
-        namespace: monitoring
-        name: k8s
 
 configMapGenerator:
 


### PR DESCRIPTION
### Summary 💡

Delete the alertmanagerConfigs when monitoring type is one of `prometheus` or `mimir`.

Relates:
- #554 

### Description 📝

Delete the alertmanagerConfigs when monitoring type is prometheus or mimir only.

Other monitoring types, like `prometheusAgent`, don't deploy the alertmanagerConfigs at all and the patching would fail with the following error:

```
ERRO error while creating cluster: error while executing distribution phase: error while executing phase: error running core distribution phase: error applying Distribution modules: error while running shell: /bin/sh sh <redacted>/furyctl/.furyctl/flatcar-dev/distribution/scripts/apply.sh: command failed - exit status 1
out:
err: Error: accumulating resources: accumulation err='accumulating resources from 'monitoring': read <redacted>/.furyctl/flatcar-dev/distribution/manifests/monitoring: is a directory': recursed accumulation of path '<redacted>/.furyctl/flatcar-dev/distribution/manifests/monitoring': no resource matches strategic merge patch "AlertmanagerConfig.v1alpha1.monitoring.coreos.com/deadmanswitch.monitoring": no matches for Id AlertmanagerConfig.v1alpha1.monitoring.coreos.com/deadmanswitch.monitoring; failed to find unique target for patch AlertmanagerConfig.v1alpha1.monitoring.coreos.com/deadmanswitch.monitoring
```


### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Successful deploy with monitoring.type = prometheusAgent
- [x] Successful deploy with monitoring.type = prometheus and no alertmanager webhooks configured (no alertmanagerConfigs created).
- [x] Successful deploy with monitoring.type = prometheus and some alertmanager wehbooks configured (only the right alertmanagerConfigs were created).

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

