### PR TITLE
fix: enhance installDisk validation for Unix device paths and add cor…

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,15 @@
+# SIGHUP Distribution Release vTBD
+
+Welcome to the latest release of SD maintained by SIGHUP by ReeVo team.
+
+## New features 🌟
+
+TBD
+
+## Bug fixes 🐞
+
+- [[#581](https://github.com/sighupio/distribution/issues/581)] Immutable: node `storage.installDisk` now accepts persistent device paths like `/dev/disk/by-id/wwn-...`, `/dev/disk/by-path/...` and `/dev/mapper/...`. The field is validated the same way Butane/Ignition validates its own device fields — the path must be absolute and clean — instead of the previous alphanumeric-only pattern that rejected every `/dev/disk/by-*` symlink.
+
+## Breaking Changes 💔
+
+TBD

--- a/docs/schemas/immutable-kfd-v1alpha2.md
+++ b/docs/schemas/immutable-kfd-v1alpha2.md
@@ -6700,17 +6700,17 @@ Whether to additionally generate a generic mount unit for this filesystem, or a 
 
 ### Description
 
-Unix device path. Example: /dev/sda, /dev/nvme0n1
+Absolute, clean Unix device path, validated like Butane/Ignition does for device fields: it must be absolute and must not contain empty, '.' or '..' path segments. Example: /dev/sda, /dev/nvme0n1, /dev/disk/by-id/wwn-0x5000c500a1b2c3d4
 
 ### Constraints
 
 **pattern**: the string must match the following regular expression:
 
 ```regexp
-^/dev/[a-zA-Z0-9/]+$
+^(/([^/.][^/]*|\.[^/.][^/]*|\.\.[^/]+))+$
 ```
 
-[try pattern](https://regexr.com/?expression=^\/dev\/[a-zA-Z0-9\/]%2B$)
+[try pattern](https://regexr.com/?expression=^\(\/\([^\/.][^\/]*|\.[^\/.][^\/]*|\.\.[^\/]%2B\)\)%2B$)
 
 ## .spec.infrastructure.nodes.storage.links
 

--- a/schemas/public/immutable-kfd-v1alpha2.json
+++ b/schemas/public/immutable-kfd-v1alpha2.json
@@ -4032,8 +4032,8 @@
     },
     "Types.DevicePath": {
       "type": "string",
-      "pattern": "^/dev/[a-zA-Z0-9/]+$",
-      "description": "Unix device path. Example: /dev/sda, /dev/nvme0n1"
+      "pattern": "^(/([^/.][^/]*|\\.[^/.][^/]*|\\.\\.[^/]+))+$",
+      "description": "Absolute, clean Unix device path, validated like Butane/Ignition does for device fields: it must be absolute and must not contain empty, '.' or '..' path segments. Example: /dev/sda, /dev/nvme0n1, /dev/disk/by-id/wwn-0x5000c500a1b2c3d4"
     },
     "Types.IpAddress": {
       "type": "string",

--- a/templates/infrastructure/immutable/butane/install-flatcar.bu.tpl
+++ b/templates/infrastructure/immutable/butane/install-flatcar.bu.tpl
@@ -73,7 +73,7 @@ systemd:
         {{- end }}
         {{- end }}
         ExecStartPre=/usr/bin/curl --retry 2 --retry-connrefused --connect-timeout 5 --max-time 15 --retry-max-time 40 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=installing'
-        ExecStart=/usr/bin/flatcar-install -d {{ .installDisk }} -i /opt/ignition/config.ign -b {{ .ipxeServerURL }}/assets/flatcar/{{ .arch }}
+        ExecStart=/usr/bin/flatcar-install -d '{{ .installDisk }}' -i /opt/ignition/config.ign -b {{ .ipxeServerURL }}/assets/flatcar/{{ .arch }}
         {{- if .ipxeServerPostInstallCommands }}
         ExecStartPost=/usr/bin/curl --retry 2 --retry-connrefused --connect-timeout 5 --max-time 15 --retry-max-time 40 -X POST '{{ .ipxeServerURL }}/status?node={{ .hostname }}&status=running%%20post-install%%20commands'
         {{- range .ipxeServerPostInstallCommands }}

--- a/tests/e2e/immutable/schema.sh
+++ b/tests/e2e/immutable/schema.sh
@@ -539,3 +539,69 @@ test_schema() {
 
     test_schema "public" "immutable-kfd-v1alpha2" "122-no" expect
 }
+
+# Node storage installDisk device paths (123-128)
+
+@test "123 - ok" {
+    info
+
+    test_schema "public" "immutable-kfd-v1alpha2" "123-ok" expect_ok
+}
+
+@test "124 - ok" {
+    info
+
+    test_schema "public" "immutable-kfd-v1alpha2" "124-ok" expect_ok
+}
+
+@test "125 - no" {
+    info
+
+    expect() {
+        expect_no "${1}"
+
+        # relative path
+        assert_error_contains "/spec/infrastructure/nodes/0/storage/installDisk" "does not match pattern" || return $?
+    }
+
+    test_schema "public" "immutable-kfd-v1alpha2" "125-no" expect
+}
+
+@test "126 - no" {
+    info
+
+    expect() {
+        expect_no "${1}"
+
+        # trailing slash, not a clean path
+        assert_error_contains "/spec/infrastructure/nodes/0/storage/installDisk" "does not match pattern" || return $?
+    }
+
+    test_schema "public" "immutable-kfd-v1alpha2" "126-no" expect
+}
+
+@test "127 - no" {
+    info
+
+    expect() {
+        expect_no "${1}"
+
+        # empty path segment, not a clean path
+        assert_error_contains "/spec/infrastructure/nodes/0/storage/installDisk" "does not match pattern" || return $?
+    }
+
+    test_schema "public" "immutable-kfd-v1alpha2" "127-no" expect
+}
+
+@test "128 - no" {
+    info
+
+    expect() {
+        expect_no "${1}"
+
+        # '..' path segment, not a clean path
+        assert_error_contains "/spec/infrastructure/nodes/0/storage/installDisk" "does not match pattern" || return $?
+    }
+
+    test_schema "public" "immutable-kfd-v1alpha2" "128-no" expect
+}

--- a/tests/schemas/public/immutable-kfd-v1alpha2/123-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/123-ok.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        storage:
+          installDisk: /dev/disk/by-id/wwn-0x5000c500a1b2c3d4
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    pkiPath: ./pki
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none

--- a/tests/schemas/public/immutable-kfd-v1alpha2/124-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/124-ok.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        storage:
+          installDisk: /dev/disk/by-path/pci-0000:00:1f.2-ata-1
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    pkiPath: ./pki
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none

--- a/tests/schemas/public/immutable-kfd-v1alpha2/125-no.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/125-no.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        storage:
+          installDisk: sda
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    pkiPath: ./pki
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none

--- a/tests/schemas/public/immutable-kfd-v1alpha2/126-no.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/126-no.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        storage:
+          installDisk: /dev/sda/
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    pkiPath: ./pki
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none

--- a/tests/schemas/public/immutable-kfd-v1alpha2/127-no.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/127-no.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        storage:
+          installDisk: /dev//sda
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    pkiPath: ./pki
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none

--- a/tests/schemas/public/immutable-kfd-v1alpha2/128-no.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/128-no.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        storage:
+          installDisk: /dev/../etc/passwd
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    pkiPath: ./pki
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none


### PR DESCRIPTION
### Summary 💡

`installDisk` did not accept disk paths like `/dev/disk/by-id/wwn-...`. The old rule only allowed letters, digits and `/`, so any path with `-`, `_`, `.` or `:` failed. Users had to use `/dev/sda`, and that name can change on reboot and point to the wrong disk.

Closes: #581

Relates: -

### Description 📝

New rule for `installDisk`: 

```json
"pattern": "^(/([^/.][^/]*|\\.[^/.][^/]*|\\.\\.[^/]+))+$"
```

Any character except `/` is allowed inside a path part, so `by-id`, `by-path` (with `:`), `by-diskseq` and `/dev/mapper` all work now.

The value is also quoted in the Butane template (`-d '{{ .installDisk }}'`). The new rule allows spaces, and without quotes a value with a space would turn into extra arguments for `flatcar-install`.

This rule is only used by `installDisk`, so nothing else changes.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] `bats -t tests/e2e/immutable/schema.sh` → 53 pass, 0 fail
- [x] 6 new test files: `123-ok` (the path from the issue), `124-ok` (`by-path`, has `:`), `125-no` to `128-no` (relative path, trailing slash, `//`, `..`)
- [x] Tried 17 real disk paths (`wwn-`, `ata-`, `scsi-`, `nvme-eui.`, `dm-uuid-`, `by-path/pci-…`, `/dev/mapper/`, `/dev/md/`): all pass. The old rule rejected 13 of them

### Future work 🔧

None.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change — this rule only exists in the Immutable schema
- [x] CI is green
