### PR TITLE
chore(immutable schema): macaddress description

### DIFF
--- a/docs/schemas/immutable-kfd-v1alpha2.md
+++ b/docs/schemas/immutable-kfd-v1alpha2.md
@@ -5908,7 +5908,7 @@ The kernel parameter value. Example: "1"
 
 ### Description
 
-MAC address in format XX:XX:XX:XX:XX:XX
+MAC address for PXE boot identification. Not case-sensitive, accepts `:` or `-` as separator. Example: 52:54:00:10:00:01
 
 ### Constraints
 

--- a/schemas/public/immutable-kfd-v1alpha2.json
+++ b/schemas/public/immutable-kfd-v1alpha2.json
@@ -277,7 +277,7 @@
         },
         "macAddress": {
           "$ref": "#/$defs/Types.MacAddress",
-          "description": "MAC address for PXE boot identification. Example: 52:54:00:10:00:01"
+          "description": "MAC address for PXE boot identification. Not case-sensitive, accepts `:` or `-` as separator. Example: 52:54:00:10:00:01"
         },
         "storage": {
           "$ref": "#/$defs/Spec.Infrastructure.Node.Storage"
@@ -4026,8 +4026,7 @@
     },
     "Types.MacAddress": {
       "type": "string",
-      "pattern": "^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$",
-      "description": "MAC address in format XX:XX:XX:XX:XX:XX"
+      "pattern": "^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$"
     },
     "Types.DevicePath": {
       "type": "string",


### PR DESCRIPTION
### Summary 💡

Improve node's macAddress field description with information for the user on how to write the value.

### Description 📝

Improve node's macAddress field description with information for the user on how to write the value, specifying that the field is not case sensitive and the user can use either `-` or `:` as separator.

furyctl handles the normalization both on the butane template rendering and in the pxe server path:

https://github.com/sighupio/furyctl/blob/e1e343681dd7c9cf57d5e377927de447fe3b3b37/internal/apis/kfd/v1alpha2/immutable/create/infrastructure_bootsrap.go#L384

https://github.com/sighupio/furyctl/blob/e1e343681dd7c9cf57d5e377927de447fe3b3b37/cmd/serve/path.go#L72-L76

### Breaking Changes 💔

None

### Tests performed 🧪

N.A. documentation change

### Future work 🔧

None

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
~~- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)~~
~~- [] I've tested the proposed changes and wrote the tests performed in the section above~~
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

