### PR TITLE
fix(immutable): set search domain

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -13,6 +13,7 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 - [[#555](https://github.com/sighupio/distribution/pull/555)] Monitoring templates: don't try to patch the alertmanagerConfigs when they are not being deployed at all.
 - [[#561](https://github.com/sighupio/distribution/pull/561)] Immutable: align possible properties for Kubernetes phase `kubeletConfiguration` parameter with OnPremises, accepting all possible values now.
 - [[#564](https://github.com/sighupio/distribution/pull/564)] OnPremises: fixed a race in the preflight `verify-playbook.yaml` where fetching `admin.conf` from multiple masters in parallel could randomly fail with a checksum mismatch.
+- [[#568](https://github.com/sighupio/distribution/pull/568)] Immutable: actually set the search domains for an interface if it is defined in the node configuration, this value was being ignored until now.
 
 ## Breaking Changes 💔
 

--- a/templates/infrastructure/immutable/butane/_helpers.tpl
+++ b/templates/infrastructure/immutable/butane/_helpers.tpl
@@ -79,22 +79,26 @@ passwd:
           {{- if index $iface "dhcp4" }}
           DHCP=ipv4
           {{- else }}
-          {{- range $iface.addresses }}
+            {{- range $iface.addresses }}
           Address={{ . }}
-          {{- end }}
-          {{- if index $iface "gateway" }}
+            {{- end }}
+            {{- if index $iface "gateway" }}
           Gateway={{ $iface.gateway }}
-          {{- end }}
-          {{- range ($iface | digAny "nameservers" "addresses" list) }}
+            {{- end }}
+            {{- range ($iface | digAny "nameservers" "addresses" list) }}
           DNS={{ . }}
-          {{- end }}
+            {{- end }}
+            {{- $domains := $iface | digAny "nameservers" "search" list }}
+            {{- if $domains }}
+          Domains={{ range $domains }}{{ . }} {{end}}
+            {{- end }}
           {{- end }}
           {{- if hasKeyAny $iface "routes" }}
-          {{- range $iface.routes }}
+            {{- range $iface.routes }}
           [Route]
           Destination={{ .to }}
           Gateway={{ .via }}
-          {{- end }}
+            {{- end }}
           {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### Summary 💡

Update butane templates to include the search domain if defined in the node's network configuration. This value was being ignored.

### Description 📝

When setting the search domain in an interface with static IP configuration, the search domain was not being actually set in the node's networkd configuration.

This PR updates the butane template helper to include the search domain if it is defined.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested that if the search domain is set, the configuration ends up in the node and it actually works (e.g. pinging the host without the fqdn resolves the fqdn appending the search domain)
- [x] Tested that there are no errors and no search domain is set when the field is not set in the furyctl.yaml file.

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [X] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

