### PR TITLE
fix(immutable): require pki path parameter in schema

### DIFF
--- a/docs/schemas/immutable-kfd-v1alpha2.md
+++ b/docs/schemas/immutable-kfd-v1alpha2.md
@@ -6920,7 +6920,7 @@ SSH username. Example: core
 | [etcd](#speckubernetesetcd)                 | `object` | Optional |
 | [networking](#speckubernetesnetworking)     | `object` | Required |
 | [nodeGroups](#speckubernetesnodegroups)     | `array`  | Optional |
-| [pkiPath](#speckubernetespkipath)           | `string` | Optional |
+| [pkiPath](#speckubernetespkipath)           | `string` | Required |
 | [version](#speckubernetesversion)           | `string` | Optional |
 
 ### Description

--- a/docs/schemas/immutable-kfd-v1alpha2.md
+++ b/docs/schemas/immutable-kfd-v1alpha2.md
@@ -8114,6 +8114,10 @@ Kubernetes taints to apply to nodes in this group.
 
 Path to the PKI directory where to find the certificates and keys for Kubernetes Control Plane and etcd. Must have the `master` and `etcd` folders inside.
 
+### Constraints
+
+**minimum length**: the minimum number of characters for this string is: `1`
+
 ## .spec.kubernetes.version
 
 ### Description

--- a/schemas/public/immutable-kfd-v1alpha2.json
+++ b/schemas/public/immutable-kfd-v1alpha2.json
@@ -1162,6 +1162,7 @@
         }
       },
       "required": [
+        "pkiPath",
         "controlPlane",
         "networking"
       ]

--- a/schemas/public/immutable-kfd-v1alpha2.json
+++ b/schemas/public/immutable-kfd-v1alpha2.json
@@ -1139,6 +1139,7 @@
         },
         "pkiPath": {
           "type": "string",
+          "minLength": 1,
           "description": "Path to the PKI directory where to find the certificates and keys for Kubernetes Control Plane and etcd. Must have the `master` and `etcd` folders inside."
         },
         "controlPlane": {

--- a/templates/config/immutable-kfd-v1alpha2.yaml.tpl
+++ b/templates/config/immutable-kfd-v1alpha2.yaml.tpl
@@ -229,6 +229,10 @@ spec:
 
   # Kubernetes cluster configuration
   kubernetes:
+    # Folder that holds the CA certificates and keys for the control plane and etcd.
+    # It must have a `master` and an `etcd` subfolder. Create it with `furyctl create pki`.
+    # A path that starts with `./` is relative to this file.
+    pkiPath: ./pki
     # Kubernetes Cluster basic networking configuration independent of the CNI.
     # More advanced configuration can be defined in the distribution.modules.networking section
     networking:

--- a/tests/e2e/immutable/schema.sh
+++ b/tests/e2e/immutable/schema.sh
@@ -513,7 +513,7 @@ test_schema() {
     test_schema "public" "immutable-kfd-v1alpha2" "120-no" expect_no
 }
 
-# PKI folder (121)
+# PKI folder (121-122)
 
 @test "121 - no" {
     info
@@ -526,4 +526,16 @@ test_schema() {
     }
 
     test_schema "public" "immutable-kfd-v1alpha2" "121-no" expect
+}
+
+@test "122 - no" {
+    info
+
+    expect() {
+        expect_no "${1}"
+
+        assert_error_contains "/spec/kubernetes/pkiPath" "minLength" || return $?
+    }
+
+    test_schema "public" "immutable-kfd-v1alpha2" "122-no" expect
 }

--- a/tests/e2e/immutable/schema.sh
+++ b/tests/e2e/immutable/schema.sh
@@ -512,3 +512,18 @@ test_schema() {
 
     test_schema "public" "immutable-kfd-v1alpha2" "120-no" expect_no
 }
+
+# PKI folder (121)
+
+@test "121 - no" {
+    info
+
+    expect() {
+        expect_no "${1}"
+
+        assert_error_contains "/spec/kubernetes" "missing property" || return $?
+        assert_error_contains "/spec/kubernetes" "'pkiPath'" || return $?
+    }
+
+    test_schema "public" "immutable-kfd-v1alpha2" "121-no" expect
+}

--- a/tests/schemas/public/immutable-kfd-v1alpha2/002-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/002-ok.yaml
@@ -289,6 +289,7 @@ spec:
   # Kubernetes cluster configuration
   # Ref: https://kubernetes.io/docs/setup/production-environment/
   kubernetes:
+    pkiPath: ./pki
     controlPlane:
       address: k8s-api.example.com:6443
       kubeletConfiguration:

--- a/tests/schemas/public/immutable-kfd-v1alpha2/006-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/006-ok.yaml
@@ -27,6 +27,7 @@ spec:
       privateKeyPath: ~/.ssh/id_rsa
 
   kubernetes:
+    pkiPath: ./pki
     controlPlane:
       address: k8s-api.example.com:6443
       members:

--- a/tests/schemas/public/immutable-kfd-v1alpha2/011-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/011-ok.yaml
@@ -33,6 +33,7 @@ spec:
       privateKeyPath: ~/.ssh/id_rsa
 
   kubernetes:
+    pkiPath: ./pki
     controlPlane:
       address: k8s-api.example.com:6443
       members:

--- a/tests/schemas/public/immutable-kfd-v1alpha2/042-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/042-ok.yaml
@@ -45,6 +45,7 @@ spec:
       privateKeyPath: ~/.ssh/id_rsa
 
   kubernetes:
+    pkiPath: ./pki
     # Valid controlPlane configuration with 3 members
     controlPlane:
       address: k8s-api.example.com:6443

--- a/tests/schemas/public/immutable-kfd-v1alpha2/063-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/063-ok.yaml
@@ -27,6 +27,7 @@ spec:
       privateKeyPath: ~/.ssh/id_rsa
 
   kubernetes:
+    pkiPath: ./pki
     controlPlane:
       address: k8s-api.example.com:6443
       members:

--- a/tests/schemas/public/immutable-kfd-v1alpha2/093-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/093-ok.yaml
@@ -28,6 +28,7 @@ spec:
       privateKeyPath: ~/.ssh/id_rsa
 
   kubernetes:
+    pkiPath: ./pki
     controlPlane:
       address: aio.k8s.example.com:6443
       members:

--- a/tests/schemas/public/immutable-kfd-v1alpha2/094-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/094-ok.yaml
@@ -91,6 +91,7 @@ spec:
       privateKeyPath: ~/.ssh/id_rsa
 
   kubernetes:
+    pkiPath: ./pki
     controlPlane:
       address: k8s-api.example.com:6443
       members:

--- a/tests/schemas/public/immutable-kfd-v1alpha2/100-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/100-ok.yaml
@@ -33,6 +33,7 @@ spec:
       privateKeyPath: ~/.ssh/id_rsa
 
   kubernetes:
+    pkiPath: ./pki
     controlPlane:
       address: k8s-api.example.com:6443
       members:

--- a/tests/schemas/public/immutable-kfd-v1alpha2/101-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/101-ok.yaml
@@ -41,6 +41,7 @@ spec:
       privateKeyPath: ~/.ssh/id_rsa
 
   kubernetes:
+    pkiPath: ./pki
     controlPlane:
       address: k8s-api.example.com:6443
       members:

--- a/tests/schemas/public/immutable-kfd-v1alpha2/102-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/102-ok.yaml
@@ -41,6 +41,7 @@ spec:
       privateKeyPath: ~/.ssh/id_rsa
 
   kubernetes:
+    pkiPath: ./pki
     controlPlane:
       address: k8s-api.example.com:6443
       members:

--- a/tests/schemas/public/immutable-kfd-v1alpha2/111-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/111-ok.yaml
@@ -36,6 +36,7 @@ spec:
       privateKeyPath: ~/.ssh/id_rsa
 
   kubernetes:
+    pkiPath: ./pki
     controlPlane:
       address: k8s-api.example.com:6443
       members:

--- a/tests/schemas/public/immutable-kfd-v1alpha2/112-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/112-ok.yaml
@@ -37,6 +37,7 @@ spec:
       privateKeyPath: ~/.ssh/id_rsa
 
   kubernetes:
+    pkiPath: ./pki
     controlPlane:
       address: k8s-api.example.com:6443
       members:

--- a/tests/schemas/public/immutable-kfd-v1alpha2/115-ok.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/115-ok.yaml
@@ -43,6 +43,7 @@ spec:
       privateKeyPath: ~/.ssh/id_rsa
 
   kubernetes:
+    pkiPath: ./pki
     controlPlane:
       address: k8s-api.example.com:6443
       members:

--- a/tests/schemas/public/immutable-kfd-v1alpha2/121-no.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/121-no.yaml
@@ -31,7 +31,6 @@ spec:
       privateKeyPath: ~/.ssh/id_rsa
 
   kubernetes:
-    pkiPath: ./pki
     controlPlane:
       address: k8s-api.example.com:6443
       members:

--- a/tests/schemas/public/immutable-kfd-v1alpha2/122-no.yaml
+++ b/tests/schemas/public/immutable-kfd-v1alpha2/122-no.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kfd.sighup.io/v1alpha2
+kind: Immutable
+metadata:
+  name: minimal-cluster
+spec:
+  distributionVersion: v1.32.1
+
+  infrastructure:
+    nodes:
+      - hostname: node01.k8s.example.com
+        macAddress: 52:54:00:10:00:01
+        storage:
+          installDisk: /dev/sda
+        network:
+          ethernets:
+            eth0:
+              addresses:
+                - "192.168.1.10/24"
+              gateway: "192.168.1.1"
+              nameservers:
+                addresses:
+                  - 8.8.8.8
+
+    ssh:
+      username: core
+      privateKeyPath: ~/.ssh/id_rsa
+
+  kubernetes:
+    pkiPath: ""
+    controlPlane:
+      address: k8s-api.example.com:6443
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    etcd:
+      members:
+        - hostname: node01.k8s.example.com
+          ip: 192.168.1.10
+
+    networking:
+      podCIDR: 10.244.0.0/16
+      serviceCIDR: 10.96.0.0/12
+
+  distribution:
+    modules:
+      networking:
+        type: calico
+
+      ingress:
+        baseDomain: example.com
+        nginx:
+          type: single
+          tls:
+            provider: none
+
+      logging:
+        type: none
+
+      monitoring:
+        type: none
+
+      tracing:
+        type: none
+
+      policy:
+        type: none
+
+      dr:
+        type: none
+
+      auth:
+        provider:
+          type: none


### PR DESCRIPTION
### Summary 💡

Make `.kubernetes.pkiPath` a required parameter for Immutable clusters

Relates:
- #584 
- #583 (branched from this PR, because both touch same files)

### Description 📝


Make .kubernetes.pkiPath a required parameter (and ≠ "") for Immutable clusters (without the path to the pki a cluster cannot be created).

Update schema tests to consider this case, the tests did not actually have the pkiPath field set.

Update configuration template with relative comment so the pkiPath field is added to the config generated by `furyctl create config`

Rebuild schema documentation

### Breaking Changes 💔

None actually, clusters need the pkiPath to be set in order to create them, otherwise the creation fails, so existing config files probably already have it set.

### Tests performed 🧪

- [x] Schema tests passing
- [x] Tested Immutable cluster creation from scratch

### Future work 🔧

Actually validate that the pki folder exists (furyctl side)

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
~~- [] I've updated the `docs/releases/unreleased.md` file (or equivalent)~~
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

