### PR TITLE
Fix/immutable kubelet configuration

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -10,6 +10,7 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 ## Bug fixes 🐞
 
 - [[#555](https://github.com/sighupio/distribution/pull/555)] Monitoring templates: don't try to patch the alertmanagerConfigs when they are not being deployed at all.
+- [[#561](https://github.com/sighupio/distribution/pull/561)] Immutable: align possible properties for Kubernetes phase `kubeletConfiguration` parameter with OnPremises, accepting all possible values now.
 
 ## Breaking Changes 💔
 

--- a/docs/schemas/immutable-kfd-v1alpha2.md
+++ b/docs/schemas/immutable-kfd-v1alpha2.md
@@ -7277,14 +7277,16 @@ NOTE: Changing the `type` after the cluster has been created is not currently su
 
 ### Properties
 
-| Property                                                                | Type      | Required |
-|:------------------------------------------------------------------------|:----------|:---------|
-| [maxPods](#speckubernetesadvancedkubeletconfigurationmaxpods)           | `integer` | Optional |
-| [podPidsLimit](#speckubernetesadvancedkubeletconfigurationpodpidslimit) | `integer` | Optional |
+| Property                                                                    | Type      | Required |
+|:----------------------------------------------------------------------------|:----------|:---------|
+| [maxPods](#speckubernetesadvancedkubeletconfigurationmaxpods)               | `integer` | Optional |
+| [systemReserved](#speckubernetesadvancedkubeletconfigurationsystemreserved) | `object`  | Optional |
 
 ### Description
 
-Kubelet configuration parameters. Ref: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
+Kubelet configuration parameters. This open field allows users to specify any parameter supported by the `KubeletConfiguration` object. Examples of uses include controlling the maximum number of pods per node (`maxPods`), the maximum number of PIDs per pod (`podPidsLimit`), managing container logging (`containerLogMaxSize`), or Topology Manager options (`topologyManagerPolicyOptions`). All values must follow the official Kubelet specification: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/.
+
+NOTE: Content will **not** be validated by furyctl. To customize the TLS cipher suites of the Kubelet, set only the `Spec.Kubernetes.Advanced.Encryption.tlsCipherSuitesKubelet` field - do not configure them under this field.
 
 ## .spec.kubernetes.advanced.kubeletConfiguration.maxPods
 
@@ -7292,11 +7294,52 @@ Kubelet configuration parameters. Ref: https://kubernetes.io/docs/reference/conf
 
 Maximum number of pods per node. Example: 200
 
-## .spec.kubernetes.advanced.kubeletConfiguration.podPidsLimit
+## .spec.kubernetes.advanced.kubeletConfiguration.systemReserved
+
+### Properties
+
+| Property                                                                                        | Type     | Required |
+|:------------------------------------------------------------------------------------------------|:---------|:---------|
+| [cpu](#speckubernetesadvancedkubeletconfigurationsystemreservedcpu)                             | `string` | Optional |
+| [ephemeral-storage](#speckubernetesadvancedkubeletconfigurationsystemreservedephemeral-storage) | `string` | Optional |
+| [memory](#speckubernetesadvancedkubeletconfigurationsystemreservedmemory)                       | `string` | Optional |
+| [pid](#speckubernetesadvancedkubeletconfigurationsystemreservedpid)                             | `string` | Optional |
 
 ### Description
 
-Maximum number of PIDs per pod. Example: 8192
+Resources reserved for system daemons that are not managed by Kubernetes (e.g. the OS, sshd, container runtime). Values are Kubernetes resource quantities. Example:
+```yaml
+systemReserved:
+  cpu: "500m"
+  memory: "1Gi"
+  ephemeral-storage: "2Gi"
+  pid: "1000"
+```
+. Ref: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#system-reserved
+
+## .spec.kubernetes.advanced.kubeletConfiguration.systemReserved.cpu
+
+### Description
+
+CPU reserved for system daemons. Example: `500m`
+
+## .spec.kubernetes.advanced.kubeletConfiguration.systemReserved.ephemeral-storage
+
+### Description
+
+Ephemeral storage reserved for system daemons. Example: `2Gi`
+
+## .spec.kubernetes.advanced.kubeletConfiguration.systemReserved.memory
+
+### Description
+
+Memory reserved for system daemons. Example: `1Gi`
+
+## .spec.kubernetes.advanced.kubeletConfiguration.systemReserved.pid
+
+### Description
+
+Process IDs reserved for system daemons. Example: `1000`
 
 ## .spec.kubernetes.advanced.oidc
 
@@ -7479,14 +7522,16 @@ The virtual router ID of Keepalived, an arbitrary unique number from 1 to 255 us
 
 ### Properties
 
-| Property                                                                    | Type      | Required |
-|:----------------------------------------------------------------------------|:----------|:---------|
-| [maxPods](#speckubernetescontrolplanekubeletconfigurationmaxpods)           | `integer` | Optional |
-| [podPidsLimit](#speckubernetescontrolplanekubeletconfigurationpodpidslimit) | `integer` | Optional |
+| Property                                                                        | Type      | Required |
+|:--------------------------------------------------------------------------------|:----------|:---------|
+| [maxPods](#speckubernetescontrolplanekubeletconfigurationmaxpods)               | `integer` | Optional |
+| [systemReserved](#speckubernetescontrolplanekubeletconfigurationsystemreserved) | `object`  | Optional |
 
 ### Description
 
-Kubelet configuration parameters. Ref: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
+Kubelet configuration parameters. This open field allows users to specify any parameter supported by the `KubeletConfiguration` object. Examples of uses include controlling the maximum number of pods per node (`maxPods`), the maximum number of PIDs per pod (`podPidsLimit`), managing container logging (`containerLogMaxSize`), or Topology Manager options (`topologyManagerPolicyOptions`). All values must follow the official Kubelet specification: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/.
+
+NOTE: Content will **not** be validated by furyctl. To customize the TLS cipher suites of the Kubelet, set only the `Spec.Kubernetes.Advanced.Encryption.tlsCipherSuitesKubelet` field - do not configure them under this field.
 
 ## .spec.kubernetes.controlPlane.kubeletConfiguration.maxPods
 
@@ -7494,11 +7539,52 @@ Kubelet configuration parameters. Ref: https://kubernetes.io/docs/reference/conf
 
 Maximum number of pods per node. Example: 200
 
-## .spec.kubernetes.controlPlane.kubeletConfiguration.podPidsLimit
+## .spec.kubernetes.controlPlane.kubeletConfiguration.systemReserved
+
+### Properties
+
+| Property                                                                                            | Type     | Required |
+|:----------------------------------------------------------------------------------------------------|:---------|:---------|
+| [cpu](#speckubernetescontrolplanekubeletconfigurationsystemreservedcpu)                             | `string` | Optional |
+| [ephemeral-storage](#speckubernetescontrolplanekubeletconfigurationsystemreservedephemeral-storage) | `string` | Optional |
+| [memory](#speckubernetescontrolplanekubeletconfigurationsystemreservedmemory)                       | `string` | Optional |
+| [pid](#speckubernetescontrolplanekubeletconfigurationsystemreservedpid)                             | `string` | Optional |
 
 ### Description
 
-Maximum number of PIDs per pod. Example: 8192
+Resources reserved for system daemons that are not managed by Kubernetes (e.g. the OS, sshd, container runtime). Values are Kubernetes resource quantities. Example:
+```yaml
+systemReserved:
+  cpu: "500m"
+  memory: "1Gi"
+  ephemeral-storage: "2Gi"
+  pid: "1000"
+```
+. Ref: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#system-reserved
+
+## .spec.kubernetes.controlPlane.kubeletConfiguration.systemReserved.cpu
+
+### Description
+
+CPU reserved for system daemons. Example: `500m`
+
+## .spec.kubernetes.controlPlane.kubeletConfiguration.systemReserved.ephemeral-storage
+
+### Description
+
+Ephemeral storage reserved for system daemons. Example: `2Gi`
+
+## .spec.kubernetes.controlPlane.kubeletConfiguration.systemReserved.memory
+
+### Description
+
+Memory reserved for system daemons. Example: `1Gi`
+
+## .spec.kubernetes.controlPlane.kubeletConfiguration.systemReserved.pid
+
+### Description
+
+Process IDs reserved for system daemons. Example: `1000`
 
 ## .spec.kubernetes.controlPlane.labels
 
@@ -7720,14 +7806,16 @@ Kubernetes annotations to apply to nodes in this group.
 
 ### Properties
 
-| Property                                                                  | Type      | Required |
-|:--------------------------------------------------------------------------|:----------|:---------|
-| [maxPods](#speckubernetesnodegroupskubeletconfigurationmaxpods)           | `integer` | Optional |
-| [podPidsLimit](#speckubernetesnodegroupskubeletconfigurationpodpidslimit) | `integer` | Optional |
+| Property                                                                      | Type      | Required |
+|:------------------------------------------------------------------------------|:----------|:---------|
+| [maxPods](#speckubernetesnodegroupskubeletconfigurationmaxpods)               | `integer` | Optional |
+| [systemReserved](#speckubernetesnodegroupskubeletconfigurationsystemreserved) | `object`  | Optional |
 
 ### Description
 
-Kubelet configuration parameters. Ref: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
+Kubelet configuration parameters. This open field allows users to specify any parameter supported by the `KubeletConfiguration` object. Examples of uses include controlling the maximum number of pods per node (`maxPods`), the maximum number of PIDs per pod (`podPidsLimit`), managing container logging (`containerLogMaxSize`), or Topology Manager options (`topologyManagerPolicyOptions`). All values must follow the official Kubelet specification: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/.
+
+NOTE: Content will **not** be validated by furyctl. To customize the TLS cipher suites of the Kubelet, set only the `Spec.Kubernetes.Advanced.Encryption.tlsCipherSuitesKubelet` field - do not configure them under this field.
 
 ## .spec.kubernetes.nodeGroups.kubeletConfiguration.maxPods
 
@@ -7735,11 +7823,52 @@ Kubelet configuration parameters. Ref: https://kubernetes.io/docs/reference/conf
 
 Maximum number of pods per node. Example: 200
 
-## .spec.kubernetes.nodeGroups.kubeletConfiguration.podPidsLimit
+## .spec.kubernetes.nodeGroups.kubeletConfiguration.systemReserved
+
+### Properties
+
+| Property                                                                                          | Type     | Required |
+|:--------------------------------------------------------------------------------------------------|:---------|:---------|
+| [cpu](#speckubernetesnodegroupskubeletconfigurationsystemreservedcpu)                             | `string` | Optional |
+| [ephemeral-storage](#speckubernetesnodegroupskubeletconfigurationsystemreservedephemeral-storage) | `string` | Optional |
+| [memory](#speckubernetesnodegroupskubeletconfigurationsystemreservedmemory)                       | `string` | Optional |
+| [pid](#speckubernetesnodegroupskubeletconfigurationsystemreservedpid)                             | `string` | Optional |
 
 ### Description
 
-Maximum number of PIDs per pod. Example: 8192
+Resources reserved for system daemons that are not managed by Kubernetes (e.g. the OS, sshd, container runtime). Values are Kubernetes resource quantities. Example:
+```yaml
+systemReserved:
+  cpu: "500m"
+  memory: "1Gi"
+  ephemeral-storage: "2Gi"
+  pid: "1000"
+```
+. Ref: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#system-reserved
+
+## .spec.kubernetes.nodeGroups.kubeletConfiguration.systemReserved.cpu
+
+### Description
+
+CPU reserved for system daemons. Example: `500m`
+
+## .spec.kubernetes.nodeGroups.kubeletConfiguration.systemReserved.ephemeral-storage
+
+### Description
+
+Ephemeral storage reserved for system daemons. Example: `2Gi`
+
+## .spec.kubernetes.nodeGroups.kubeletConfiguration.systemReserved.memory
+
+### Description
+
+Memory reserved for system daemons. Example: `1Gi`
+
+## .spec.kubernetes.nodeGroups.kubeletConfiguration.systemReserved.pid
+
+### Description
+
+Process IDs reserved for system daemons. Example: `1000`
 
 ## .spec.kubernetes.nodeGroups.labels
 

--- a/schemas/public/immutable-kfd-v1alpha2.json
+++ b/schemas/public/immutable-kfd-v1alpha2.json
@@ -1390,8 +1390,8 @@
     },
     "Spec.Kubernetes.KubeletConfiguration": {
       "type": "object",
-      "additionalProperties": false,
-      "description": "Kubelet configuration parameters. Ref: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/",
+      "additionalProperties": true,
+      "description": "Kubelet configuration parameters. This open field allows users to specify any parameter supported by the `KubeletConfiguration` object. Examples of uses include controlling the maximum number of pods per node (`maxPods`), the maximum number of PIDs per pod (`podPidsLimit`), managing container logging (`containerLogMaxSize`), or Topology Manager options (`topologyManagerPolicyOptions`). All values must follow the official Kubelet specification: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/.\n\nNOTE: Content will **not** be validated by furyctl. To customize the TLS cipher suites of the Kubelet, set only the `Spec.Kubernetes.Advanced.Encryption.tlsCipherSuitesKubelet` field - do not configure them under this field.",
       "properties": {
         "maxPods": {
           "type": "integer",
@@ -1399,10 +1399,32 @@
           "minimum": 1,
           "maximum": 1000
         },
-        "podPidsLimit": {
-          "type": "integer",
-          "description": "Maximum number of PIDs per pod. Example: 8192",
-          "minimum": 1
+        "systemReserved": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resources reserved for system daemons that are not managed by Kubernetes (e.g. the OS, sshd, container runtime). Values are Kubernetes resource quantities. Example:\n```yaml\nsystemReserved:\n  cpu: \"500m\"\n  memory: \"1Gi\"\n  ephemeral-storage: \"2Gi\"\n  pid: \"1000\"\n```\n. Ref: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#system-reserved",
+          "properties": {
+            "cpu": {
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?(m|)$",
+              "description": "CPU reserved for system daemons, in cores or millicores. Examples: `500m`, `1`, `0.5`"
+            },
+            "memory": {
+              "$ref": "#/$defs/Types.KubernetesQuantity",
+              "description": "Memory reserved for system daemons. Example: `1Gi`, `500Mi`"
+            },
+            "ephemeral-storage": {
+              "$ref": "#/$defs/Types.KubernetesQuantity",
+              "description": "Ephemeral storage reserved for system daemons. Example: `2Gi`"
+            },
+            "pid": {
+              "type": "string",
+              "pattern": "^[0-9]+$",
+              "description": "Process IDs reserved for system daemons. Example: `1000`"
+            }
+          }
         }
       }
     },


### PR DESCRIPTION

### Summary 💡

Make kubelet configuration schema for Immutable kind accept additional properties, aligning it with OnPremises.

### Description 📝

Make kubelet configuration schema for Immutable kind accept additional properties, aligning it with OnPremises.

The field had only two hardcoded properties of the 89 possible values.

Kept maxPods as documented field and added the systemReserved field and subfields to the documented properties because they are the most used ones and an editor can auto-complete them (and are validated by the json schema)

### Breaking Changes 💔

The field now accepts more values than before, but this is the expected behaviour.

### Tests performed 🧪

- [x] Tested setting the kubeletParameters field for an Immutable cluster and validated that they get applied.
- [x] Tested not setting kubeletParameters field for an Immutable cluster and validated that the apply works.

### Future work 🔧

Decide if we want to actually validate all 89 possible values for the kubeletConfiguration field (that depend on kubeadm and kubernetes versions, probably)

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

