### PR TITLE
feat(immutable)!: add node storage.disks and storage.filesystems

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -7,6 +7,7 @@ Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
 - [[#553](https://github.com/sighupio/distribution/pull/553)] EKSCluster: added schema validation to require at least one of `privateAccess` or `publicAccess` to be `true` in the Kubernetes API server configuration.
 - [[#554](https://github.com/sighupio/distribution/pull/554)] Monitoring: bump PrometheusAgent version to 3.10.0
 - [[#566](https://github.com/sighupio/distribution/pull/566)] Immutable: nodes can now boot on a segment without a DHCP server. furyctl derives an initramfs `ip=`/`nameserver=` kernel argument from a node's static interfaces, and a new optional node `kernelArguments` field (`shouldExist`/`shouldNotExist`, mirroring Butane's `kernel_arguments`) lets you set kernel arguments explicitly.
+- [[#569](https://github.com/sighupio/distribution/pull/569)] Immutable: new optional node `storage.disks` and `storage.filesystems` fields, mirroring Butane's own sections like `storage.files` already does, so extra disks can be partitioned, formatted and mounted declaratively. They replace the previous `storage.additionalDisks` field, which was never rendered.
 
 ## Bug fixes 🐞
 

--- a/docs/schemas/immutable-kfd-v1alpha2.md
+++ b/docs/schemas/immutable-kfd-v1alpha2.md
@@ -6110,183 +6110,18 @@ The user ID of the account.
 
 ### Properties
 
-| Property                                                          | Type     | Required |
-|:------------------------------------------------------------------|:---------|:---------|
-| [additionalDisks](#specinfrastructurenodesstorageadditionaldisks) | `array`  | Optional |
-| [directories](#specinfrastructurenodesstoragedirectories)         | `array`  | Optional |
-| [files](#specinfrastructurenodesstoragefiles)                     | `array`  | Optional |
-| [installDisk](#specinfrastructurenodesstorageinstalldisk)         | `string` | Required |
-| [links](#specinfrastructurenodesstoragelinks)                     | `array`  | Optional |
+| Property                                                  | Type     | Required |
+|:----------------------------------------------------------|:---------|:---------|
+| [directories](#specinfrastructurenodesstoragedirectories) | `array`  | Optional |
+| [disks](#specinfrastructurenodesstoragedisks)             | `array`  | Optional |
+| [files](#specinfrastructurenodesstoragefiles)             | `array`  | Optional |
+| [filesystems](#specinfrastructurenodesstoragefilesystems) | `array`  | Optional |
+| [installDisk](#specinfrastructurenodesstorageinstalldisk) | `string` | Required |
+| [links](#specinfrastructurenodesstoragelinks)             | `array`  | Optional |
 
 ### Description
 
-Storage configuration for the node, including install disk and additional disks with partitions.
-
-## .spec.infrastructure.nodes.storage.additionalDisks
-
-### Properties
-
-| Property                                                               | Type     | Required |
-|:-----------------------------------------------------------------------|:---------|:---------|
-| [device](#specinfrastructurenodesstorageadditionaldisksdevice)         | `string` | Required |
-| [partitions](#specinfrastructurenodesstorageadditionaldiskspartitions) | `array`  | Required |
-
-### Description
-
-Additional disk configuration with partitions.
-
-## .spec.infrastructure.nodes.storage.additionalDisks.device
-
-### Description
-
-Unix device path. Example: /dev/sda, /dev/nvme0n1
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^/dev/[a-zA-Z0-9/]+$
-```
-
-[try pattern](https://regexr.com/?expression=^\/dev\/[a-zA-Z0-9\/]%2B$)
-
-## .spec.infrastructure.nodes.storage.additionalDisks.partitions
-
-### Properties
-
-| Property                                                                         | Type      | Required |
-|:---------------------------------------------------------------------------------|:----------|:---------|
-| [filesystem](#specinfrastructurenodesstorageadditionaldiskspartitionsfilesystem) | `object`  | Required |
-| [label](#specinfrastructurenodesstorageadditionaldiskspartitionslabel)           | `string`  | Required |
-| [number](#specinfrastructurenodesstorageadditionaldiskspartitionsnumber)         | `integer` | Required |
-| [sizeMiB](#specinfrastructurenodesstorageadditionaldiskspartitionssizemib)       | `integer` | Required |
-
-### Description
-
-Partition definition with filesystem and mount options.
-
-### Constraints
-
-**minimum number of items**: the minimum number of items for this array is: `1`
-
-## .spec.infrastructure.nodes.storage.additionalDisks.partitions.filesystem
-
-### Properties
-
-| Property                                                                                       | Type     | Required |
-|:-----------------------------------------------------------------------------------------------|:---------|:---------|
-| [format](#specinfrastructurenodesstorageadditionaldiskspartitionsfilesystemformat)             | `string` | Required |
-| [label](#specinfrastructurenodesstorageadditionaldiskspartitionsfilesystemlabel)               | `string` | Required |
-| [mountOptions](#specinfrastructurenodesstorageadditionaldiskspartitionsfilesystemmountoptions) | `array`  | Optional |
-| [mountPoint](#specinfrastructurenodesstorageadditionaldiskspartitionsfilesystemmountpoint)     | `string` | Required |
-
-### Description
-
-Filesystem configuration for a partition.
-
-## .spec.infrastructure.nodes.storage.additionalDisks.partitions.filesystem.format
-
-### Description
-
-Filesystem type
-
-### Constraints
-
-**enum**: the value of this property must be equal to one of the following string values:
-
-| Value   |
-|:--------|
-|`"ext4"` |
-|`"xfs"`  |
-|`"btrfs"`|
-|`"ext3"` |
-|`"vfat"` |
-
-## .spec.infrastructure.nodes.storage.additionalDisks.partitions.filesystem.label
-
-### Description
-
-Filesystem label (max 12 chars for XFS compatibility). Example: ETCD
-
-### Constraints
-
-**maximum length**: the maximum number of characters for this string is: `12`
-
-**minimum length**: the minimum number of characters for this string is: `1`
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^[A-Z0-9_-]+$
-```
-
-[try pattern](https://regexr.com/?expression=^[A-Z0-9_-]%2B$)
-
-## .spec.infrastructure.nodes.storage.additionalDisks.partitions.filesystem.mountOptions
-
-### Description
-
-Mount options (validated safe options only). Example: ["noatime", "nodiratime"]
-
-### Constraints
-
-**enum**: the value of this property must be equal to one of the following string values:
-
-| Value         |
-|:--------------|
-|`"noatime"`    |
-|`"nodiratime"` |
-|`"relatime"`   |
-|`"strictatime"`|
-|`"nodev"`      |
-|`"nosuid"`     |
-|`"noexec"`     |
-|`"ro"`         |
-|`"rw"`         |
-|`"sync"`       |
-|`"async"`      |
-|`"discard"`    |
-|`"nodiscard"`  |
-|`"defaults"`   |
-
-## .spec.infrastructure.nodes.storage.additionalDisks.partitions.filesystem.mountPoint
-
-### Description
-
-Mount point path. Example: /var/lib/etcd
-
-### Constraints
-
-**pattern**: the string must match the following regular expression:
-
-```regexp
-^/[a-zA-Z0-9/_-]*$
-```
-
-[try pattern](https://regexr.com/?expression=^\/[a-zA-Z0-9\/_-]*$)
-
-## .spec.infrastructure.nodes.storage.additionalDisks.partitions.label
-
-### Description
-
-Partition label. Example: etcd-data
-
-### Constraints
-
-**minimum length**: the minimum number of characters for this string is: `1`
-
-## .spec.infrastructure.nodes.storage.additionalDisks.partitions.number
-
-### Description
-
-Partition number. Example: 1
-
-## .spec.infrastructure.nodes.storage.additionalDisks.partitions.sizeMiB
-
-### Description
-
-Partition size in MiB. Use 0 to use all available space.
+Storage configuration for the node, including the install disk and the Butane storage sections.
 
 ## .spec.infrastructure.nodes.storage.directories
 
@@ -6371,6 +6206,138 @@ The user ID of the owner.
 ### Description
 
 The username of the owner.
+
+## .spec.infrastructure.nodes.storage.disks
+
+### Properties
+
+| Property                                                     | Type      | Required |
+|:-------------------------------------------------------------|:----------|:---------|
+| [device](#specinfrastructurenodesstoragedisksdevice)         | `string`  | Required |
+| [partitions](#specinfrastructurenodesstoragediskspartitions) | `array`   | Optional |
+| [wipe_table](#specinfrastructurenodesstoragediskswipe_table) | `boolean` | Optional |
+
+### Description
+
+Represents a disk to be partitioned.
+
+## .spec.infrastructure.nodes.storage.disks.device
+
+### Description
+
+The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks. Example: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive1
+
+## .spec.infrastructure.nodes.storage.disks.partitions
+
+### Properties
+
+| Property                                                                                   | Type      | Required |
+|:-------------------------------------------------------------------------------------------|:----------|:---------|
+| [guid](#specinfrastructurenodesstoragediskspartitionsguid)                                 | `string`  | Optional |
+| [label](#specinfrastructurenodesstoragediskspartitionslabel)                               | `string`  | Optional |
+| [number](#specinfrastructurenodesstoragediskspartitionsnumber)                             | `integer` | Optional |
+| [resize](#specinfrastructurenodesstoragediskspartitionsresize)                             | `boolean` | Optional |
+| [should_exist](#specinfrastructurenodesstoragediskspartitionsshould_exist)                 | `boolean` | Optional |
+| [size_mib](#specinfrastructurenodesstoragediskspartitionssize_mib)                         | `integer` | Optional |
+| [start_mib](#specinfrastructurenodesstoragediskspartitionsstart_mib)                       | `integer` | Optional |
+| [type_guid](#specinfrastructurenodesstoragediskspartitionstype_guid)                       | `string`  | Optional |
+| [wipe_partition_entry](#specinfrastructurenodesstoragediskspartitionswipe_partition_entry) | `boolean` | Optional |
+
+### Description
+
+Represents a partition to be created on the disk.
+
+## .spec.infrastructure.nodes.storage.disks.partitions.guid
+
+### Description
+
+The GPT unique partition GUID.
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^(|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$
+```
+
+[try pattern](https://regexr.com/?expression=^\(|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\)$)
+
+## .spec.infrastructure.nodes.storage.disks.partitions.label
+
+### Description
+
+The PARTLABEL for the partition, used to reference it from a filesystem as /dev/disk/by-partlabel/LABEL. Cannot contain a colon. Example: data
+
+### Constraints
+
+**maximum length**: the maximum number of characters for this string is: `36`
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^[^:]*$
+```
+
+[try pattern](https://regexr.com/?expression=^[^:]*$)
+
+## .spec.infrastructure.nodes.storage.disks.partitions.number
+
+### Description
+
+The partition number, which will change the partition table entry at that location. If not specified, the next available partition number will be used.
+
+## .spec.infrastructure.nodes.storage.disks.partitions.resize
+
+### Description
+
+Whether or not the existing partition should be resized. Defaults to false. If true, Ignition will resize an existing partition if it matches the config in all respects except the partition size.
+
+## .spec.infrastructure.nodes.storage.disks.partitions.should_exist
+
+### Description
+
+Whether or not the partition with the specified number should exist. Defaults to true. If false, Ignition will either delete the specified partition or fail, depending on wipe_partition_entry.
+
+## .spec.infrastructure.nodes.storage.disks.partitions.size_mib
+
+### Description
+
+The size of the partition with a unit of mebibytes. If zero, the partition will be made as large as possible.
+
+## .spec.infrastructure.nodes.storage.disks.partitions.start_mib
+
+### Description
+
+The start of the partition with a unit of mebibytes. If zero, the partition will be positioned at the start of the largest block available.
+
+## .spec.infrastructure.nodes.storage.disks.partitions.type_guid
+
+### Description
+
+The GPT partition type GUID. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
+
+### Constraints
+
+**pattern**: the string must match the following regular expression:
+
+```regexp
+^(|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$
+```
+
+[try pattern](https://regexr.com/?expression=^\(|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\)$)
+
+## .spec.infrastructure.nodes.storage.disks.partitions.wipe_partition_entry
+
+### Description
+
+If true, Ignition will clobber an existing partition if it does not match the config. If false, Ignition will fail instead. Defaults to false.
+
+## .spec.infrastructure.nodes.storage.disks.wipe_table
+
+### Description
+
+Whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact. Defaults to false.
 
 ## .spec.infrastructure.nodes.storage.files
 
@@ -6641,6 +6608,93 @@ The user ID of the owner.
 ### Description
 
 The user name of the owner.
+
+## .spec.infrastructure.nodes.storage.filesystems
+
+### Properties
+
+| Property                                                                     | Type      | Required |
+|:-----------------------------------------------------------------------------|:----------|:---------|
+| [device](#specinfrastructurenodesstoragefilesystemsdevice)                   | `string`  | Required |
+| [format](#specinfrastructurenodesstoragefilesystemsformat)                   | `string`  | Optional |
+| [label](#specinfrastructurenodesstoragefilesystemslabel)                     | `string`  | Optional |
+| [mount_options](#specinfrastructurenodesstoragefilesystemsmount_options)     | `array`   | Optional |
+| [options](#specinfrastructurenodesstoragefilesystemsoptions)                 | `array`   | Optional |
+| [path](#specinfrastructurenodesstoragefilesystemspath)                       | `string`  | Optional |
+| [uuid](#specinfrastructurenodesstoragefilesystemsuuid)                       | `string`  | Optional |
+| [wipe_filesystem](#specinfrastructurenodesstoragefilesystemswipe_filesystem) | `boolean` | Optional |
+| [with_mount_unit](#specinfrastructurenodesstoragefilesystemswith_mount_unit) | `boolean` | Optional |
+
+### Description
+
+Represents a filesystem to be created on a device.
+
+## .spec.infrastructure.nodes.storage.filesystems.device
+
+### Description
+
+The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks. Example: /dev/disk/by-partlabel/data
+
+## .spec.infrastructure.nodes.storage.filesystems.format
+
+### Description
+
+The filesystem format.
+
+### Constraints
+
+**enum**: the value of this property must be equal to one of the following string values:
+
+| Value   |
+|:--------|
+|`"ext4"` |
+|`"btrfs"`|
+|`"xfs"`  |
+|`"swap"` |
+|`"vfat"` |
+|`"none"` |
+
+## .spec.infrastructure.nodes.storage.filesystems.label
+
+### Description
+
+The label of the filesystem. Requires format to be set. Example: DATA
+
+## .spec.infrastructure.nodes.storage.filesystems.mount_options
+
+### Description
+
+Any special options to be passed to the mount command.
+
+## .spec.infrastructure.nodes.storage.filesystems.options
+
+### Description
+
+Any additional options to be passed to the format-specific mkfs utility.
+
+## .spec.infrastructure.nodes.storage.filesystems.path
+
+### Description
+
+The mount-point of the filesystem in the real root. Required unless the format is swap. Example: /var/lib/containerd
+
+## .spec.infrastructure.nodes.storage.filesystems.uuid
+
+### Description
+
+The UUID of the filesystem.
+
+## .spec.infrastructure.nodes.storage.filesystems.wipe_filesystem
+
+### Description
+
+Whether or not to wipe the device before filesystem creation. Defaults to false.
+
+## .spec.infrastructure.nodes.storage.filesystems.with_mount_unit
+
+### Description
+
+Whether to additionally generate a generic mount unit for this filesystem, or a swap unit for this swap area. Defaults to false.
 
 ## .spec.infrastructure.nodes.storage.installDisk
 

--- a/schemas/public/immutable-kfd-v1alpha2.json
+++ b/schemas/public/immutable-kfd-v1alpha2.json
@@ -356,18 +356,148 @@
     "Spec.Infrastructure.Node.Storage": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Storage configuration for the node, including install disk and additional disks with partitions.",
+      "description": "Storage configuration for the node, including the install disk and the Butane storage sections.",
       "properties": {
         "installDisk": {
           "$ref": "#/$defs/Types.DevicePath",
           "description": "The disk device where the OS will be installed. Example: /dev/sda"
         },
-        "additionalDisks": {
+        "disks": {
           "type": "array",
+          "description": "The list of disks to be partitioned. Every disk must have a unique device. See https://www.flatcar.org/docs/latest/provisioning/config-transpiler/configuration/",
           "items": {
-            "$ref": "#/$defs/Spec.Infrastructure.Node.Storage.Disk"
-          },
-          "description": "Additional disks to partition and mount."
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Represents a disk to be partitioned.",
+            "properties": {
+              "device": {
+                "type": "string",
+                "description": "The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks. Example: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive1"
+              },
+              "wipe_table": {
+                "type": "boolean",
+                "description": "Whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact. Defaults to false."
+              },
+              "partitions": {
+                "type": "array",
+                "description": "The list of partitions to be created on the disk. Every partition must have either a number or a label.",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Represents a partition to be created on the disk.",
+                  "properties": {
+                    "label": {
+                      "type": "string",
+                      "description": "The PARTLABEL for the partition, used to reference it from a filesystem as /dev/disk/by-partlabel/LABEL. Cannot contain a colon. Example: data",
+                      "maxLength": 36,
+                      "pattern": "^[^:]*$"
+                    },
+                    "number": {
+                      "type": "integer",
+                      "description": "The partition number, which will change the partition table entry at that location. If not specified, the next available partition number will be used."
+                    },
+                    "size_mib": {
+                      "type": "integer",
+                      "description": "The size of the partition with a unit of mebibytes. If zero, the partition will be made as large as possible."
+                    },
+                    "start_mib": {
+                      "type": "integer",
+                      "description": "The start of the partition with a unit of mebibytes. If zero, the partition will be positioned at the start of the largest block available."
+                    },
+                    "type_guid": {
+                      "type": "string",
+                      "description": "The GPT partition type GUID. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).",
+                      "pattern": "^(|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
+                    },
+                    "guid": {
+                      "type": "string",
+                      "description": "The GPT unique partition GUID.",
+                      "pattern": "^(|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
+                    },
+                    "wipe_partition_entry": {
+                      "type": "boolean",
+                      "description": "If true, Ignition will clobber an existing partition if it does not match the config. If false, Ignition will fail instead. Defaults to false."
+                    },
+                    "should_exist": {
+                      "type": "boolean",
+                      "description": "Whether or not the partition with the specified number should exist. Defaults to true. If false, Ignition will either delete the specified partition or fail, depending on wipe_partition_entry."
+                    },
+                    "resize": {
+                      "type": "boolean",
+                      "description": "Whether or not the existing partition should be resized. Defaults to false. If true, Ignition will resize an existing partition if it matches the config in all respects except the partition size."
+                    }
+                  }
+                }
+              }
+            },
+            "required": [
+              "device"
+            ]
+          }
+        },
+        "filesystems": {
+          "type": "array",
+          "description": "The list of filesystems to be created. Every filesystem must have a unique device. See https://www.flatcar.org/docs/latest/provisioning/config-transpiler/configuration/",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Represents a filesystem to be created on a device.",
+            "properties": {
+              "device": {
+                "type": "string",
+                "description": "The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks. Example: /dev/disk/by-partlabel/data"
+              },
+              "format": {
+                "type": "string",
+                "description": "The filesystem format.",
+                "enum": [
+                  "ext4",
+                  "btrfs",
+                  "xfs",
+                  "swap",
+                  "vfat",
+                  "none"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "description": "The mount-point of the filesystem in the real root. Required unless the format is swap. Example: /var/lib/containerd"
+              },
+              "wipe_filesystem": {
+                "type": "boolean",
+                "description": "Whether or not to wipe the device before filesystem creation. Defaults to false."
+              },
+              "label": {
+                "type": "string",
+                "description": "The label of the filesystem. Requires format to be set. Example: DATA"
+              },
+              "uuid": {
+                "type": "string",
+                "description": "The UUID of the filesystem."
+              },
+              "options": {
+                "type": "array",
+                "description": "Any additional options to be passed to the format-specific mkfs utility.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "mount_options": {
+                "type": "array",
+                "description": "Any special options to be passed to the mount command.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "with_mount_unit": {
+                "type": "boolean",
+                "description": "Whether to additionally generate a generic mount unit for this filesystem, or a swap unit for this swap area. Defaults to false."
+              }
+            },
+            "required": [
+              "device"
+            ]
+          }
         },
         "files": {
           "type": "array",
@@ -671,112 +801,6 @@
       },
       "required": [
         "path"
-      ]
-    },
-    "Spec.Infrastructure.Node.Storage.Disk": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "Additional disk configuration with partitions.",
-      "properties": {
-        "device": {
-          "$ref": "#/$defs/Types.DevicePath",
-          "description": "The disk device path. Example: /dev/sdb"
-        },
-        "partitions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Spec.Infrastructure.Node.Storage.Partition"
-          },
-          "description": "Partitions to create on this disk.",
-          "minItems": 1
-        }
-      },
-      "required": [
-        "device",
-        "partitions"
-      ]
-    },
-    "Spec.Infrastructure.Node.Storage.Partition": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "Partition definition with filesystem and mount options.",
-      "properties": {
-        "label": {
-          "type": "string",
-          "description": "Partition label. Example: etcd-data",
-          "minLength": 1
-        },
-        "number": {
-          "type": "integer",
-          "description": "Partition number. Example: 1",
-          "minimum": 1,
-          "maximum": 128
-        },
-        "sizeMiB": {
-          "type": "integer",
-          "description": "Partition size in MiB. Use 0 to use all available space.",
-          "minimum": 0
-        },
-        "filesystem": {
-          "$ref": "#/$defs/Spec.Infrastructure.Node.Storage.Filesystem"
-        }
-      },
-      "required": [
-        "label",
-        "number",
-        "sizeMiB",
-        "filesystem"
-      ]
-    },
-    "Spec.Infrastructure.Node.Storage.Filesystem": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "Filesystem configuration for a partition.",
-      "properties": {
-        "format": {
-          "$ref": "#/$defs/Types.FilesystemType",
-          "description": "Filesystem type. Example: ext4, xfs"
-        },
-        "label": {
-          "type": "string",
-          "description": "Filesystem label (max 12 chars for XFS compatibility). Example: ETCD",
-          "minLength": 1,
-          "maxLength": 12,
-          "pattern": "^[A-Z0-9_-]+$"
-        },
-        "mountPoint": {
-          "type": "string",
-          "description": "Mount point path. Example: /var/lib/etcd",
-          "pattern": "^/[a-zA-Z0-9/_-]*$"
-        },
-        "mountOptions": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "noatime",
-              "nodiratime",
-              "relatime",
-              "strictatime",
-              "nodev",
-              "nosuid",
-              "noexec",
-              "ro",
-              "rw",
-              "sync",
-              "async",
-              "discard",
-              "nodiscard",
-              "defaults"
-            ]
-          },
-          "description": "Mount options (validated safe options only). Example: [\"noatime\", \"nodiratime\"]"
-        }
-      },
-      "required": [
-        "format",
-        "label",
-        "mountPoint"
       ]
     },
     "Spec.Infrastructure.Node.Network": {
@@ -4009,17 +4033,6 @@
       "type": "string",
       "pattern": "^/dev/[a-zA-Z0-9/]+$",
       "description": "Unix device path. Example: /dev/sda, /dev/nvme0n1"
-    },
-    "Types.FilesystemType": {
-      "type": "string",
-      "enum": [
-        "ext4",
-        "xfs",
-        "btrfs",
-        "ext3",
-        "vfat"
-      ],
-      "description": "Filesystem type"
     },
     "Types.IpAddress": {
       "type": "string",

--- a/templates/infrastructure/immutable/butane/controlplane.bu.tpl
+++ b/templates/infrastructure/immutable/butane/controlplane.bu.tpl
@@ -44,6 +44,17 @@ storage:
   directories:
 {{ .node.storage.directories | toYaml | indent 4 }}
 {{- end }}
+  # User-provided additional disks
+{{- if hasKeyAny .node.storage "disks" }}
+  disks:
+{{ .node.storage.disks | toYaml | indent 4 }}
+{{- end }}
+
+  # User-provided additional filesystems
+{{- if hasKeyAny .node.storage "filesystems" }}
+  filesystems:
+{{ .node.storage.filesystems | toYaml | indent 4 }}
+{{- end }}
 
 systemd:
   units:

--- a/templates/infrastructure/immutable/butane/etcd.bu.tpl
+++ b/templates/infrastructure/immutable/butane/etcd.bu.tpl
@@ -48,6 +48,17 @@ storage:
   directories:
 {{ .node.storage.directories | toYaml | indent 4 }}
 {{- end }}
+  # User-provided additional disks
+{{- if hasKeyAny .node.storage "disks" }}
+  disks:
+{{ .node.storage.disks | toYaml | indent 4 }}
+{{- end }}
+
+  # User-provided additional filesystems
+{{- if hasKeyAny .node.storage "filesystems" }}
+  filesystems:
+{{ .node.storage.filesystems | toYaml | indent 4 }}
+{{- end }}
 
 systemd:
   units:

--- a/templates/infrastructure/immutable/butane/loadbalancer.bu.tpl
+++ b/templates/infrastructure/immutable/butane/loadbalancer.bu.tpl
@@ -40,6 +40,17 @@ storage:
   directories:
 {{ .node.storage.directories | toYaml | indent 4 }}
 {{- end }}
+  # User-provided additional disks
+{{- if hasKeyAny .node.storage "disks" }}
+  disks:
+{{ .node.storage.disks | toYaml | indent 4 }}
+{{- end }}
+
+  # User-provided additional filesystems
+{{- if hasKeyAny .node.storage "filesystems" }}
+  filesystems:
+{{ .node.storage.filesystems | toYaml | indent 4 }}
+{{- end }}
 
 systemd:
   units:

--- a/templates/infrastructure/immutable/butane/worker.bu.tpl
+++ b/templates/infrastructure/immutable/butane/worker.bu.tpl
@@ -40,6 +40,17 @@ storage:
   directories:
 {{ .node.storage.directories | toYaml | indent 4 }}
 {{- end }}
+  # User-provided additional disks
+{{- if hasKeyAny .node.storage "disks" }}
+  disks:
+{{ .node.storage.disks | toYaml | indent 4 }}
+{{- end }}
+
+  # User-provided additional filesystems
+{{- if hasKeyAny .node.storage "filesystems" }}
+  filesystems:
+{{ .node.storage.filesystems | toYaml | indent 4 }}
+{{- end }}
 
 systemd:
   units:

--- a/tests/e2e/immutable/schema.sh
+++ b/tests/e2e/immutable/schema.sh
@@ -474,3 +474,41 @@ test_schema() {
 
     test_schema "public" "immutable-kfd-v1alpha2" "114-no" expect_no
 }
+
+# Node storage disks and filesystems (115-120)
+
+@test "115 - ok" {
+    info
+
+    test_schema "public" "immutable-kfd-v1alpha2" "115-ok" expect_ok
+}
+
+@test "116 - no" {
+    info
+
+    test_schema "public" "immutable-kfd-v1alpha2" "116-no" expect_no
+}
+
+@test "117 - no" {
+    info
+
+    test_schema "public" "immutable-kfd-v1alpha2" "117-no" expect_no
+}
+
+@test "118 - no" {
+    info
+
+    test_schema "public" "immutable-kfd-v1alpha2" "118-no" expect_no
+}
+
+@test "119 - no" {
+    info
+
+    test_schema "public" "immutable-kfd-v1alpha2" "119-no" expect_no
+}
+
+@test "120 - no" {
+    info
+
+    test_schema "public" "immutable-kfd-v1alpha2" "120-no" expect_no
+}

--- a/tests/schemas/public/immutable-kfd-v1alpha2/002-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/002-ok.yaml
@@ -24,16 +24,6 @@ spec:
         macAddress: 52:54:00:10:00:01
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: etcd-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: ext4
-                    label: ETCD
-                    mountPoint: /var/lib/etcd
         # Node-specific kernel parameters (override global settings)
         # Control plane: tuning for high connection rates
         kernelParameters:
@@ -62,16 +52,6 @@ spec:
         macAddress: 52:54:00:10:00:02
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: etcd-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: ext4
-                    label: ETCD
-                    mountPoint: /var/lib/etcd
         kernelParameters:
           - name: fs.inotify.max_user_watches
             value: "1048576"
@@ -90,16 +70,6 @@ spec:
         macAddress: 52:54:00:10:00:03
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: etcd-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: ext4
-                    label: ETCD
-                    mountPoint: /var/lib/etcd
         kernelParameters:
           - name: fs.inotify.max_user_watches
             value: "1048576"
@@ -119,16 +89,6 @@ spec:
         macAddress: 52:54:00:30:00:01
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: kubelet-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: xfs
-                    label: KUBELET
-                    mountPoint: /var/lib/kubelet
         # Load balancer: kernel tuning for high connection tracking
         kernelParameters:
           - name: net.netfilter.nf_conntrack_max
@@ -148,16 +108,6 @@ spec:
         macAddress: 52:54:00:30:00:02
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: kubelet-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: xfs
-                    label: KUBELET
-                    mountPoint: /var/lib/kubelet
         kernelParameters:
           - name: net.netfilter.nf_conntrack_max
             value: "1000000"
@@ -177,16 +127,6 @@ spec:
         macAddress: 52:54:00:40:00:01
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: kubelet-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: xfs
-                    label: KUBELET
-                    mountPoint: /var/lib/kubelet
         # Infrastructure: kernel tuning for Elasticsearch/logging workloads
         kernelParameters:
           - name: vm.max_map_count
@@ -205,16 +145,6 @@ spec:
         macAddress: 52:54:00:40:00:02
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: kubelet-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: xfs
-                    label: KUBELET
-                    mountPoint: /var/lib/kubelet
         kernelParameters:
           - name: vm.max_map_count
             value: "262144"
@@ -232,16 +162,6 @@ spec:
         macAddress: 52:54:00:40:00:03
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: kubelet-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: xfs
-                    label: KUBELET
-                    mountPoint: /var/lib/kubelet
         kernelParameters:
           - name: vm.max_map_count
             value: "262144"
@@ -260,17 +180,6 @@ spec:
         macAddress: 52:54:00:50:00:01
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: containerd-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: xfs
-                    label: CONTAINERD
-                    mountPoint: /var/lib/containerd
-                    mountOptions: ["noatime", "nodiratime"]
         # Application: kernel tuning for network throughput
         kernelParameters:
           - name: net.core.rmem_max
@@ -289,17 +198,6 @@ spec:
         macAddress: 52:54:00:50:00:02
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: containerd-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: xfs
-                    label: CONTAINERD
-                    mountPoint: /var/lib/containerd
-                    mountOptions: ["noatime", "nodiratime"]
         kernelParameters:
           - name: net.core.rmem_max
             value: "16777216"
@@ -317,17 +215,6 @@ spec:
         macAddress: 52:54:00:50:00:03
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: containerd-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: xfs
-                    label: CONTAINERD
-                    mountPoint: /var/lib/containerd
-                    mountOptions: ["noatime", "nodiratime"]
         kernelParameters:
           - name: net.core.rmem_max
             value: "16777216"
@@ -346,16 +233,6 @@ spec:
         macAddress: 52:54:00:60:00:01
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: kubelet-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: xfs
-                    label: KUBELET
-                    mountPoint: /var/lib/kubelet
         # Database: kernel tuning for I/O optimization
         kernelParameters:
           - name: vm.swappiness
@@ -374,16 +251,6 @@ spec:
         macAddress: 52:54:00:60:00:02
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: kubelet-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: xfs
-                    label: KUBELET
-                    mountPoint: /var/lib/kubelet
         kernelParameters:
           - name: vm.swappiness
             value: "10"
@@ -401,16 +268,6 @@ spec:
         macAddress: 52:54:00:60:00:03
         storage:
           installDisk: /dev/sda
-          additionalDisks:
-            - device: /dev/sdb
-              partitions:
-                - label: kubelet-data
-                  number: 1
-                  sizeMiB: 0
-                  filesystem:
-                    format: xfs
-                    label: KUBELET
-                    mountPoint: /var/lib/kubelet
         kernelParameters:
           - name: vm.swappiness
             value: "10"

--- a/tests/schemas/public/immutable-kfd-v1alpha2/115-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/115-ok.yaml
@@ -1,0 +1,90 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        storage:
+          installDisk: /dev/sda
+          disks:
+            - device: /dev/vdb
+              wipe_table: true
+              partitions:
+                - label: data
+                  number: 1
+          filesystems:
+            - device: /dev/disk/by-partlabel/data
+              format: xfs
+              label: data
+              path: /var/lib/data
+              with_mount_unit: true
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none

--- a/tests/schemas/public/immutable-kfd-v1alpha2/116-no.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/116-no.yaml
@@ -1,0 +1,80 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        storage:
+          installDisk: /dev/sda
+          disk:
+            - device: /dev/vdb
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none

--- a/tests/schemas/public/immutable-kfd-v1alpha2/117-no.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/117-no.yaml
@@ -1,0 +1,86 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        storage:
+          installDisk: /dev/sda
+          disks:
+            - device: /dev/vdb
+              partitions:
+                - label: data
+                  number: 1
+                  filesystem:
+                    format: xfs
+                    mountPoint: /var/lib/data
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none

--- a/tests/schemas/public/immutable-kfd-v1alpha2/118-no.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/118-no.yaml
@@ -1,0 +1,84 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        storage:
+          installDisk: /dev/sda
+          disks:
+            - device: /dev/vdb
+              partitions:
+                - label: data
+                  number: 1
+                  sizeMib: 1024
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none

--- a/tests/schemas/public/immutable-kfd-v1alpha2/119-no.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/119-no.yaml
@@ -1,0 +1,82 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        storage:
+          installDisk: /dev/sda
+          filesystems:
+            - device: /dev/disk/by-partlabel/data
+              format: zfs
+              path: /var/lib/data
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none

--- a/tests/schemas/public/immutable-kfd-v1alpha2/120-no.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/120-no.yaml
@@ -1,0 +1,83 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        storage:
+          installDisk: /dev/sda
+          disks:
+            - wipe_table: true
+              partitions:
+                - label: data
+                  number: 1
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->

### Summary 💡

Immutable nodes can now set up extra disks through `spec.infrastructure.nodes[].storage.disks` and `storage.filesystems`,
mirroring Butane's own sections like `storage.files` already does. They replace `storage.additionalDisks`, which
validated but was never rendered.

Closes: #556

Relates:

### Description 📝

`storage.additionalDisks` was dead: it passed validation, no template read it, so extra disks were silently never
partitioned.

It could not be wired up as it was. Its shape was not Butane's: it nested the filesystem inside each partition, while
Butane keeps disks and filesystems as two sibling lists joined by a device path. So the node config now speaks Butane
directly. Both keys are optional and independent, so you can partition without formatting, or format a whole disk with no
`disks` entry.

Subfields are declared inline with `additionalProperties: false`, like `storage.files`. They come from the Butane version
furyctl uses, checked in both directions: nothing Butane accepts is missing, nothing we accept is unknown to it.

This is not only style. Butane merely warns on an unknown key and furyctl keeps going, so a `sizeMib` typo used to pass
validation, get dropped, and give you a partition sized "as large as possible" on a node that boots fine. It now fails
early.

The four node templates get the same block. Dropping `additionalDisks` also removes the four `$defs` that only it used.

Known limit: the link between a partition label and a filesystem device is a plain path, and neither Butane nor JSON
Schema checks it. A typo there still only shows up at boot.

### Breaking Changes 💔

`storage.additionalDisks` is removed. A `furyctl.yaml` that still sets it now fails validation. No running cluster is
affected, since the field was never rendered.

Migration is mechanical:

| before | after |
|---|---|
| `additionalDisks[].device` | `disks[].device` |
| `partitions[].sizeMiB` | `disks[].partitions[].size_mib` |
| `partitions[].filesystem` | its own `filesystems[]` entry, with `device: /dev/disk/by-partlabel/<label>` |
| `filesystem.mountPoint` | `filesystems[].path` |
| `filesystem.mountOptions` | `filesystems[].mount_options` |
| the mount it implied | `with_mount_unit: true` |

### Tests performed 🧪

- [x] Schema suite green (45/45). Five new cases cover the typos and shapes that used to slip through: singular `disk`,
      the old nested `filesystem`, `sizeMib`, a format outside the enum, and a disk with no device. Removing the new
      subfields makes four of them pass again, so they test what they claim.
- [x] Fields checked one by one against Butane, both ways. Required fields were probed with `butane`, not guessed.
- [x] The block the templates emit goes through `butane --strict` into valid Ignition, no warnings, mount unit created.
      `disks` alone and `filesystems` alone both work.
- [x] A real pre-migration config is rejected with a per-node error and migrates without loss.
- [x] CI is green.

Not covered: a live `furyctl apply`. The block is identical in the four templates and was validated through `butane`
directly.

### Future work 🔧

- `tests/templates/immutable/` does not exist, so the regression suite never renders these templates.
- `systemd.units` declares no subfields, so it validates nothing — the same gap this PR closes for disks, left out to
  keep the scope clean.
- `Types.DevicePath` rejects hyphens, so it cannot express `/dev/disk/by-id/...`. That is why `device` is a plain string.

### Self-assessment checklist 🏁

- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] CI is green
