### PR TITLE
fix(immutable): kube-proxy-less clusters

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -13,4 +13,4 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 
 ## Breaking Changes 💔
 
-TBD
+- [[#559](https://github.com/sighupio/distribution/pull/559)] Immutable: kube-proxy configuration in Kubernetes advanced configuration is now a `type` enum instead of an `enabled` boolean option, following OnPremises' schema. Disabling kube-proxy was actually not working for Immutable due to this inconsistency.

--- a/docs/schemas/immutable-kfd-v1alpha2.md
+++ b/docs/schemas/immutable-kfd-v1alpha2.md
@@ -7245,10 +7245,10 @@ Type of limit to apply (Server, Namespace, User, SourceAndObject).
 
 ### Properties
 
-| Property                                                                     | Type      | Required |
-|:-----------------------------------------------------------------------------|:----------|:---------|
-| [additionalProperties](#speckubernetesadvancedkubeproxyadditionalproperties) | `object`  | Optional |
-| [enabled](#speckubernetesadvancedkubeproxyenabled)                           | `boolean` | Optional |
+| Property                                                                     | Type     | Required |
+|:-----------------------------------------------------------------------------|:---------|:---------|
+| [additionalProperties](#speckubernetesadvancedkubeproxyadditionalproperties) | `object` | Optional |
+| [type](#speckubernetesadvancedkubeproxytype)                                 | `string` | Optional |
 
 ### Description
 
@@ -7256,13 +7256,22 @@ Configuration for the kube-proxy component.
 
 ## .spec.kubernetes.advanced.kubeProxy.additionalProperties
 
-## .spec.kubernetes.advanced.kubeProxy.enabled
+## .spec.kubernetes.advanced.kubeProxy.type
 
 ### Description
 
-Setting this option to `false` will skip the installation of the kube-proxy component and install the CNI plugin with the following configuration: Cilium in kube-proxy-replacement mode and Calico in eBPF mode. Default is `true`.
+The operating mode for kube-proxy. `none` skips kube-proxy installation and configures the CNI accordingly (Cilium in kube-proxy-replacement mode, Calico in eBPF mode).  `nftables` (default) installs kube-proxy in nftables mode.
 
-NOTE: Changing this option after the cluster has been created is not currently supported.
+NOTE: Changing the `type` after the cluster has been created is not currently supported.
+
+### Constraints
+
+**enum**: the value of this property must be equal to one of the following string values:
+
+| Value      |
+|:-----------|
+|`"none"`    |
+|`"nftables"`|
 
 ## .spec.kubernetes.advanced.kubeletConfiguration
 

--- a/rules/immutable-kfd-v1alpha2.yaml
+++ b/rules/immutable-kfd-v1alpha2.yaml
@@ -70,9 +70,10 @@ kubernetes:
   - path: .spec.kubernetes.controlPlane.members.*
     immutable: true
     description: "Control plane member configuration cannot be changed after cluster creation"
-  # kubeProxy can be disabled and reenabled in a live cluster, but requires manual intervention
+  # kubeProxy backend can be changed in a live cluster, but requires manual intervention
   # to reconfigure the kube-proxy DaemonSet. We could automate this in the future.
-  - path: .spec.kubernetes.advanced.kubeProxy.enabled
+  - path: .spec.kubernetes.advanced.kubeProxy.type
+    description: "Changes to kube-proxy backend are not currently supported"
     immutable: true
 
 distribution:

--- a/schemas/public/immutable-kfd-v1alpha2.json
+++ b/schemas/public/immutable-kfd-v1alpha2.json
@@ -1459,9 +1459,10 @@
           "description": "Configuration for the kube-proxy component.",
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean",
-              "description": "Setting this option to `false` will skip the installation of the kube-proxy component and install the CNI plugin with the following configuration: Cilium in kube-proxy-replacement mode and Calico in eBPF mode. Default is `true`.\n\nNOTE: Changing this option after the cluster has been created is not currently supported."
+            "type": {
+              "type": "string",
+              "enum": ["none", "nftables"],
+              "description": "The operating mode for kube-proxy. `none` skips kube-proxy installation and configures the CNI accordingly (Cilium in kube-proxy-replacement mode, Calico in eBPF mode).  `nftables` (default) installs kube-proxy in nftables mode.\n\nNOTE: Changing the `type` after the cluster has been created is not currently supported."
             },
             "additionalProperties": false
           }

--- a/templates/config/immutable-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/immutable-kfd-v1alpha2.yaml.tpl
@@ -273,7 +273,7 @@ spec:
     #   encryption:
     #     configuration: "{file://./secrets/etcd-encryption-config.yaml}"
     #   kubeProxy:
-    #     enabled: true
+    #     type: none  # disables kube-proxy and sets Calico in eBPF mode / Cilium in kube-proxy-replacement mode.
 
   # SIGHUP Distribution modules
   distribution:

--- a/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/monitoring/kustomization.yaml.tpl
@@ -2,13 +2,17 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+{{- $providerType := .spec.distribution.common.provider.type }}
 {{- $vendorPrefix := print "../" .spec.distribution.common.relativeVendorPath }}
 {{- $monitoringType := .spec.distribution.modules.monitoring.type }}
 {{- $installEnhancedHPAMetrics := .spec.distribution.modules.monitoring.prometheusAdapter.installEnhancedHPAMetrics }}
 {{- $haproxyType := .spec.distribution.modules.ingress.haproxy.type }}
 {{- $isBYOIC := .spec.distribution.modules.ingress.byoic.enabled }}
 {{- $hasAnyIngress := or (ne .spec.distribution.modules.ingress.nginx.type "none") (ne $haproxyType "none") $isBYOIC }}
-# rendering Kustomization file for monitoring type {{ $monitoringType }}
+{{- $defaultKubeProxyType := "ipvs" }}
+{{- if eq $providerType "immutable" }}
+  {{- $defaultKubeProxyType = "nftables" }}
+{{- end }}
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -18,14 +22,14 @@ resources:
   - kapp-configs/prometheus-operator-crd.yaml
   - {{ print $vendorPrefix "/modules/monitoring/katalog/prometheus-operator" }}
 {{- /* The `digAny` condition needs to be specified exactly as written below to properly check if the field has been populated */}}
-{{- if ne (.spec | digAny "kubernetes" "advanced" "kubeProxy" "type" "ipvs") "none" }}
+{{- if ne (.spec | digAny "kubernetes" "advanced" "kubeProxy" "type" $defaultKubeProxyType) "none" }}
   - {{ print $vendorPrefix "/modules/monitoring/katalog/kube-proxy-metrics" }}
 {{- end }}
   - {{ print $vendorPrefix "/modules/monitoring/katalog/kube-state-metrics" }}
   - {{ print $vendorPrefix "/modules/monitoring/katalog/node-exporter" }}
   - {{ print $vendorPrefix "/modules/monitoring/katalog/x509-exporter" }}
   - {{ print $vendorPrefix "/modules/monitoring/katalog/blackbox-exporter" }}
-{{- if eq .spec.distribution.common.provider.type "none" "immutable" }}{{/* none === on-premises and kfddistribution */}}
+{{- if eq $providerType "none" "immutable" }}{{/* none === on-premises and kfddistribution */}}
   - {{ print $vendorPrefix "/modules/monitoring/katalog/kubeadm-sm" }}
   {{- if or (.spec | digAny "kubernetes" "loadBalancers" "enabled" false) (gt (.spec | digAny "infrastructure" "loadBalancers" "members" list | len) 0) }}
   - {{ print $vendorPrefix "/modules/monitoring/katalog/haproxy" }}
@@ -35,7 +39,7 @@ resources:
   - resources/etcd-scrapeConfig.yaml
   {{- end }}
 {{- end }}
-{{- if eq .spec.distribution.common.provider.type "eks" }}
+{{- if eq $providerType "eks" }}
   - {{ print $vendorPrefix "/modules/monitoring/katalog/eks-sm" }}
 {{- end }}
 {{- if or (eq $monitoringType "prometheus") (eq $monitoringType "mimir") }}
@@ -85,7 +89,7 @@ patches:
         name: etcd-metrics
         namespace: kube-system
 {{- end }}
-{{- if eq .spec.distribution.common.provider.type "eks" }}{{/* in EKS there are no files to monitor on nodes */}}
+{{- if eq $providerType "eks" }}{{/* in EKS there are no files to monitor on nodes */}}
   - patch: |-
       $patch: delete
       apiVersion: apps/v1

--- a/templates/distribution/manifests/networking/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/networking/kustomization.yaml.tpl
@@ -2,23 +2,29 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+{{- $providerType := .spec.distribution.common.provider.type }}
+{{- $cni := .spec.distribution.modules.networking.type }}
 {{- $vendorPrefix := print "../" .spec.distribution.common.relativeVendorPath }}
 {{- $haproxyType := .spec.distribution.modules.ingress.haproxy.type }}
 {{- $isBYOIC := .spec.distribution.modules.ingress.byoic.enabled }}
 {{- $hasAnyIngress := or (ne .spec.distribution.modules.ingress.nginx.type "none") (ne $haproxyType "none") $isBYOIC }}
 {{- /* The `digAny` condition needs to be specified exactly as written below to properly check if the field has been populated */}}
-{{- $kubeProxyType := .spec | digAny "kubernetes" "advanced" "kubeProxy" "type" "ipvs" }}
+{{- $defaultKubeProxyType := "ipvs" }}
+{{- if eq $providerType "immutable" }}
+  {{- $defaultKubeProxyType = "nftables" }}
+{{- end }}
+{{- $kubeProxyType := .spec | digAny "kubernetes" "advanced" "kubeProxy" "type" $defaultKubeProxyType }}
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-{{- if eq .spec.distribution.common.provider.type "eks" }}
+{{- if eq $providerType "eks" }}
   - {{ print $vendorPrefix "/modules/networking/katalog/tigera/eks-policy-only" }}
 {{- end }}
 
-{{- if eq .spec.distribution.common.provider.type "none" "immutable" }}{{/* none == on-prem, kfddistribution */}}
-    {{- if eq .spec.distribution.modules.networking.type "calico" }}
+{{- if eq $providerType "none" "immutable" }}{{/* none == on-prem, kfddistribution */}}
+    {{- if eq $cni "calico" }}
   - {{ print $vendorPrefix "/modules/networking/katalog/tigera/on-prem" }}
   - resources/calico-ns.yml
       {{- if eq $kubeProxyType "none" }}
@@ -28,7 +34,7 @@ resources:
   - resources/whisker-ingress.yml
       {{- end }}
     {{- end }}
-    {{- if eq .spec.distribution.modules.networking.type "cilium" }}
+    {{- if eq $cni "cilium" }}
   - {{ print $vendorPrefix "/modules/networking/katalog/cilium" }}
       {{- if $hasAnyIngress }}
   - resources/ingress-infra.yml
@@ -38,19 +44,16 @@ resources:
 
 {{/* The Calico policies only grant the ingress controller access to the Whisker UI; they are not
      SD network policies, so they don't depend on networkPoliciesEnabled field. */}}
-{{ if and (eq .spec.distribution.modules.networking.type "calico") $hasAnyIngress }}
+{{ if and (eq $cni "calico") $hasAnyIngress }}
   - policies
 {{- end }}
 
 patches:
-{{- if eq .spec.distribution.common.provider.type "eks" }}
+{{- if eq $providerType "eks" }}
   - path: patches/tigera/infra-nodes-and-mask.yaml
 {{- end }}
-{{- if eq .spec.distribution.common.provider.type "none" "immutable" }}
-  {{- if eq .spec.distribution.modules.networking.type "calico" }}
-    {{- if eq .spec.distribution.common.provider.type "immutable" }}
-  - path: patches/tigera/nfTables-dataplane.yaml
-    {{- end }}
+{{- if eq $providerType "none" "immutable" }}
+  {{- if eq $cni "calico" }}
   - path: patches/tigera/infra-nodes-and-mask.yaml
   - target:
       group: apps
@@ -59,13 +62,13 @@ patches:
       name: tigera-operator
       namespace: tigera-operator
     path: patches/tigera/tigera-operator-tolerations.yaml
-  {{- if eq $kubeProxyType "none" }}
+    {{- if eq $kubeProxyType "none" }}
   - path: patches/tigera/ebpf-mode.yaml
-  {{- else if eq $kubeProxyType "nftables" }}
+    {{- else if eq $kubeProxyType "nftables" }}
   - path: patches/tigera/nfTables-dataplane.yaml
+    {{- end }}
   {{- end }}
-  {{- end }}
-  {{- if eq .spec.distribution.modules.networking.type "cilium" }}
+  {{- if eq $cni "cilium" }}
   - path: patches/cilium/infra-nodes.yaml
   - target:
       group: apps
@@ -80,8 +83,8 @@ patches:
   {{- end }}
 {{- end }}
 
-{{- if eq .spec.distribution.common.provider.type "none" "immutable" }}
-  {{- if eq .spec.distribution.modules.networking.type "cilium" }}
+{{- if eq $providerType "none" "immutable" }}
+  {{- if eq $cni "cilium" }}
 configMapGenerator:
   - behavior: merge
     envs:
@@ -90,4 +93,3 @@ configMapGenerator:
     namespace: kube-system
   {{- end }}
 {{- end }}
-

--- a/templates/distribution/manifests/networking/patches/cilium/cilium-config.env.tpl
+++ b/templates/distribution/manifests/networking/patches/cilium/cilium-config.env.tpl
@@ -1,4 +1,8 @@
 {{- $providerType := .spec.distribution.common.provider.type }}
+{{- $defaultKubeProxyType := "ipvs" }}
+{{- if eq $providerType "immutable" }}
+  {{- $defaultKubeProxyType = "nftables" }}
+{{- end }}
 
 {{- $podCIDR := "" }}
 {{- if and (eq $providerType "none") (hasKeyAny .spec "kubernetes") }}{{/* OnPremises */}}
@@ -14,6 +18,6 @@
 cluster-pool-ipv4-mask-size={{ .spec.distribution.modules.networking.cilium.maskSize }}
 cluster-pool-ipv4-cidr={{ $podCIDR }}
 {{- /* The `digAny` condition needs to be specified exactly as written below to properly check if the field has been populated */}}
-{{- if eq (.spec | digAny "kubernetes" "advanced" "kubeProxy" "type" "ipvs") "none" }}
+{{- if eq (.spec | digAny "kubernetes" "advanced" "kubeProxy" "type" $defaultKubeProxyType) "none" }}
 kube-proxy-replacement=true
 {{- end }}

--- a/templates/kubernetes/immutable/hosts.yaml.tpl
+++ b/templates/kubernetes/immutable/hosts.yaml.tpl
@@ -223,7 +223,7 @@ all:
     {{- end }}
     {{- /* We assume that kubeProxy is enabled by default */}}
     {{- /* The `digAny` condition needs to be specified exactly as written below to properly check if the field has been populated */}}
-    {{- if not (.spec | digAny "kubernetes" "advanced" "kubeProxy" "enabled" true) }}
+    {{- if eq (.spec | digAny "kubernetes" "advanced" "kubeProxy" "type" "nftables") "none" }}
     kubeadm_skip_phases:
       - "addon/kube-proxy"
     {{- end }}

--- a/tests/templates/ekscluster/00-disabled/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/ekscluster/00-disabled/baseline/manifests/monitoring/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-# rendering Kustomization file for monitoring type none
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/templates/ekscluster/00-disabled/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/ekscluster/00-disabled/baseline/manifests/networking/kustomization.yaml
@@ -13,4 +13,3 @@ resources:
 
 patches:
   - path: patches/tigera/infra-nodes-and-mask.yaml
-

--- a/tests/templates/ekscluster/01-full-nginx/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/ekscluster/01-full-nginx/baseline/manifests/monitoring/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-# rendering Kustomization file for monitoring type mimir
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/templates/ekscluster/01-full-nginx/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/ekscluster/01-full-nginx/baseline/manifests/networking/kustomization.yaml
@@ -13,4 +13,3 @@ resources:
 
 patches:
   - path: patches/tigera/infra-nodes-and-mask.yaml
-

--- a/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/monitoring/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-# rendering Kustomization file for monitoring type prometheus
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/networking/kustomization.yaml
@@ -13,4 +13,3 @@ resources:
 
 patches:
   - path: patches/tigera/infra-nodes-and-mask.yaml
-

--- a/tests/templates/immutable/00-disabled/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/immutable/00-disabled/baseline/manifests/monitoring/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-# rendering Kustomization file for monitoring type none
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/templates/immutable/00-disabled/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/immutable/00-disabled/baseline/manifests/networking/kustomization.yaml
@@ -13,7 +13,6 @@ resources:
 
 
 patches:
-  - path: patches/tigera/nfTables-dataplane.yaml
   - path: patches/tigera/infra-nodes-and-mask.yaml
   - target:
       group: apps
@@ -22,4 +21,4 @@ patches:
       name: tigera-operator
       namespace: tigera-operator
     path: patches/tigera/tigera-operator-tolerations.yaml
-
+  - path: patches/tigera/nfTables-dataplane.yaml

--- a/tests/templates/immutable/01-full-calico-nginx/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/immutable/01-full-calico-nginx/baseline/manifests/monitoring/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-# rendering Kustomization file for monitoring type mimir
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/templates/immutable/01-full-calico-nginx/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/immutable/01-full-calico-nginx/baseline/manifests/networking/kustomization.yaml
@@ -15,7 +15,6 @@ resources:
   - policies
 
 patches:
-  - path: patches/tigera/nfTables-dataplane.yaml
   - path: patches/tigera/infra-nodes-and-mask.yaml
   - target:
       group: apps
@@ -24,4 +23,4 @@ patches:
       name: tigera-operator
       namespace: tigera-operator
     path: patches/tigera/tigera-operator-tolerations.yaml
-
+  - path: patches/tigera/nfTables-dataplane.yaml

--- a/tests/templates/immutable/02-full-cilium-haproxy/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/immutable/02-full-cilium-haproxy/baseline/manifests/monitoring/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-# rendering Kustomization file for monitoring type prometheus
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/templates/immutable/02-full-cilium-haproxy/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/immutable/02-full-cilium-haproxy/baseline/manifests/networking/kustomization.yaml
@@ -27,4 +27,3 @@ configMapGenerator:
     - patches/cilium/cilium-config.env
     name: cilium-config
     namespace: kube-system
-

--- a/tests/templates/kfddistribution/00-disabled/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/kfddistribution/00-disabled/baseline/manifests/monitoring/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-# rendering Kustomization file for monitoring type none
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/templates/kfddistribution/00-disabled/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/kfddistribution/00-disabled/baseline/manifests/networking/kustomization.yaml
@@ -11,4 +11,3 @@ resources:
 
 
 patches:
-

--- a/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/monitoring/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-# rendering Kustomization file for monitoring type mimir
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/networking/kustomization.yaml
@@ -23,4 +23,3 @@ patches:
       name: tigera-operator
       namespace: tigera-operator
     path: patches/tigera/tigera-operator-tolerations.yaml
-

--- a/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/monitoring/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-# rendering Kustomization file for monitoring type prometheus
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/networking/kustomization.yaml
@@ -27,4 +27,3 @@ configMapGenerator:
     - patches/cilium/cilium-config.env
     name: cilium-config
     namespace: kube-system
-

--- a/tests/templates/onpremises/00-disabled/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/onpremises/00-disabled/baseline/manifests/monitoring/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-# rendering Kustomization file for monitoring type none
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/templates/onpremises/00-disabled/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/onpremises/00-disabled/baseline/manifests/networking/kustomization.yaml
@@ -21,4 +21,3 @@ patches:
       name: tigera-operator
       namespace: tigera-operator
     path: patches/tigera/tigera-operator-tolerations.yaml
-

--- a/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/monitoring/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-# rendering Kustomization file for monitoring type mimir
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/networking/kustomization.yaml
@@ -23,4 +23,3 @@ patches:
       name: tigera-operator
       namespace: tigera-operator
     path: patches/tigera/tigera-operator-tolerations.yaml
-

--- a/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/monitoring/kustomization.yaml
+++ b/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/monitoring/kustomization.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-# rendering Kustomization file for monitoring type prometheus
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/networking/kustomization.yaml
+++ b/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/networking/kustomization.yaml
@@ -27,4 +27,3 @@ configMapGenerator:
     - patches/cilium/cilium-config.env
     name: cilium-config
     namespace: kube-system
-


### PR DESCRIPTION
### Summary 💡

Fixes templates logic for Immutable clusters without kube-proxy

Relates:
- #558 
- #505 

### Description 📝

Since the change from a boolean to an enum of kube-proxy's configuration for onPremises, disabling kube-proxy for Immutable clusters was broken because it was not considered in the templates logic change.

This PR:
- Aligns the Immutable schema with onPremises changing from a boolean to an enum for future proofing and to simplify the templates logic.
- Updates templates logic to consider Immutable kind for kube-proxy configuration.
- Updates the templates regressions test baseline.

> [!NOTE]
> Immutable does not support IPVS at all. The default has always been nfTables instead.

### Breaking Changes 💔

kube-proxy configuration is not a boolean anymore and is an enum now.

`furyctl.yaml` before:
```yaml
...
kind: Immutable
spec:
  kubernetes:
    advanced:
      kubeProxy:
        enabled: false
```

`furyctl.yaml` after:
```yaml
...
kind: Immutable
spec:
  kubernetes:
    advanced:
      kubeProxy:
        type: none
```

### Tests performed 🧪

- [x] Tested Immutable on cilium with kube-proxy
- [x] Tested Immutable on cilium without kube-proxy
- [x] Tested Immutable on calico with kube-proxy
- [x] Tested Immutable on calico without kube-proxy
- [x] There are no regressions for the other kinds running `mise run test:templates:regressions`
- [x] Tested immutability rule works:
```
ERRO error while creating cluster: error while executing preflight phase: error checking state diffs: immutable path changed: immutable value changed: path .spec.kubernetes.advanced.kubeProxy.type  oldValue none newValue nftables
```

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

