### PR TITLE
feat(immutable/butane): derive initramfs kernel args for no-DHCP nodes

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,6 +6,7 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 
 - [[#553](https://github.com/sighupio/distribution/pull/553)] EKSCluster: added schema validation to require at least one of `privateAccess` or `publicAccess` to be `true` in the Kubernetes API server configuration.
 - [[#554](https://github.com/sighupio/distribution/pull/554)] Monitoring: bump PrometheusAgent version to 3.10.0
+- [[#TBD](https://github.com/sighupio/distribution/pull/TBD)] Immutable: nodes can now boot on a segment without a DHCP server. furyctl derives an initramfs `ip=`/`nameserver=` kernel argument from a node's static interfaces, and a new optional node `kernelArguments` field (`shouldExist`/`shouldNotExist`, mirroring Butane's `kernel_arguments`) lets you set kernel arguments explicitly.
 
 ## Bug fixes 🐞
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,7 +6,7 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 
 - [[#553](https://github.com/sighupio/distribution/pull/553)] EKSCluster: added schema validation to require at least one of `privateAccess` or `publicAccess` to be `true` in the Kubernetes API server configuration.
 - [[#554](https://github.com/sighupio/distribution/pull/554)] Monitoring: bump PrometheusAgent version to 3.10.0
-- [[#TBD](https://github.com/sighupio/distribution/pull/TBD)] Immutable: nodes can now boot on a segment without a DHCP server. furyctl derives an initramfs `ip=`/`nameserver=` kernel argument from a node's static interfaces, and a new optional node `kernelArguments` field (`shouldExist`/`shouldNotExist`, mirroring Butane's `kernel_arguments`) lets you set kernel arguments explicitly.
+- [[#566](https://github.com/sighupio/distribution/pull/566)] Immutable: nodes can now boot on a segment without a DHCP server. furyctl derives an initramfs `ip=`/`nameserver=` kernel argument from a node's static interfaces, and a new optional node `kernelArguments` field (`shouldExist`/`shouldNotExist`, mirroring Butane's `kernel_arguments`) lets you set kernel arguments explicitly.
 
 ## Bug fixes 🐞
 

--- a/docs/schemas/immutable-kfd-v1alpha2.md
+++ b/docs/schemas/immutable-kfd-v1alpha2.md
@@ -5831,6 +5831,7 @@ Optional IP address. If not specified, it is inferred from the node's network co
 |:-------------------------------------------------------------|:---------|:---------|
 | [arch](#specinfrastructurenodesarch)                         | `string` | Optional |
 | [hostname](#specinfrastructurenodeshostname)                 | `string` | Required |
+| [kernelArguments](#specinfrastructurenodeskernelarguments)   | `object` | Optional |
 | [kernelParameters](#specinfrastructurenodeskernelparameters) | `array`  | Optional |
 | [macAddress](#specinfrastructurenodesmacaddress)             | `string` | Required |
 | [network](#specinfrastructurenodesnetwork)                   | `object` | Required |
@@ -5878,6 +5879,31 @@ Fully qualified domain name for the node. Example: node01.k8s.example.com
 ```
 
 [try pattern](https://regexr.com/?expression=^\([a-zA-Z0-9]\([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]\)?\.\)%2B[a-zA-Z]{2,}$)
+
+## .spec.infrastructure.nodes.kernelArguments
+
+### Properties
+
+| Property                                                                | Type    | Required |
+|:------------------------------------------------------------------------|:--------|:---------|
+| [shouldExist](#specinfrastructurenodeskernelargumentsshouldexist)       | `array` | Optional |
+| [shouldNotExist](#specinfrastructurenodeskernelargumentsshouldnotexist) | `array` | Optional |
+
+### Description
+
+Kernel arguments for this node, mirroring Butane's kernel_arguments (both lists optional). They are written to the bootloader and applied by Ignition on the node's first boot.
+
+## .spec.infrastructure.nodes.kernelArguments.shouldExist
+
+### Description
+
+Kernel arguments to add, rendered to Butane should_exist. Example: console=ttyS0,115200n8
+
+## .spec.infrastructure.nodes.kernelArguments.shouldNotExist
+
+### Description
+
+Kernel arguments to remove, rendered to Butane should_not_exist. Example: mitigations=auto
 
 ## .spec.infrastructure.nodes.kernelParameters
 
@@ -7321,25 +7347,65 @@ systemReserved:
 
 ### Description
 
-CPU reserved for system daemons. Example: `500m`
+CPU reserved for system daemons, in cores or millicores. Examples: `500m`, `1`, `0.5`
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^[0-9]+(\.[0-9]+)?(m|)$
+```
+
+[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(m|\)$)
 
 ## .spec.kubernetes.advanced.kubeletConfiguration.systemReserved.ephemeral-storage
 
 ### Description
 
-Ephemeral storage reserved for system daemons. Example: `2Gi`
+Kubernetes resource quantity format. Examples: 50Gi, 100Mi, 1Ti
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^[0-9]+(\.[0-9]+)?(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk])$
+```
+
+[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk]\)$)
 
 ## .spec.kubernetes.advanced.kubeletConfiguration.systemReserved.memory
 
 ### Description
 
-Memory reserved for system daemons. Example: `1Gi`
+Kubernetes resource quantity format. Examples: 50Gi, 100Mi, 1Ti
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^[0-9]+(\.[0-9]+)?(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk])$
+```
+
+[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk]\)$)
 
 ## .spec.kubernetes.advanced.kubeletConfiguration.systemReserved.pid
 
 ### Description
 
 Process IDs reserved for system daemons. Example: `1000`
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^[0-9]+$
+```
+
+[try pattern](https://regexr.com/?expression=^[0-9]%2B$)
 
 ## .spec.kubernetes.advanced.oidc
 
@@ -7566,25 +7632,65 @@ systemReserved:
 
 ### Description
 
-CPU reserved for system daemons. Example: `500m`
+CPU reserved for system daemons, in cores or millicores. Examples: `500m`, `1`, `0.5`
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^[0-9]+(\.[0-9]+)?(m|)$
+```
+
+[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(m|\)$)
 
 ## .spec.kubernetes.controlPlane.kubeletConfiguration.systemReserved.ephemeral-storage
 
 ### Description
 
-Ephemeral storage reserved for system daemons. Example: `2Gi`
+Kubernetes resource quantity format. Examples: 50Gi, 100Mi, 1Ti
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^[0-9]+(\.[0-9]+)?(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk])$
+```
+
+[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk]\)$)
 
 ## .spec.kubernetes.controlPlane.kubeletConfiguration.systemReserved.memory
 
 ### Description
 
-Memory reserved for system daemons. Example: `1Gi`
+Kubernetes resource quantity format. Examples: 50Gi, 100Mi, 1Ti
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^[0-9]+(\.[0-9]+)?(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk])$
+```
+
+[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk]\)$)
 
 ## .spec.kubernetes.controlPlane.kubeletConfiguration.systemReserved.pid
 
 ### Description
 
 Process IDs reserved for system daemons. Example: `1000`
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^[0-9]+$
+```
+
+[try pattern](https://regexr.com/?expression=^[0-9]%2B$)
 
 ## .spec.kubernetes.controlPlane.labels
 
@@ -7850,25 +7956,65 @@ systemReserved:
 
 ### Description
 
-CPU reserved for system daemons. Example: `500m`
+CPU reserved for system daemons, in cores or millicores. Examples: `500m`, `1`, `0.5`
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^[0-9]+(\.[0-9]+)?(m|)$
+```
+
+[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(m|\)$)
 
 ## .spec.kubernetes.nodeGroups.kubeletConfiguration.systemReserved.ephemeral-storage
 
 ### Description
 
-Ephemeral storage reserved for system daemons. Example: `2Gi`
+Kubernetes resource quantity format. Examples: 50Gi, 100Mi, 1Ti
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^[0-9]+(\.[0-9]+)?(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk])$
+```
+
+[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk]\)$)
 
 ## .spec.kubernetes.nodeGroups.kubeletConfiguration.systemReserved.memory
 
 ### Description
 
-Memory reserved for system daemons. Example: `1Gi`
+Kubernetes resource quantity format. Examples: 50Gi, 100Mi, 1Ti
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^[0-9]+(\.[0-9]+)?(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk])$
+```
+
+[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk]\)$)
 
 ## .spec.kubernetes.nodeGroups.kubeletConfiguration.systemReserved.pid
 
 ### Description
 
 Process IDs reserved for system daemons. Example: `1000`
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^[0-9]+$
+```
+
+[try pattern](https://regexr.com/?expression=^[0-9]%2B$)
 
 ## .spec.kubernetes.nodeGroups.labels
 

--- a/docs/schemas/immutable-kfd-v1alpha2.md
+++ b/docs/schemas/immutable-kfd-v1alpha2.md
@@ -5831,7 +5831,6 @@ Optional IP address. If not specified, it is inferred from the node's network co
 |:-------------------------------------------------------------|:---------|:---------|
 | [arch](#specinfrastructurenodesarch)                         | `string` | Optional |
 | [hostname](#specinfrastructurenodeshostname)                 | `string` | Required |
-| [kernelArguments](#specinfrastructurenodeskernelarguments)   | `object` | Optional |
 | [kernelParameters](#specinfrastructurenodeskernelparameters) | `array`  | Optional |
 | [macAddress](#specinfrastructurenodesmacaddress)             | `string` | Required |
 | [network](#specinfrastructurenodesnetwork)                   | `object` | Required |
@@ -5879,31 +5878,6 @@ Fully qualified domain name for the node. Example: node01.k8s.example.com
 ```
 
 [try pattern](https://regexr.com/?expression=^\([a-zA-Z0-9]\([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]\)?\.\)%2B[a-zA-Z]{2,}$)
-
-## .spec.infrastructure.nodes.kernelArguments
-
-### Properties
-
-| Property                                                                | Type    | Required |
-|:------------------------------------------------------------------------|:--------|:---------|
-| [shouldExist](#specinfrastructurenodeskernelargumentsshouldexist)       | `array` | Optional |
-| [shouldNotExist](#specinfrastructurenodeskernelargumentsshouldnotexist) | `array` | Optional |
-
-### Description
-
-Kernel arguments for this node, mirroring Butane's kernel_arguments (both lists optional). They are written to the bootloader and applied by Ignition on the node's first boot.
-
-## .spec.infrastructure.nodes.kernelArguments.shouldExist
-
-### Description
-
-Kernel arguments to add, rendered to Butane should_exist. Example: console=ttyS0,115200n8
-
-## .spec.infrastructure.nodes.kernelArguments.shouldNotExist
-
-### Description
-
-Kernel arguments to remove, rendered to Butane should_not_exist. Example: mitigations=auto
 
 ## .spec.infrastructure.nodes.kernelParameters
 
@@ -7347,65 +7321,25 @@ systemReserved:
 
 ### Description
 
-CPU reserved for system daemons, in cores or millicores. Examples: `500m`, `1`, `0.5`
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^[0-9]+(\.[0-9]+)?(m|)$
-```
-
-[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(m|\)$)
+CPU reserved for system daemons. Example: `500m`
 
 ## .spec.kubernetes.advanced.kubeletConfiguration.systemReserved.ephemeral-storage
 
 ### Description
 
-Kubernetes resource quantity format. Examples: 50Gi, 100Mi, 1Ti
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^[0-9]+(\.[0-9]+)?(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk])$
-```
-
-[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk]\)$)
+Ephemeral storage reserved for system daemons. Example: `2Gi`
 
 ## .spec.kubernetes.advanced.kubeletConfiguration.systemReserved.memory
 
 ### Description
 
-Kubernetes resource quantity format. Examples: 50Gi, 100Mi, 1Ti
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^[0-9]+(\.[0-9]+)?(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk])$
-```
-
-[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk]\)$)
+Memory reserved for system daemons. Example: `1Gi`
 
 ## .spec.kubernetes.advanced.kubeletConfiguration.systemReserved.pid
 
 ### Description
 
 Process IDs reserved for system daemons. Example: `1000`
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^[0-9]+$
-```
-
-[try pattern](https://regexr.com/?expression=^[0-9]%2B$)
 
 ## .spec.kubernetes.advanced.oidc
 
@@ -7632,65 +7566,25 @@ systemReserved:
 
 ### Description
 
-CPU reserved for system daemons, in cores or millicores. Examples: `500m`, `1`, `0.5`
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^[0-9]+(\.[0-9]+)?(m|)$
-```
-
-[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(m|\)$)
+CPU reserved for system daemons. Example: `500m`
 
 ## .spec.kubernetes.controlPlane.kubeletConfiguration.systemReserved.ephemeral-storage
 
 ### Description
 
-Kubernetes resource quantity format. Examples: 50Gi, 100Mi, 1Ti
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^[0-9]+(\.[0-9]+)?(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk])$
-```
-
-[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk]\)$)
+Ephemeral storage reserved for system daemons. Example: `2Gi`
 
 ## .spec.kubernetes.controlPlane.kubeletConfiguration.systemReserved.memory
 
 ### Description
 
-Kubernetes resource quantity format. Examples: 50Gi, 100Mi, 1Ti
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^[0-9]+(\.[0-9]+)?(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk])$
-```
-
-[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk]\)$)
+Memory reserved for system daemons. Example: `1Gi`
 
 ## .spec.kubernetes.controlPlane.kubeletConfiguration.systemReserved.pid
 
 ### Description
 
 Process IDs reserved for system daemons. Example: `1000`
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^[0-9]+$
-```
-
-[try pattern](https://regexr.com/?expression=^[0-9]%2B$)
 
 ## .spec.kubernetes.controlPlane.labels
 
@@ -7956,65 +7850,25 @@ systemReserved:
 
 ### Description
 
-CPU reserved for system daemons, in cores or millicores. Examples: `500m`, `1`, `0.5`
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^[0-9]+(\.[0-9]+)?(m|)$
-```
-
-[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(m|\)$)
+CPU reserved for system daemons. Example: `500m`
 
 ## .spec.kubernetes.nodeGroups.kubeletConfiguration.systemReserved.ephemeral-storage
 
 ### Description
 
-Kubernetes resource quantity format. Examples: 50Gi, 100Mi, 1Ti
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^[0-9]+(\.[0-9]+)?(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk])$
-```
-
-[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk]\)$)
+Ephemeral storage reserved for system daemons. Example: `2Gi`
 
 ## .spec.kubernetes.nodeGroups.kubeletConfiguration.systemReserved.memory
 
 ### Description
 
-Kubernetes resource quantity format. Examples: 50Gi, 100Mi, 1Ti
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^[0-9]+(\.[0-9]+)?(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk])$
-```
-
-[try pattern](https://regexr.com/?expression=^[0-9]%2B\(\.[0-9]%2B\)?\(Ei?|Pi?|Ti?|Gi?|Mi?|Ki?|[EPTGMk]\)$)
+Memory reserved for system daemons. Example: `1Gi`
 
 ## .spec.kubernetes.nodeGroups.kubeletConfiguration.systemReserved.pid
 
 ### Description
 
 Process IDs reserved for system daemons. Example: `1000`
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^[0-9]+$
-```
-
-[try pattern](https://regexr.com/?expression=^[0-9]%2B$)
 
 ## .spec.kubernetes.nodeGroups.labels
 

--- a/schemas/public/immutable-kfd-v1alpha2.json
+++ b/schemas/public/immutable-kfd-v1alpha2.json
@@ -179,6 +179,27 @@
         "value"
       ]
     },
+    "Spec.Infrastructure.Node.KernelArguments": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Kernel arguments for this node, mirroring Butane's kernel_arguments (both lists optional). They are written to the bootloader and applied by Ignition on the node's first boot.",
+      "properties": {
+        "shouldExist": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Kernel arguments to add, rendered to Butane should_exist. Example: console=ttyS0,115200n8"
+        },
+        "shouldNotExist": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Kernel arguments to remove, rendered to Butane should_not_exist. Example: mitigations=auto"
+        }
+      }
+    },
     "Spec.Infrastructure.IpxeServer": {
       "type": "object",
       "additionalProperties": false,
@@ -310,6 +331,10 @@
         },
         "storage": {
           "$ref": "#/$defs/Spec.Infrastructure.Node.Storage"
+        },
+        "kernelArguments": {
+          "$ref": "#/$defs/Spec.Infrastructure.Node.KernelArguments",
+          "description": "Node-specific kernel arguments. When omitted, furyctl derives the initramfs network arguments (ip=/nameserver=) from the node's static interfaces so it can boot on a segment without DHCP. When set, these replace that derivation, so include the network arguments yourself if the node has no DHCP."
         },
         "kernelParameters": {
           "type": "array",

--- a/templates/infrastructure/immutable/butane/_helpers.tpl
+++ b/templates/infrastructure/immutable/butane/_helpers.tpl
@@ -99,6 +99,58 @@ passwd:
 {{- end }}
 {{- end }}
 
+{{- /* initramfs network kargs so Ignition can fetch sysext before switch-root; without them a
+node on a DHCP-less segment never boots. node.kernelArguments, if set, is emitted verbatim
+(manual override); otherwise ip=/nameserver= are derived from the node's static interfaces.
+Emit exactly ONE ip= (the gateway iface): dracut can't split two and powers off, and first_boot
+re-adds removed args, bricking the node. networkd configures the rest after switch-root. Node
+configs only, never install-flatcar (ignition-kargs-helper hard-fails on PXE). Read map keys
+with index, not $ka.foo: templates run missingkey=error, so an absent key aborts the render. */}}
+
+{{- define "initramfs-kargs" }}
+{{- if index .node "kernelArguments" }}
+{{- $ka := index .node "kernelArguments" }}
+{{- $se := index $ka "shouldExist" }}
+{{- $sne := index $ka "shouldNotExist" }}
+{{- if or $se $sne }}
+kernel_arguments:
+{{- if $se }}
+  should_exist:
+    {{- range $se }}
+    - {{ . }}
+    {{- end }}
+{{- end }}
+{{- if $sne }}
+  should_not_exist:
+    {{- range $sne }}
+    - {{ . }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{- else }}
+{{- $selName := "" }}
+{{- $sel := dict }}
+{{- range $name, $iface := (.node.network | digAny "ethernets" dict) }}
+{{- if and (not (index $iface "dhcp4")) (index $iface "addresses") }}
+{{- if or (eq $selName "") (and (not (index $sel "gateway")) (index $iface "gateway")) }}
+{{- $selName = $name }}
+{{- $sel = $iface }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $selName }}
+{{- $cidr := splitList "/" (first $sel.addresses) }}
+
+kernel_arguments:
+  should_exist:
+    - ip={{ first $cidr }}::{{ $sel | digAny "gateway" "" }}:{{ last $cidr }}:{{ $.node.hostname }}:{{ $selName }}:none
+{{- range ($sel | digAny "nameservers" "addresses" list) }}
+    - nameserver={{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "containerd-sysext-files" }}
     # containerd sysext download and sysupdate configuration
     - path: /opt/extensions/containerd/containerd-{{ .sysext.containerd.version }}-{{ .node.arch }}.raw

--- a/templates/infrastructure/immutable/butane/controlplane.bu.tpl
+++ b/templates/infrastructure/immutable/butane/controlplane.bu.tpl
@@ -6,6 +6,7 @@ variant: flatcar
 version: 1.1.0
 
 {{ template "passwd" . }}
+{{ template "initramfs-kargs" . }}
 
 storage:
   files:

--- a/templates/infrastructure/immutable/butane/etcd.bu.tpl
+++ b/templates/infrastructure/immutable/butane/etcd.bu.tpl
@@ -6,6 +6,7 @@ variant: flatcar
 version: 1.1.0
 
 {{ template "passwd" . }}
+{{ template "initramfs-kargs" . }}
 
 storage:
   files:

--- a/templates/infrastructure/immutable/butane/loadbalancer.bu.tpl
+++ b/templates/infrastructure/immutable/butane/loadbalancer.bu.tpl
@@ -6,6 +6,7 @@ variant: flatcar
 version: 1.1.0
 
 {{ template "passwd" . }}
+{{ template "initramfs-kargs" . }}
 
 storage:
   files:

--- a/templates/infrastructure/immutable/butane/worker.bu.tpl
+++ b/templates/infrastructure/immutable/butane/worker.bu.tpl
@@ -6,6 +6,7 @@ variant: flatcar
 version: 1.1.0
 
 {{ template "passwd" . }}
+{{ template "initramfs-kargs" . }}
 
 storage:
   files:

--- a/tests/e2e/immutable/schema.sh
+++ b/tests/e2e/immutable/schema.sh
@@ -468,3 +468,27 @@ test_schema() {
 
     test_schema "public" "immutable-kfd-v1alpha2" "110-no" expect_no
 }
+
+@test "111 - ok" {
+    info
+
+    test_schema "public" "immutable-kfd-v1alpha2" "111-ok" expect_ok
+}
+
+@test "112 - ok" {
+    info
+
+    test_schema "public" "immutable-kfd-v1alpha2" "112-ok" expect_ok
+}
+
+@test "113 - no" {
+    info
+
+    test_schema "public" "immutable-kfd-v1alpha2" "113-no" expect_no
+}
+
+@test "114 - no" {
+    info
+
+    test_schema "public" "immutable-kfd-v1alpha2" "114-no" expect_no
+}

--- a/tests/schemas/public/immutable-kfd-v1alpha2/111-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/111-ok.yaml
@@ -1,0 +1,83 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# kernelArguments with only shouldExist (shouldNotExist omitted). Both lists are
+# optional, mirroring Butane's kernel_arguments; this must validate.
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        kernelArguments:
+          shouldExist:
+            - console=ttyS0,115200n8
+        storage:
+          installDisk: /dev/sda
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none

--- a/tests/schemas/public/immutable-kfd-v1alpha2/112-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/112-ok.yaml
@@ -1,0 +1,84 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# kernelArguments with both shouldExist and shouldNotExist; this must validate.
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        kernelArguments:
+          shouldExist:
+            - console=ttyS0,115200n8
+          shouldNotExist:
+            - console=tty0
+        storage:
+          installDisk: /dev/sda
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none

--- a/tests/schemas/public/immutable-kfd-v1alpha2/113-no.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/113-no.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# kernelArguments.shouldExist must be a list of strings, not a string. Must fail.
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        kernelArguments:
+          shouldExist: console=ttyS0,115200n8
+        storage:
+          installDisk: /dev/sda
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none

--- a/tests/schemas/public/immutable-kfd-v1alpha2/114-no.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/114-no.yaml
@@ -1,0 +1,84 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# kernelArguments only allows shouldExist and shouldNotExist
+# (additionalProperties: false). An unknown key must fail.
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        kernelArguments:
+          shouldExist:
+            - console=ttyS0,115200n8
+          unknownKey: nope
+        storage:
+          installDisk: /dev/sda
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none


### PR DESCRIPTION
<!-- markdownlint-disable-file MD013 MD041 -->

### Summary 💡

Nodes on a segment with no DHCP server could not finish booting. This makes furyctl fill in the boot-time network setting for such a node automatically, and adds an optional per-node `kernelArguments` field so you can set kernel arguments yourself.

Closes: #565

Relates:

### Description 📝

For the problem this solves, see the linked issue.

What this PR does:

- **Auto-derive (default).** If a node has a static IP and no DHCP, furyctl now adds one boot-time kernel argument (`ip=...`, plus `nameserver=...`) so the node has a working network early enough to download its sysext images. It picks the interface that has a gateway and adds **exactly one** `ip=` — two would make dracut give up and power the machine off, leaving it unrecoverable. Nodes that use DHCP get nothing extra, exactly like before.
- **Override.** A new optional node field `kernelArguments` lets you set kernel arguments yourself. It has two optional lists, `shouldExist` and `shouldNotExist`, exactly like Butane's `kernel_arguments`. When set, furyctl uses your values instead of deriving them.

Both lists are optional, matching Butane's `kernel_arguments` (rendered as `should_exist` / `should_not_exist`).

### Breaking Changes 💔

None. `kernelArguments` is a new optional field, and nodes that use DHCP render exactly as before.

### Tests performed 🧪

- [x] Schema validation, covering `kernelArguments` with only `shouldExist`, with both lists, with a wrong-type value, and with an unknown key — the valid ones pass and the invalid ones are rejected.
- [x] `furyctl create config --kind Immutable --version v1.35.0` still works.
- [x] Rendered a real 8-node config and checked the resulting Ignition kernel arguments for each scenario:
  - override with both lists → both rendered
  - override with only `shouldExist` → only `should_exist` rendered
  - override with only `shouldNotExist` → only `should_not_exist` rendered
  - override with empty lists → no `kernel_arguments` block
  - auto, one static interface with a gateway → one `ip=` + `nameserver=`
  - auto, DHCP interface → nothing added
  - auto, two static interfaces → exactly one `ip=` (the one with the gateway)
  - auto, gateway on the second interface → that interface is the one chosen

### Future work 🔧

- Reject `dhcp4: true` together with `addresses` on the same interface in the schema (today the static address is silently dropped).
- Warn when a static interface has no `nameservers` and the boot server is referenced by hostname.
- Document real-hardware interface naming (the `eth0` name only matches on virtio NICs).
- Update the `installer-immutable` manual-ISO docs to describe the now-working no-DHCP boot.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change — this change is scoped to Immutable only
- [ ] CI is green
