### PR TITLE
fix(preflight/on-prem): avoid checksum race when fetching admin.conf from multiple masters

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -10,6 +10,7 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 ## Bug fixes 🐞
 
 - [[#555](https://github.com/sighupio/distribution/pull/555)] Monitoring templates: don't try to patch the alertmanagerConfigs when they are not being deployed at all.
+- [[#563](https://github.com/sighupio/distribution/pull/563)] OnPremises: fixed a race in the preflight `verify-playbook.yaml` where fetching `admin.conf` from multiple masters in parallel could randomly fail with a checksum mismatch.
 
 ## Breaking Changes 💔
 

--- a/templates/preflight/onpremises/verify-playbook.yaml
+++ b/templates/preflight/onpremises/verify-playbook.yaml
@@ -11,14 +11,6 @@
         path: /etc/kubernetes/admin.conf
       register: admin_conf_stat
 
-    - name: Getting admin.conf kubeconfig
-      become: yes
-      fetch:
-        src: /etc/kubernetes/admin.conf
-        dest: "{{ kubernetes_kubeconfig_path }}/admin.conf"
-        flat: yes
-      when: admin_conf_stat.stat.exists
-
     - name: Set fact if admin.conf exists
       set_fact:
         admin_conf_exists: "{{ admin_conf_stat.stat.exists }}"
@@ -41,4 +33,19 @@
       fail:
         msg: "No master node has /etc/kubernetes/admin.conf"
       when: not any_master_has_conf
- 
+
+    - name: Group master nodes with admin.conf
+      group_by:
+        key: masters_with_admin_conf
+      when: admin_conf_stat.stat.exists
+
+- name: Fetch admin.conf from a single master that has it
+  hosts: masters_with_admin_conf
+  become: true
+  tasks:
+    - name: Getting admin.conf kubeconfig
+      run_once: true
+      fetch:
+        src: /etc/kubernetes/admin.conf
+        dest: "{{ kubernetes_kubeconfig_path }}/admin.conf"
+        flat: yes


### PR DESCRIPTION
### Summary 💡

Fixes a checksum mismatch race condition when fetching `admin.conf` from multiple masters in parallel. Read the related issue for the full contex.



### Description 📝

Masters classify themselves via `group_by`, then the fetch runs once, scoped only to hosts confirmed to have `admin.conf`.

### Breaking Changes 💔

None.


### Tests performed 🧪

All against a 3 control plane nodes OnPremises cluster.

- [x] No master has `admin.conf`: fails same as before, tested via `furyctl apply`
- [x] Some masters have it, some don't: group classification and fetch, both tested with an interrupted `furyctl apply` retry
- [x] `furyctl get kubeconfig` and `furyctl delete cluster` since them using this playbook: both work end to end

### Future work 🔧

None.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [ ] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [ ] I've tested the proposed changes and wrote the tests performed in the section above
- [ ] My branch is up-to-date with the target branch and there are no conflicts
- [ ] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change — only OnPremises is touched here
- [ ] CI is green