### PR TITLE
fix(on-prem): avoid checksum race when fetching admin.conf from multiple masters

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -11,6 +11,7 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 
 - [[#555](https://github.com/sighupio/distribution/pull/555)] Monitoring templates: don't try to patch the alertmanagerConfigs when they are not being deployed at all.
 - [[#561](https://github.com/sighupio/distribution/pull/561)] Immutable: align possible properties for Kubernetes phase `kubeletConfiguration` parameter with OnPremises, accepting all possible values now.
+- [[#564](https://github.com/sighupio/distribution/pull/564)] OnPremises: fixed a race in the preflight `verify-playbook.yaml` where fetching `admin.conf` from multiple masters in parallel could randomly fail with a checksum mismatch.
 
 ## Breaking Changes 💔
 

--- a/templates/preflight/onpremises/verify-playbook.yaml
+++ b/templates/preflight/onpremises/verify-playbook.yaml
@@ -18,6 +18,7 @@
         dest: "{{ kubernetes_kubeconfig_path }}/admin.conf"
         flat: yes
       when: admin_conf_stat.stat.exists
+      run_once: true
 
     - name: Set fact if admin.conf exists
       set_fact:


### PR DESCRIPTION
### Summary 💡

Fixes a checksum mismatch race condition when fetching `admin.conf` from multiple masters in parallel. Read the related issue for the full context.

<!--
If there's an existing issue for your change, please link to it below inserting a link or the issue number.

If there's _not_ an existing issue, please open one first if the problem you are solving needs to be clearly identified,
for example, an error message that other users could get and search for online.
-->
Closes: https://github.com/sighupio/distribution/issues/561

<!-- If this PR is related to changes produced in other repos, like a Module, please link them below. -->
Relates:

### Description 📝

Add `run_once: true` to the existing fetch task, matching the equivalent task already in place for the Immutable provider (`templates/preflight/immutable/verify-playbook.yaml`).

### Breaking Changes 💔

None.


### Tests performed 🧪

All against a 3 control plane nodes OnPremises cluster.

- [x] No master has `admin.conf`: fails same as before, tested via `furyctl apply`
- [x] Some masters have it, some don't: group classification and fetch, both tested with an interrupted `furyctl apply` retry
- [x] `furyctl get kubeconfig` and `furyctl delete cluster` since them using this playbook: both work end to end

### Future work 🔧

None.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

