### PR TITLE
fix(eks/templates): prevent HAProxy LoadBalancer Service recreation on EKS

### DIFF
--- a/docs/releases/v1.35.1.md
+++ b/docs/releases/v1.35.1.md
@@ -28,6 +28,7 @@ No changes in modules version.
 - [[#564](https://github.com/sighupio/distribution/pull/564)] OnPremises: fixed a race in the preflight `verify-playbook.yaml` where fetching `admin.conf` from multiple masters in parallel could randomly fail with a checksum mismatch.
 - [[#568](https://github.com/sighupio/distribution/pull/568)] Immutable: actually set the search domains for an interface if it is defined in the node configuration, this value was being ignored until now.
 - [[#579](https://github.com/sighupio/distribution/pull/579)] Immutable: convert `default` route destination to networkd's compatible `0.0.0.0/0` so the default route is not silently ignored anymore.
+- [[#580](https://github.com/sighupio/distribution/pull/580)] EKSCluster: add a kapp rebase rule so `spec.loadBalancerClass` on the HAProxy `LoadBalancer` Services always keeps value the AWS Load Balancer Controller webhook already set on them, instead of trying to clear it during the upgrade.
 
 ## Breaking Changes 💔
 

--- a/templates/distribution/manifests/ingress/kustomization.yaml.tpl
+++ b/templates/distribution/manifests/ingress/kustomization.yaml.tpl
@@ -60,6 +60,10 @@ resources:
   - resources/ingress-infra.yml
 {{- end }}
 
+{{- if and (eq .spec.distribution.common.provider.type "eks") (ne $haproxyType "none") }}
+  - resources/haproxy-loadbalancerclass-rebase.yml
+{{- end }}
+
 {{- $nginxUsesSecret := and (ne .spec.distribution.modules.ingress.nginx.type "none") (eq .spec.distribution.modules.ingress.nginx.tls.provider "secret") }}
 {{- $haproxyUsesSecret := and (ne $haproxyType "none") (eq .spec.distribution.modules.ingress.haproxy.tls.provider "secret") }}
 {{- if or $nginxUsesSecret $haproxyUsesSecret }}

--- a/templates/distribution/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml.tpl
+++ b/templates/distribution/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml.tpl
@@ -1,0 +1,24 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+{{- if eq .spec.distribution.common.provider.type "eks" }}
+{{- if ne .spec.distribution.modules.ingress.haproxy.type "none" }}
+---
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+metadata:
+  # this resource has no metadata of its own; this is only here
+  # because kustomize requires metadata.name on every resource it accumulates.
+  name: haproxy-loadbalancerclass-rebase
+
+rebaseRules:
+  - path: [spec, loadBalancerClass]
+    type: copy
+    sources: [existing]
+    resourceMatchers:
+      - apiVersionKindMatcher:
+          apiVersion: v1
+          kind: Service
+{{- end }}
+{{- end }}

--- a/tests/templates/ekscluster/00-disabled/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/ekscluster/00-disabled/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/ekscluster/01-full-nginx/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/ekscluster/01-full-nginx/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/ingress/kustomization.yaml
+++ b/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/ingress/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - ../../../vendor/modules/ingress/katalog/cert-manager
   - resources/cert-manager-clusterissuer.yml
   - resources/ingress-infra.yml
+  - resources/haproxy-loadbalancerclass-rebase.yml
 
 
 patches:

--- a/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/ekscluster/02-full-haproxy/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,19 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+---
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+metadata:
+  # this resource has no metadata of its own; this is only here
+  # because kustomize requires metadata.name on every resource it accumulates.
+  name: haproxy-loadbalancerclass-rebase
+
+rebaseRules:
+  - path: [spec, loadBalancerClass]
+    type: copy
+    sources: [existing]
+    resourceMatchers:
+      - apiVersionKindMatcher:
+          apiVersion: v1
+          kind: Service

--- a/tests/templates/immutable/00-disabled/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/immutable/00-disabled/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/immutable/01-full-calico-nginx/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/immutable/01-full-calico-nginx/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/immutable/02-full-cilium-haproxy/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/immutable/02-full-cilium-haproxy/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/immutable/03-calico-kube-proxy-less/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/immutable/03-calico-kube-proxy-less/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/immutable/04-cilium-kube-proxy-less/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/immutable/04-cilium-kube-proxy-less/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/kfddistribution/00-disabled/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/kfddistribution/00-disabled/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/kfddistribution/01-full-calico-nginx/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/kfddistribution/02-full-cilium-haproxy/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/onpremises/00-disabled/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/onpremises/00-disabled/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/onpremises/01-full-calico-nginx/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/onpremises/02-full-cilium-haproxy/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/onpremises/03-calico-kube-proxy-less/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/onpremises/03-calico-kube-proxy-less/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/tests/templates/onpremises/04-cilium-kube-proxy-less/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
+++ b/tests/templates/onpremises/04-cilium-kube-proxy-less/baseline/manifests/ingress/resources/haproxy-loadbalancerclass-rebase.yml
@@ -1,0 +1,3 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.

By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterward.

Opening a PR in draft lets other team members know you're working on this change, and gives you a 
place to track your work in progress.

When opening PRs in Draft, **don't assign reviewers until the PR is ready for review**.

Once you are comfortable with the status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

Prevent HAProxy `LoadBalancer` Services on EKS from being deleted and recreated, with a new NLB, on some `furyctl apply` runs.

Closes:

Relates:

### Description 📝

AWS Load Balancer Controller's mutating webhook sets `spec.loadBalancerClass` on the HAProxy `LoadBalancer` Services as soon as they are created while the controller is running, for example after migrating to HAProxy on an existing cluster. SD never declared that field. Once the webhook had set it out of band, the next `kapp` update touching these Services would fail with `spec.loadBalancerClass: ... may not change once set`, since the field is immutable once set. This triggered `kapp`'s `fallback-on-replace` strategy, which deletes and recreates the Service and its NLB.

This PR adds a `kapp` rebase rule so `spec.loadBalancerClass` always keeps whatever value is already on the live Service, instead of the module trying to change it.

### Breaking Changes 💔

None. 

### Tests performed 🧪

- [x] Reproduced the original failure end to end on a real EKS cluster: deployed HAProxy after the AWS Load Balancer Controller was already running, then upgraded the controller from v2.16.0 to v3.4.0 and the SD version. Confirmed the rebase rule prevents it. Service UID and NLB hostname stayed unchanged across the upgrade.

### Future work 🔧

None. 

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green
