### PR TITLE
fix(immutable): default route

### DIFF
--- a/docs/releases/v1.35.1.md
+++ b/docs/releases/v1.35.1.md
@@ -25,6 +25,7 @@ No changes in modules version.
 - [[#561](https://github.com/sighupio/distribution/pull/561)] Immutable: align possible properties for Kubernetes phase `kubeletConfiguration` parameter with OnPremises, accepting all possible values now.
 - [[#564](https://github.com/sighupio/distribution/pull/564)] OnPremises: fixed a race in the preflight `verify-playbook.yaml` where fetching `admin.conf` from multiple masters in parallel could randomly fail with a checksum mismatch.
 - [[#568](https://github.com/sighupio/distribution/pull/568)] Immutable: actually set the search domains for an interface if it is defined in the node configuration, this value was being ignored until now.
+- [[#579](https://github.com/sighupio/distribution/pull/579)] Immutable: convert `default` route destination to networkd's compatible `0.0.0.0/0` so the default route is not silently ignored anymore.
 
 ## Breaking Changes 💔
 

--- a/templates/infrastructure/immutable/butane/_helpers.tpl
+++ b/templates/infrastructure/immutable/butane/_helpers.tpl
@@ -87,7 +87,7 @@ passwd:
           {{- if hasKeyAny $iface "routes" }}
             {{- range $iface.routes }}
           [Route]
-          Destination={{ .to }}
+          Destination={{ if eq .to "default"}}0.0.0.0/0{{ else }}{{ .to }}{{ end }}
           Gateway={{ .via }}
             {{- end }}
           {{- end }}


### PR DESCRIPTION
### Summary 💡

Convert `default` into `0.0.0.0/0` for networkd compatibility.


Closes #578 

### Description 📝

We are exposing interfaces configuration in the schema following netplan's format because it has a nicer UX and let us inspect easily the node's network configuration from furyctl and the templates.

We then generate networkd configuration files from the netplan format. The templates were passing to networkd the `default` keyword for static routes but networkd silently ignores it instead of creating the default route. networkd accepts `0.0.0.0/0` instead of `default`.

This PR converts `default` into `0.0.0.0/0` for networkd compatibility.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Declared a default route and checked on the node that the default route is present
- [x] Declared several routes and checked that they are all present in the node

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

