### PR TITLE
feat(immutable): serve python sysext from local PXE like other sysexts

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -7,6 +7,7 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 - [[#553](https://github.com/sighupio/distribution/pull/553)] EKSCluster: added schema validation to require at least one of `privateAccess` or `publicAccess` to be `true` in the Kubernetes API server configuration.
 - [[#554](https://github.com/sighupio/distribution/pull/554)] Monitoring: bump PrometheusAgent version to 3.10.0
 - [[#566](https://github.com/sighupio/distribution/pull/566)] Immutable: nodes can now boot on a segment without a DHCP server. furyctl derives an initramfs `ip=`/`nameserver=` kernel argument from a node's static interfaces, and a new optional node `kernelArguments` field (`shouldExist`/`shouldNotExist`, mirroring Butane's `kernel_arguments`) lets you set kernel arguments explicitly.
+- [[#567](https://github.com/sighupio/distribution/pull/567)] Immutable: the Python sysext is served from the local PXE server like the other sysexts, so nodes no longer fetch it from the public Flatcar server at first boot.
 - [[#569](https://github.com/sighupio/distribution/pull/569)] Immutable: new optional node `storage.disks` and `storage.filesystems` fields, mirroring Butane's own sections like `storage.files` already does, so extra disks can be partitioned, formatted and mounted declaratively. They replace the previous `storage.additionalDisks` field, which was never rendered.
 
 ## Bug fixes 🐞

--- a/templates/infrastructure/immutable/butane/_helpers.tpl
+++ b/templates/infrastructure/immutable/butane/_helpers.tpl
@@ -25,15 +25,6 @@ passwd:
         inline: {{ .node.hostname }}
 {{- end }}
 
-{{- define  "python"}}
-    # Enable bundled Python sysext needed by Ansible
-    - path: /etc/flatcar/enabled-sysext.conf
-      mode: 0644
-      contents:
-        inline: |
-          python
-{{- end }}
-
 {{- define "sysupdate-noop"}}
     # This dummy sysupdate configuration is needed to prevent spurious error messages
     - path: /etc/sysupdate.d/noop.conf
@@ -301,6 +292,37 @@ kernel_arguments:
     # Enable etcd sysext
     - path: /etc/extensions/etcd.raw
       target: /opt/extensions/etcd/etcd-{{ .sysext.etcd.version }}-{{ .node.arch }}.raw
+      hard: false
+{{- end }}
+
+{{- define "python-sysext-files" }}
+    # flatcar-python sysext download and sysupdate configuration (name matches the raw's extension-release)
+    - path: /opt/extensions/flatcar-python/flatcar-python-{{ (index .sysext "flatcar-python").version }}-{{ .node.arch }}.raw
+      mode: 0644
+      contents:
+        source: {{ .ipxeServerURL }}/assets/extensions/flatcar-python-{{ (index .sysext "flatcar-python").version }}-{{ .node.arch }}.raw
+    - path: /etc/sysupdate.flatcar-python.d/flatcar-python.conf
+      contents:
+        inline: |
+          [Transfer]
+          ProtectVersion=%A
+
+          [Source]
+          Type=regular-file
+          Path=/opt/extensions/flatcar-python
+          MatchPattern=flatcar-python-@v-@u.raw
+
+          [Target]
+          Type=regular-file
+          Path=/etc/extensions
+          MatchPattern=flatcar-python-@v
+          CurrentSymlink=/etc/extensions/flatcar-python.raw
+{{- end }}
+
+{{- define "python-sysext-links" }}
+    # Enable the flatcar-python sysext
+    - path: /etc/extensions/flatcar-python.raw
+      target: /opt/extensions/flatcar-python/flatcar-python-{{ (index .sysext "flatcar-python").version }}-{{ .node.arch }}.raw
       hard: false
 {{- end }}
 

--- a/templates/infrastructure/immutable/butane/controlplane.bu.tpl
+++ b/templates/infrastructure/immutable/butane/controlplane.bu.tpl
@@ -12,7 +12,6 @@ storage:
   files:
 {{ template "hostname" . }}
 {{ template "network" . }}
-{{ template "python" . }}
 {{ template "sysupdate-noop" . }}
 {{ template "update-server-config" . }}
 {{ template "sshd-pq-configuration" . }}
@@ -20,6 +19,7 @@ storage:
 {{ template "keepalived-sysext-files" . }}
 {{ template "kubernetes-sysext-files" . }}
 {{ template "etcd-sysext-files" . }}
+{{ template "python-sysext-files" . }}
     # User-provided additional files
 {{- if hasKeyAny .node.storage "files" }}
 {{ .node.storage.files | toYaml | indent 4 }}
@@ -34,6 +34,7 @@ storage:
 {{ template "keepalived-sysext-links" . }}
 {{ template "kubernetes-sysext-links" . }}
 {{ template "etcd-sysext-links" . }}
+{{ template "python-sysext-links" . }}
     # User-provided additional links
 {{- if hasKeyAny .node.storage "links" }}
 {{ .node.storage.links | toYaml | indent 4 }}

--- a/templates/infrastructure/immutable/butane/etcd.bu.tpl
+++ b/templates/infrastructure/immutable/butane/etcd.bu.tpl
@@ -12,12 +12,12 @@ storage:
   files:
 {{ template "hostname" . }}
 {{ template "network" . }}
-{{ template "python" . }}
 {{ template "sysupdate-noop" . }}
 {{ template "update-server-config" . }}
 {{ template "sshd-pq-configuration" . }}
 {{ template "containerd-sysext-files" . }}
 {{ template "etcd-sysext-files" . }}
+{{ template "python-sysext-files" . }}
     # kubeadm - needed for configuring etcd
     - path: /opt/extensions/kubeadm/kubeadm-{{ .sysext.kubeadm.version }}-{{ .node.arch }}.raw
       contents:
@@ -34,6 +34,7 @@ storage:
     # Enable custom sysexts
 {{ template "containerd-sysext-links" . }}
 {{ template "etcd-sysext-links" . }}
+{{ template "python-sysext-links" . }}
     # Kubeadm
     - target: /opt/extensions/kubeadm/kubeadm-{{ .sysext.kubeadm.version }}-{{ .node.arch }}.raw
       path: /etc/extensions/kubeadm.raw

--- a/templates/infrastructure/immutable/butane/loadbalancer.bu.tpl
+++ b/templates/infrastructure/immutable/butane/loadbalancer.bu.tpl
@@ -12,12 +12,12 @@ storage:
   files:
 {{ template "hostname" . }}
 {{ template "network" . }}
-{{ template "python" . }}
 {{ template "sysupdate-noop" . }}
 {{ template "update-server-config" . }}
 {{ template "sshd-pq-configuration" . }}
 {{ template "containerd-sysext-files" . }}
 {{ template "keepalived-sysext-files" . }}
+{{ template "python-sysext-files" . }}
     # User-provided additional files
 {{- if hasKeyAny .node.storage "files" }}
 {{ .node.storage.files | toYaml | indent 4 }}
@@ -30,6 +30,7 @@ storage:
     # Enable custom sysexts
 {{ template "containerd-sysext-links" . }}
 {{ template "keepalived-sysext-links" . }}
+{{ template "python-sysext-links" . }}
     # User-provided additional links
 {{- if hasKeyAny .node.storage "links" }}
 {{ .node.storage.links | toYaml | indent 4 }}

--- a/templates/infrastructure/immutable/butane/worker.bu.tpl
+++ b/templates/infrastructure/immutable/butane/worker.bu.tpl
@@ -12,12 +12,12 @@ storage:
   files:
 {{ template "hostname" . }}
 {{ template "network" . }}
-{{ template "python" . }}
 {{ template "sysupdate-noop" . }}
 {{ template "update-server-config" . }}
 {{ template "sshd-pq-configuration" . }}
 {{ template "containerd-sysext-files" . }}
 {{ template "kubernetes-sysext-files" . }}
+{{ template "python-sysext-files" . }}
     # User-provided additional files
 {{- if hasKeyAny .node.storage "files" }}
 {{ .node.storage.files | toYaml | indent 4 }}
@@ -30,6 +30,7 @@ storage:
     # Enable custom sysexts
 {{ template "containerd-sysext-links" . }}
 {{ template "kubernetes-sysext-links" . }}
+{{ template "python-sysext-links" . }}
     # User-provided additional links
 {{- if hasKeyAny .node.storage "links" }}
 {{ .node.storage.links | toYaml | indent 4 }}


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->

### Summary 💡

Immutable nodes now get the Flatcar Python sysext from the local PXE server, like every other sysext, instead of
enabling it through `enabled-sysext.conf` and having systemd fetch it from the public Flatcar server on first boot.

This is one of the three PRs that together resolve #571, so it does not close the issue on its own.

Relates: #571, sighupio/installer-immutable#18, sighupio/furyctl#728

### Description 📝

Python is needed on every node for Ansible. It was the only sysext still reaching the public internet at boot:
the `python` Butane helper wrote `/etc/flatcar/enabled-sysext.conf` with a single `python` line, and Flatcar's
`systemd-sysupdate` then downloaded it from `*.release.flatcar-linux.net`. On an air-gapped network that fetch
fails and the node never finishes booting.

The helper is replaced by `python-sysext-files` and `python-sysext-links`, which are the `containerd-sysext-*`
helpers with the name swapped: the `.raw` is fetched from `{ipxeServerURL}/assets/extensions/`, a
`/etc/sysupdate.flatcar-python.d/` transfer file pins it, and `/etc/extensions/flatcar-python.raw` symlinks it in.
No new mechanism — the same managed-sysext pattern the other five already use, so `disable-sysext-updates` keeps
covering it unchanged.

The sysext is named `flatcar-python`, not `python`. That is not cosmetic: `systemd-sysext` matches the symlink
name against the `extension-release` file inside the image, and Flatcar ships that image as `flatcar-python`.
Naming it `python` stages the file but never activates the extension, which is exactly how it failed the first
time around. The dash also means the templates must use `(index .sysext "flatcar-python")` rather than a dotted
field access.

All four node roles get both helpers, in `storage.files` and `storage.links`. Only Immutable is affected.

**Merge order: sighupio/installer-immutable#18 has to merge before this PR.** It is what adds the
`flatcar-python` entry to `immutable.yaml`, and that entry is the whole `.sysext` map the templates read. Merged
the other way round, `(index .sysext "flatcar-python").version` evaluates against a missing key and the
infrastructure phase fails to render for every immutable node.

sighupio/furyctl#728 is **not** a prerequisite. furyctl already downloads every entry in the manifest's `sysext`
list generically, under the `{name}-{version}-{arch}.raw` convention these templates expect, and its YAML
decoding ignores the new `sha256` key. #728 only adds checksum verification on top, so it can land before or
after.

### Breaking Changes 💔

None. Ignition only runs on first boot, so nodes provisioned before this change keep their existing
`enabled-sysext.conf` and are unaffected — they gain the air-gap property when reprovisioned.

### Tests performed 🧪

- [x] End-to-end on a live 6-node cluster (3 control planes, 3 workers): install renders and boots with the
      sysext served from the PXE server, and `systemd-sysext status` shows `flatcar-python` merged on 6/6.
- [x] The upgrade path was exercised too, which is where the naming bug surfaced originally: the sysext is
      version-pinned to Flatcar, so it has to be re-staged for the target OS before the reboot activates it
      (handled in installer-immutable#18's `os_reboot.yml`).
- [x] Both `.raw` artifacts, both architectures, both Flatcar versions (4593.2.1 and 4593.2.3) verified present
      on the SIGHUP mirror, and their `SHA256SUMS` entries match the digests pinned in installer-immutable#18.
- [x] No `enabled-sysext.conf` and no reference to the public Flatcar release server left anywhere in the
      Immutable templates.
- [x] CI is green

Not covered by CI, and worth knowing: `tests/templates/immutable/` has no infrastructure-phase baselines and the
`render` step uses a KFDDistribution config, so nothing in the pipeline ever renders these Butane templates. A
template that fails to execute would still go green. The evidence above is manual on purpose.

### Future work 🔧

- Upstream Flatcar's own `SHA256SUMS` does not list `flatcar-python.raw` — only the SIGHUP mirror's does, as an
  added line. Every Flatcar version bump needs that line added along with the artifact, otherwise the Ansible
  `sysext` role, which derives the checksum URL as a sibling of the `.raw`, fails on the upgrade path.
- `tests/templates/immutable/` still has no infrastructure baselines, so these templates stay untested in CI.

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green
